### PR TITLE
feat: implement dynamic iframe navigation and shareable URLs for Work…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ vendor/
 node_modules
 
 zipline-upload.zip
+llm-d-prism.code-workspace

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -38,6 +38,9 @@ function App() {
     // Update URL to reflect the current view
     const params = new URLSearchParams(window.location.search);
     params.set('view', view);
+    if (view !== 'workload-catalog') {
+      params.delete('workload');
+    }
     window.history.pushState({}, '', `${window.location.pathname}?${params.toString()}`);
     
     // Reset scroll position on navigation

--- a/src/components/WorkloadCatalog.jsx
+++ b/src/components/WorkloadCatalog.jsx
@@ -1,7 +1,53 @@
-import React from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { ArrowLeft, MessageCircle, Share2 } from 'lucide-react';
 
 const WorkloadCatalog = ({ onNavigateBack }) => {
+    const [copied, setCopied] = useState(false);
+
+    // Compute the initial iframe source on mount only to prevent reloading the iframe on parent re-renders.
+    const iframeSrc = useMemo(() => {
+        const queryParams = new URLSearchParams(window.location.search);
+        const workload = queryParams.get('workload') || '';
+        const initialPath = workload ? `/workloads/${workload}` : '';
+        const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+        const baseUrl = isLocal 
+            ? 'http://localhost:5174'
+            : 'https://workload-catalog-app-369234493812.us-central1.run.app';
+        return `${baseUrl}${initialPath}`;
+    }, []);
+
+    useEffect(() => {
+        const handleMessage = (event) => {
+            if (event.data && event.data.type === 'workload-catalog-navigate') {
+                const path = event.data.path;
+                const params = new URLSearchParams(window.location.search);
+                if (path && path.startsWith('/workloads/')) {
+                    const workloadId = path.replace('/workloads/', '').trim().toLowerCase().replace(/\s+/g, '-');
+                    params.set('workload', workloadId);
+                } else {
+                    params.delete('workload');
+                }
+                window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+            }
+        };
+
+        window.addEventListener('message', handleMessage);
+        return () => {
+            window.removeEventListener('message', handleMessage);
+        };
+    }, []);
+
+    const handleShare = () => {
+        navigator.clipboard.writeText(window.location.href)
+            .then(() => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 2000);
+            })
+            .catch((err) => {
+                console.error('Failed to copy link: ', err);
+            });
+    };
+
     return (
         <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col items-center pt-16">
             
@@ -37,17 +83,17 @@ const WorkloadCatalog = ({ onNavigateBack }) => {
                         <MessageCircle className="w-4 h-4 mr-2" /> Contact us
                     </a>
                     <button 
-                        className="px-4 py-2 text-sm font-medium rounded-md text-slate-500 bg-slate-800/50 cursor-not-allowed flex items-center border border-slate-700/50 relative"
-                        disabled
+                        onClick={handleShare}
+                        className="px-4 py-2 text-sm font-medium rounded-md text-slate-300 bg-slate-800 hover:bg-slate-700 active:bg-slate-600 transition-colors flex items-center border border-slate-700 relative"
                     >
-                        <Share2 className="w-4 h-4 mr-2" /> Share view 
+                        <Share2 className="w-4 h-4 mr-2" /> {copied ? 'Copied!' : 'Share view'}
                     </button>
                 </div>
             </header>
 
             <main className="w-full px-8 py-6 pl-28 flex flex-col relative w-full h-[calc(100vh-4rem)]">
                 <iframe 
-                    src="https://workload-catalog-app-369234493812.us-central1.run.app/" 
+                    src={iframeSrc} 
                     className="w-full h-full border-0" 
                     title="Workload Catalog"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"


### PR DESCRIPTION

## What does this PR do?

Enable apps in prism like the Workload Catalog to share navigation state

## Why is this change needed?

A user can now share a link from an app embedded in prism using that apps navigation state. E.g. It is now possible to share a specific link to a specific workload catalog card, http://prism.llm-d.ai/?view=workload-catalog&workload=code-generation

## How was this tested?

- [X] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [X] Documentation updated (if applicable)