### PR TITLE
Fix trendline sorting by stage and exclude stage 0

### DIFF
--- a/src/components/InferenceSchedulingChart.jsx
+++ b/src/components/InferenceSchedulingChart.jsx
@@ -417,6 +417,9 @@ const InferenceSchedulingChart = ({ data, initialXAxis, initialYAxis, initialLog
                                             dashArray = "2 2";
                                         }
 
+                                        // Ensure points are in order of Stage
+                                        groups[k].sort((a, b) => a.stage - b.stage);
+
                                         return (
                                             <Line 
                                                 key={k}

--- a/src/components/Milestone1Dashboard.jsx
+++ b/src/components/Milestone1Dashboard.jsx
@@ -248,9 +248,10 @@ const Milestone1Dashboard = ({ onNavigateBack, onNavigate, onToggleMobileNav }) 
             
             const grouped = {};
             reports.forEach(r => {
+                if (r.stage === 0) return; // Skip stage 0
                 const q = parseFloat(r.qps.toFixed(2));
                 if (!grouped[q]) {
-                    grouped[q] = { qps: q };
+                    grouped[q] = { qps: q, stage: r.stage };
                 }
                 const prefix = r.scenario === 'k8s-service-baseline' ? 'baseline' : 'router';
                 grouped[q][`${prefix}_output_token_rate`] = parseFloat(r.output_token_rate.toFixed(2));

--- a/src/utils/gcsScanner.js
+++ b/src/utils/gcsScanner.js
@@ -249,6 +249,9 @@ export const parseInferenceSchedulingReport = (content, filePath) => {
         const prefill_node_count = doc.prefill_node_count || config.prefill_node_count || 0;
         const decode_node_count = doc.decode_node_count || config.decode_node_count || 0;
         const num_nodes = prefill_node_count + decode_node_count;
+        
+        const stageMatch = filePath.match(/_stage_(\d+)_/);
+        const stage = stageMatch ? parseInt(stageMatch[1], 10) : (doc.scenario?.load?.standardized?.stage || 0);
 
         return {
             id: crypto.randomUUID(),
@@ -262,6 +265,7 @@ export const parseInferenceSchedulingReport = (content, filePath) => {
             serving_engine,
             num_nodes: num_nodes || 4,
             runId,
+            stage,
             qps: throughput.request_rate?.mean || 0,
             output_token_rate: throughput.output_token_rate?.mean || 0,
             ttft: {


### PR DESCRIPTION
## What does this PR do?

Draw trendline through by stage id, ignore warmup stage

## Why is this change needed?

<!-- Explain the motivation: bug fix, feature request, performance improvement, etc. -->

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [ x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
