### PR TITLE
typos: whitelist MAPE and fix 'benchark' in archived PRD

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -9,6 +9,9 @@ aks = "aks"
 IST = "IST"
 # Abbreviation (e.g., 2nd -> ND)
 ND = "ND"
+# Mean Absolute Percentage Error — standard forecasting metric used in
+# specs/changes/predicted-latency/ callouts.
+MAPE = "MAPE"
 
 # Add repo-specific false positives here:
 # word = "word"

--- a/specs/archive/llm-d-components-prd.md
+++ b/specs/archive/llm-d-components-prd.md
@@ -11,7 +11,7 @@ Add 2 additional input dropdowns to the Ochestration / Serving Framework section
    -- Inference Scheduler
    -- LeaderWorkerSet
 
-The Inference Gateway option should display a count of 1 as it will temporarily map to the same benchark as the llm-d v0.30 serving stack option. The other Component options should list 0 as a count.
+The Inference Gateway option should display a count of 1 as it will temporarily map to the same benchmark as the llm-d v0.30 serving stack option. The other Component options should list 0 as a count.
 
 2. If a user selects "P/D Disaggregation" from the Optimizations dropdown, the app should present an additional dropdown inputs so the user can select the number of prefill nodes and the number of decode nodes.
 


### PR DESCRIPTION
Closes #30.

The nightly `typos` scan flagged `MAPE` as a typo of `MAP` in `specs/changes/predicted-latency/predicted_latency_scheduling_prd.md`. `MAPE` is Mean Absolute Percentage Error — a standard forecasting metric used intentionally in those callouts — so extend `_typos.toml` to keep it valid.

The whitelist surfaces a real typo further down in `specs/archive/llm-d-components-prd.md:14`: `same benchark as` → `same benchmark as`. Fix it in the same commit.

`typos .` now returns 0 findings.