### PR TITLE
🌱 Add missing governance files per CNCF audit

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -11,7 +11,7 @@ body:
         Thank you for suggesting an improvement! Please fill in the details below.
 
         Before opening a new feature request, please check
-        [existing issues](https://github.com/llm-d/{{PROJECT_NAME}}/issues)
+        [existing issues](https://github.com/llm-d/llm-d-prism/issues)
         to see if a similar request already exists.
 
   - type: textarea


### PR DESCRIPTION
Closes #8

## Summary

All governance files listed in the CNCF audit already exist in this repo (it was created from the `llm-d-go-template`). This PR fixes the one remaining issue:

- **Fixed** `{{PROJECT_NAME}}` placeholder in `.github/ISSUE_TEMPLATE/feature_request.yml` → replaced with `llm-d-prism`

### Files confirmed present and matching template

| File | Status |
|------|--------|
| `CODE_OF_CONDUCT.md` | Present, matches template |
| `SECURITY.md` | Present, matches template |
| `PR_SIGNOFF.md` | Present, matches template |
| `_typos.toml` | Present, matches template |
| `.prowlabels.yaml` | Present, matches template |
| `OWNERS` | Present, placeholder only (see note below) |
| `.github/CODEOWNERS` | Present, placeholder only (see note below) |
| `.github/PULL_REQUEST_TEMPLATE.md` | Present, matches template |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | Present, matches template |
| `.github/ISSUE_TEMPLATE/config.yml` | Present, matches template |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | **Fixed** — replaced `{{PROJECT_NAME}}` with `llm-d-prism` |

### Action needed after merge

- **`OWNERS`** still contains only commented-out placeholder entries. A follow-up is needed to populate it with actual GitHub usernames for reviewers and approvers.
- **`.github/CODEOWNERS`** similarly has a placeholder team reference (`# * @llm-d/your-team`). This should be updated once the OWNERS file is populated.