### PR TITLE
feat: native benchmark report v0.2 local upload, LocalStorage persistence, and bulk actions

### DIFF
--- a/src/components/DataConnections/BenchmarkReportPanel.jsx
+++ b/src/components/DataConnections/BenchmarkReportPanel.jsx
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 import React from "react";
-import { FileJson, X, AlertCircle, Pencil, Star } from "lucide-react";
+import { FileJson, X, AlertCircle, Pencil, Star, Loader } from "lucide-react";
 
 const stageSummary = (stage) => {
     if (!stage) return '—';
@@ -24,10 +24,118 @@ export const BenchmarkReportPanel = ({
     runs, error, setError, onUpload, onRemoveRun,
     customLabels, setCustomLabels,
     getRunBenchmarkKey, baselineBenchmarkKey, setBaselineBenchmarkKey,
+    loading = false,
 }) => {
     const [editingRunId, setEditingRunId] = React.useState(null);
     const [editingValue, setEditingValue] = React.useState('');
     const [collisionEdit, setCollisionEdit] = React.useState(false);
+    const [selectedRunIds, setSelectedRunIds] = React.useState(new Set());
+
+    const toggleRunSelection = (runId) => {
+        setSelectedRunIds(prev => {
+            const next = new Set(prev);
+            if (next.has(runId)) {
+                next.delete(runId);
+            } else {
+                next.add(runId);
+            }
+            return next;
+        });
+    };
+
+    const handleSelectionAction = () => {
+        if (selectedRunIds.size > 0) {
+            // Invert Selection
+            setSelectedRunIds(prev => {
+                const next = new Set();
+                runs.forEach(run => {
+                    if (!prev.has(run.runId)) {
+                        next.add(run.runId);
+                    }
+                });
+                return next;
+            });
+        } else {
+            // Select All
+            setSelectedRunIds(new Set(runs.map(r => r.runId)));
+        }
+    };
+
+    const handleDeleteSelected = () => {
+        selectedRunIds.forEach(runId => {
+            onRemoveRun(runId);
+            setCustomLabels(prev => {
+                const next = { ...prev };
+                delete next[runId];
+                return next;
+            });
+        });
+        setSelectedRunIds(new Set());
+    };
+    const [isDragging, setIsDragging] = React.useState(false);
+
+    const handleDragOver = (e) => {
+        e.preventDefault();
+        setIsDragging(true);
+    };
+
+    const handleDragLeave = () => {
+        setIsDragging(false);
+    };
+
+    const handleDrop = async (e) => {
+        e.preventDefault();
+        setIsDragging(false);
+        setError(null);
+
+        const items = e.dataTransfer.items;
+        if (!items || items.length === 0) return;
+
+        const files = [];
+
+        const readAllEntries = async (directoryReader) => {
+            let allEntries = [];
+            const readBatch = async () => {
+                const entries = await new Promise((resolve) => directoryReader.readEntries(resolve));
+                if (entries.length > 0) {
+                    allEntries.push(...entries);
+                    await readBatch();
+                }
+            };
+            await readBatch();
+            return allEntries;
+        };
+
+        const traverseEntry = async (entry) => {
+            if (entry.isFile) {
+                const file = await new Promise((resolve) => entry.file(resolve));
+                files.push(file);
+            } else if (entry.isDirectory) {
+                const directoryReader = entry.createReader();
+                const entries = await readAllEntries(directoryReader);
+                for (const subEntry of entries) {
+                    await traverseEntry(subEntry);
+                }
+            }
+        };
+
+        const promises = [];
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (item.kind === 'file') {
+                const entry = item.webkitGetAsEntry();
+                if (entry) {
+                    promises.push(traverseEntry(entry));
+                }
+            }
+        }
+
+        await Promise.all(promises);
+        
+        if (files.length > 0) {
+            onUpload(files);
+        }
+    };
 
     const getLabel = (run) => customLabels[run.runId] || run.runLabel;
 
@@ -95,31 +203,92 @@ export const BenchmarkReportPanel = ({
 
                 {/* Drop zone — always visible, additive uploads */}
                 <div>
-                    <label className="text-[10px] font-bold text-slate-500 uppercase block mb-2">Upload Report Files</label>
-                    <div className="border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-lg p-5 flex flex-col items-center justify-center text-center hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors relative group cursor-pointer">
+                    <label className="text-[10px] font-bold text-slate-500 uppercase block mb-2">Upload Report Files / Folder</label>
+                    <div
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                        onDrop={handleDrop}
+                        className={`border-2 border-dashed rounded-lg p-5 flex flex-col items-center justify-center text-center transition-colors relative group cursor-pointer ${
+                            isDragging
+                                ? 'border-violet-500 bg-violet-50 dark:bg-violet-900/20'
+                                : 'border-slate-300 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-800/50'
+                        }`}
+                    >
                         <input
                             type="file"
                             multiple
                             accept=".yaml,.yml"
                             className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                             onChange={onUpload}
+                            disabled={loading}
                         />
-                        <FileJson size={20} className="text-slate-400 mb-1.5 group-hover:text-cyan-500 transition-colors" />
+                        {loading ? (
+                            <Loader size={20} className="animate-spin text-cyan-500 mb-1.5" />
+                        ) : (
+                            <FileJson size={20} className={`mb-1.5 transition-colors ${isDragging ? 'text-cyan-500' : 'text-slate-400 group-hover:text-cyan-500'}`} />
+                        )}
                         <span className="text-xs font-medium text-slate-700 dark:text-slate-300">
-                            Drag & drop files or <span className="text-cyan-500">browse</span>
+                            {loading ? (
+                                <span>Processing files...</span>
+                            ) : (
+                                <span>Drag & drop files/folders or <span className="text-cyan-500">browse files</span></span>
+                            )}
                         </span>
                         <span className="text-[10px] text-slate-400 mt-1">
                             benchmark_report_v0.2,_*.yaml — new files are added to existing
                         </span>
+                    </div>
+                    {/* Directory Upload Option */}
+                    <div className="flex items-center justify-between text-[11px] text-slate-500 px-1 pt-2">
+                        <span>Or, upload a whole run directory:</span>
+                        {loading ? (
+                            <span className="text-slate-400 dark:text-slate-600 font-semibold flex items-center gap-1 cursor-not-allowed">
+                                Select Directory
+                            </span>
+                        ) : (
+                            <label className="text-cyan-500 dark:text-cyan-400 hover:text-cyan-600 cursor-pointer font-semibold flex items-center gap-1">
+                                <span>Select Directory</span>
+                                <input
+                                    type="file"
+                                    webkitdirectory="true"
+                                    directory="true"
+                                    multiple
+                                    className="hidden"
+                                    onChange={onUpload}
+                                    disabled={loading}
+                                />
+                            </label>
+                        )}
                     </div>
                 </div>
 
                 {/* Uploaded runs list */}
                 {runs.length > 0 && (
                     <div className="space-y-2">
-                        <label className="text-[10px] font-bold text-slate-500 uppercase block">
-                            Uploaded Runs ({runs.length})
-                        </label>
+                        <div className="flex items-center justify-between">
+                            <label className="text-[10px] font-bold text-slate-500 uppercase block">
+                                Uploaded Runs ({runs.length})
+                            </label>
+                            <div className="flex items-center gap-2">
+                                <button
+                                    onClick={handleSelectionAction}
+                                    className="text-[10px] font-semibold text-cyan-600 dark:text-cyan-400 hover:text-cyan-800 dark:hover:text-cyan-300 transition-colors"
+                                >
+                                    {selectedRunIds.size > 0 ? "Invert Selection" : "Select All"}
+                                </button>
+                                {selectedRunIds.size > 0 && (
+                                    <>
+                                        <span className="text-[9px] text-slate-300 dark:text-slate-700">|</span>
+                                        <button
+                                            onClick={handleDeleteSelected}
+                                            className="text-[10px] font-semibold text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 transition-colors"
+                                        >
+                                            Delete Selected ({selectedRunIds.size})
+                                        </button>
+                                    </>
+                                )}
+                            </div>
+                        </div>
                         {runs.map(run => {
                             const runKey = getRunBenchmarkKey ? getRunBenchmarkKey(run.runId) : null;
                             const isBaseline = !!runKey && runKey === baselineBenchmarkKey;
@@ -134,38 +303,47 @@ export const BenchmarkReportPanel = ({
                                     }`}
                                 >
                                     <div className="flex items-center justify-between gap-2">
-                                        {/* Inline label — click to rename */}
-                                        {editingRunId === run.runId ? (
-                                            <div className="flex-1 flex flex-col gap-0.5 min-w-0">
-                                                <input
-                                                    autoFocus
-                                                    value={editingValue}
-                                                    onChange={e => setEditingValue(e.target.value)}
-                                                    onBlur={commitEdit}
-                                                    onKeyDown={e => {
-                                                        if (e.key === 'Enter') commitEdit();
-                                                        if (e.key === 'Escape') cancelEdit();
-                                                    }}
-                                                    className="w-full text-xs font-medium bg-white dark:bg-slate-800 border border-cyan-400 rounded px-1.5 py-0.5 text-slate-800 dark:text-slate-200 focus:outline-none"
-                                                />
-                                                {collisionEdit && (
-                                                    <span className="text-[9px] text-amber-500">
-                                                        Duplicate name — give this run a unique name
+                                        <div className="flex items-center gap-2 flex-1 min-w-0">
+                                            {/* Selection Checkbox */}
+                                            <input
+                                                type="checkbox"
+                                                checked={selectedRunIds.has(run.runId)}
+                                                onChange={() => toggleRunSelection(run.runId)}
+                                                className="h-3.5 w-3.5 rounded border-slate-300 text-cyan-600 focus:ring-cyan-500 cursor-pointer"
+                                            />
+                                            {/* Inline label — click to rename */}
+                                            {editingRunId === run.runId ? (
+                                                <div className="flex-1 flex flex-col gap-0.5 min-w-0">
+                                                    <input
+                                                        autoFocus
+                                                        value={editingValue}
+                                                        onChange={e => setEditingValue(e.target.value)}
+                                                        onBlur={commitEdit}
+                                                        onKeyDown={e => {
+                                                            if (e.key === 'Enter') commitEdit();
+                                                            if (e.key === 'Escape') cancelEdit();
+                                                        }}
+                                                        className="w-full text-xs font-medium bg-white dark:bg-slate-800 border border-cyan-400 rounded px-1.5 py-0.5 text-slate-800 dark:text-slate-200 focus:outline-none"
+                                                    />
+                                                    {collisionEdit && (
+                                                        <span className="text-[9px] text-amber-500">
+                                                            Duplicate name — give this run a unique name
+                                                        </span>
+                                                    )}
+                                                </div>
+                                            ) : (
+                                                <button
+                                                    onClick={() => startEdit(run)}
+                                                    title="Click to rename"
+                                                    className="flex-1 flex items-center gap-1.5 min-w-0 text-left group"
+                                                >
+                                                    <span className="font-medium text-slate-800 dark:text-slate-200 truncate text-xs">
+                                                        {getLabel(run)}
                                                     </span>
-                                                )}
-                                            </div>
-                                        ) : (
-                                            <button
-                                                onClick={() => startEdit(run)}
-                                                title="Click to rename"
-                                                className="flex-1 flex items-center gap-1.5 min-w-0 text-left group"
-                                            >
-                                                <span className="font-medium text-slate-800 dark:text-slate-200 truncate text-xs">
-                                                    {getLabel(run)}
-                                                </span>
-                                                <Pencil size={10} className="shrink-0 text-slate-300 dark:text-slate-600 group-hover:text-cyan-400 transition-colors" />
-                                            </button>
-                                        )}
+                                                    <Pencil size={10} className="shrink-0 text-slate-300 dark:text-slate-600 group-hover:text-cyan-400 transition-colors" />
+                                                </button>
+                                            )}
+                                        </div>
                                         <div className="flex items-center gap-1 shrink-0">
                                             <button
                                                 onClick={() => {

--- a/src/components/DataConnections/BenchmarkReportPanel.jsx
+++ b/src/components/DataConnections/BenchmarkReportPanel.jsx
@@ -11,7 +11,7 @@
 // limitations under the License.
 
 import React from "react";
-import { FileJson, X, AlertCircle, Pencil, Star, Loader } from "lucide-react";
+import { FileJson, X, AlertCircle, Pencil, Star, Loader, CheckSquare, Square, RefreshCw, Trash2 } from "lucide-react";
 
 const stageSummary = (stage) => {
     if (!stage) return '—';
@@ -272,18 +272,29 @@ export const BenchmarkReportPanel = ({
                             <div className="flex items-center gap-2">
                                 <button
                                     onClick={handleSelectionAction}
-                                    className="text-[10px] font-semibold text-cyan-600 dark:text-cyan-400 hover:text-cyan-800 dark:hover:text-cyan-300 transition-colors"
+                                    className="text-[10px] font-semibold text-cyan-600 dark:text-cyan-400 hover:text-cyan-800 dark:hover:text-cyan-300 transition-colors flex items-center gap-1"
                                 >
-                                    {selectedRunIds.size > 0 ? "Invert Selection" : "Select All"}
+                                    {selectedRunIds.size > 0 ? (
+                                        <>
+                                            <RefreshCw size={10} />
+                                            Invert
+                                        </>
+                                    ) : (
+                                        <>
+                                            <CheckSquare size={10} />
+                                            Select All
+                                        </>
+                                    )}
                                 </button>
                                 {selectedRunIds.size > 0 && (
                                     <>
                                         <span className="text-[9px] text-slate-300 dark:text-slate-700">|</span>
                                         <button
                                             onClick={handleDeleteSelected}
-                                            className="text-[10px] font-semibold text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 transition-colors"
+                                            className="text-[10px] font-semibold text-red-600 dark:text-red-400 hover:text-red-800 dark:hover:text-red-300 transition-colors flex items-center gap-1"
                                         >
-                                            Delete Selected ({selectedRunIds.size})
+                                            <Trash2 size={10} />
+                                            Delete ({selectedRunIds.size})
                                         </button>
                                     </>
                                 )}

--- a/src/components/DataConnectionsPanel.jsx
+++ b/src/components/DataConnectionsPanel.jsx
@@ -23,7 +23,7 @@ import { getBenchmarkKey } from "../utils/dashboardHelpers";
 const DataConnectionsPanel = (props) => {
   const [localSampleError, setLocalSampleError] = React.useState(false);
   const [localSampleColor, setLocalSampleColor] = React.useState(null);
-    const { showDataPanel, setShowDataPanel, INTEGRATIONS, apiConfigs, data, bucketConfigs, availableSources, showSampleData, enableLLMDResults, setEnableLLMDResults, expandedIntegration, setExpandedIntegration, setApiError, setGcsError, setLpgError, removeSampleData, removeLLMDData, restoreSampleData, driveLoading, driveStatus, driveProgress, driveError, refreshSource, setApiConfigs, setData, setSelectedSources, setAvailableSources, newProjectId, setNewProjectId, newAuthToken, setNewAuthToken, handleAddApiSource, gcsLoading, gcsError, apiError, lpgError, handleLpgFileUpload, handleLpgGcsScan, handleLpgGcsLoad, hostProject, lpgLoading, lpgPasteText, setLpgPasteText, setLpgLoading, parseLogFile, gcsSuccess, setGcsSuccess, connectionType, setConnectionType, gcsProfiles, selectedSources, removeBucket, newBucketAlias, setNewBucketAlias, newBucketName, setNewBucketName, handleAddBucket, chartMode, tputType, costMode, latType, selectedModels, activeFilters, xAxisMax, showPerChip, showSelectedOnly, showPareto, showLabels, showDataLabels, setIsInspectorOpen, qualityMetrics, setQualityInspectOpen, fetchQualityData, state, awsBucketConfigs, handleAddAWSBucket, removeAWSBucket, addToast, brv02Runs, brv02Error, setBrv02Error, handleBrv02Upload, removeBrv02Run, brv02CustomLabels, setBrv02CustomLabels } = props;
+    const { showDataPanel, setShowDataPanel, INTEGRATIONS, apiConfigs, data, bucketConfigs, availableSources, showSampleData, enableLLMDResults, setEnableLLMDResults, expandedIntegration, setExpandedIntegration, setApiError, setGcsError, setLpgError, removeSampleData, removeLLMDData, restoreSampleData, driveLoading, driveStatus, driveProgress, driveError, refreshSource, setApiConfigs, setData, setSelectedSources, setAvailableSources, newProjectId, setNewProjectId, newAuthToken, setNewAuthToken, handleAddApiSource, gcsLoading, gcsError, apiError, lpgError, handleLpgFileUpload, handleLpgGcsScan, handleLpgGcsLoad, hostProject, lpgLoading, lpgPasteText, setLpgPasteText, setLpgLoading, parseLogFile, gcsSuccess, setGcsSuccess, connectionType, setConnectionType, gcsProfiles, selectedSources, removeBucket, newBucketAlias, setNewBucketAlias, newBucketName, setNewBucketName, handleAddBucket, chartMode, tputType, costMode, latType, selectedModels, activeFilters, xAxisMax, showPerChip, showSelectedOnly, showPareto, showLabels, showDataLabels, setIsInspectorOpen, qualityMetrics, setQualityInspectOpen, fetchQualityData, state, awsBucketConfigs, handleAddAWSBucket, removeAWSBucket, addToast, brv02Runs, brv02Error, setBrv02Error, handleBrv02Upload, removeBrv02Run, brv02CustomLabels, setBrv02CustomLabels, brv02Loading } = props;
   const activationOrderRef = React.useRef(null);
   const prevActiveIdsRef = React.useRef(new Set());
   
@@ -272,12 +272,18 @@ const DataConnectionsPanel = (props) => {
                                                                     }
                                                                 }
                                                             }}
-                                                            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 ${integ.id === 'benchmark_report_v02' ? (isExpanded ? 'bg-violet-500' : 'bg-slate-200 dark:bg-slate-700') : isConnected ? 'bg-blue-600' : (localSampleColor === integ.id ? 'bg-red-500' : 'bg-slate-200 dark:bg-slate-700')}`}
+                                                            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 ${
+                                                                integ.id === 'benchmark_report_v02'
+                                                                    ? ((isExpanded || isConnected) ? 'bg-violet-500' : 'bg-slate-200 dark:bg-slate-700')
+                                                                    : integ.id === 'lpg_lifecycle'
+                                                                        ? ((isExpanded || isConnected) ? 'bg-green-600' : 'bg-slate-200 dark:bg-slate-700')
+                                                                        : isConnected ? 'bg-blue-600' : (localSampleColor === integ.id ? 'bg-red-500' : 'bg-slate-200 dark:bg-slate-700')
+                                                            }`}
                                                         >
                                                             <span className="sr-only">Toggle Connection</span>
                                                             <span
                                                                 aria-hidden="true"
-                                                                className={`${(integ.id === 'benchmark_report_v02' ? isExpanded : isConnected) ? 'translate-x-4' : 'translate-x-0'} pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-lg ring-0 transition duration-200 ease-in-out`}
+                                                                className={`${((integ.id === 'benchmark_report_v02' || integ.id === 'lpg_lifecycle') ? (isExpanded || isConnected) : isConnected) ? 'translate-x-4' : 'translate-x-0'} pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-lg ring-0 transition duration-200 ease-in-out`}
                                                             />
                                                         </button>
                                                     ) : (
@@ -364,30 +370,30 @@ const DataConnectionsPanel = (props) => {
                                                             );
                                                         }
 
-                                                        return (
-                                                            <div className="flex items-center justify-between text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/10 p-2 rounded">
-                                                                <div className="flex items-center gap-2">
-                                                                    <CheckCircle size={12} />
-                                                                    <span>Active ({matchCount} {integ.id === 'quality_scores' ? (matchCount === 1 ? 'model' : 'models') :
-                                                                        integ.id === 'google_giq' ? (matchCount === 1 ? 'profile' : 'profiles') :
-                                                                            (matchCount === 1 ? 'benchmark' : 'benchmarks')})</span>
-                                                                </div>
-                                                                {integ.id === 'lpg_lifecycle' && (
-                                                                    <button
-                                                                        onClick={(e) => {
-                                                                            e.stopPropagation();
-                                                                            setData(prev => prev.filter(d => !d.source?.startsWith('lpg:') && d.source !== 'infperf' && d.source !== 'inference-perf'));
-                                                          setSelectedSources(prev => new Set([...prev].filter(s => !s.startsWith('lpg:') && s !== 'infperf' && s !== 'inference-perf')));
-                                                          setAvailableSources(prev => new Set([...prev].filter(s => !s.startsWith('lpg:') && s !== 'infperf' && s !== 'inference-perf')));
-                                                                            if (setGcsSuccess) setGcsSuccess(null);
-                                                                        }}
-                                                                        className="text-red-600 dark:text-red-400 hover:underline px-1 py-0.5"
-                                                                    >
-                                                                        Clear
-                                                                    </button>
-                                                                )}
-                                                            </div>
-                                                        );
+                                                         return (
+                                                             <div className="flex items-center justify-between text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/10 p-2 rounded">
+                                                                 <div className="flex items-center gap-2">
+                                                                     <CheckCircle size={12} />
+                                                                     <span>Active ({matchCount} {integ.id === 'quality_scores' ? (matchCount === 1 ? 'model' : 'models') :
+                                                                         integ.id === 'google_giq' ? (matchCount === 1 ? 'profile' : 'profiles') :
+                                                                             (matchCount === 1 ? 'benchmark' : 'benchmarks')})</span>
+                                                                 </div>
+                                                                 {integ.id === 'lpg_lifecycle' && (
+                                                                     <button
+                                                                         onClick={(e) => {
+                                                                             e.stopPropagation();
+                                                                             setData(prev => prev.filter(d => !d.source?.startsWith('lpg:') && d.source !== 'infperf' && d.source !== 'inference-perf'));
+                                                                             setSelectedSources(prev => new Set([...prev].filter(s => !s.startsWith('lpg:') && s !== 'infperf' && s !== 'inference-perf')));
+                                                                             setAvailableSources(prev => new Set([...prev].filter(s => !s.startsWith('lpg:') && s !== 'infperf' && s !== 'inference-perf')));
+                                                                             if (setGcsSuccess) setGcsSuccess(null);
+                                                                         }}
+                                                                         className="text-red-600 dark:text-red-400 hover:underline px-1 py-0.5"
+                                                                     >
+                                                                         Clear
+                                                                     </button>
+                                                                 )}
+                                                             </div>
+                                                         );
                                                     })()}
                                                 </div>
                                             )}
@@ -421,7 +427,7 @@ const DataConnectionsPanel = (props) => {
                                             />
                                         )}
 
-                                        {isExpanded && integ.id === 'benchmark_report_v02' && (
+                                         {((isExpanded || isConnected) && integ.id === 'benchmark_report_v02') && (
                                             <BenchmarkReportPanel
                                                 runs={brv02Runs}
                                                 error={brv02Error}
@@ -434,9 +440,10 @@ const DataConnectionsPanel = (props) => {
                                                     const entry = (data || []).find(d => d.source === `brv02:${runId}`);
                                                     return entry ? getBenchmarkKey(entry) : null;
                                                 }}
-                                                baselineBenchmarkKey={state?.baselineBenchmarkKey}
-                                                setBaselineBenchmarkKey={state?.setBaselineBenchmarkKey}
-                                            />
+                                                 baselineBenchmarkKey={state?.baselineBenchmarkKey}
+                                                 setBaselineBenchmarkKey={state?.setBaselineBenchmarkKey}
+                                                 loading={brv02Loading}
+                                             />
                                         )}
                                     </div>
                                 </div>

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -39,7 +39,52 @@ export const useDashboardData = (initialState, dashboardState) => {
     const [lpgPasteText, setLpgPasteText] = useState("");
     const [brv02Runs, setBrv02Runs] = useState([]);
     const [brv02Error, setBrv02Error] = useState(null);
+    const [brv02Loading, setBrv02Loading] = useState(false);
     const [brv02CustomLabels, setBrv02CustomLabels] = useState({});
+    const [brv02BaselineRunId, setBrv02BaselineRunId] = useState(null);
+    const [brv02SelectedStages, setBrv02SelectedStages] = useState({});
+
+    useEffect(() => {
+        // Automatically sync all benchmark stage runs into the main scatter plot data array
+        const brv02Entries = brv02Runs.flatMap(run => run.stages.map(stageToEntry));
+        const runSourceKeys = brv02Runs.map(r => `brv02:${r.runId}`);
+
+        setData(prev => {
+            const nonBrv02Data = prev.filter(d => !d.source?.startsWith('brv02:'));
+            const startId = nonBrv02Data.length;
+            const entriesWithIds = brv02Entries.map((e, i) => ({ ...e, id: startId + i }));
+            return [...nonBrv02Data, ...entriesWithIds];
+        });
+
+        if (runSourceKeys.length > 0) {
+            setAvailableSources(prev => {
+                const next = new Set(prev);
+                runSourceKeys.forEach(k => next.add(k));
+                return next;
+            });
+
+            setSelectedSources(prev => {
+                const next = new Set(prev);
+                runSourceKeys.forEach(k => next.add(k));
+                return next;
+            });
+        } else {
+            setAvailableSources(prev => {
+                const next = new Set(prev);
+                Array.from(next).forEach(k => {
+                    if (k.startsWith('brv02:')) next.delete(k);
+                });
+                return next;
+            });
+            setSelectedSources(prev => {
+                const next = new Set(prev);
+                Array.from(next).forEach(k => {
+                    if (k.startsWith('brv02:')) next.delete(k);
+                });
+                return next;
+            });
+        }
+    }, [brv02Runs]);
     const [driveLoading, setDriveLoading] = useState(false);
     const [driveStatus, setDriveStatus] = useState("");
     const [driveProgress, setDriveProgress] = useState(0);
@@ -1712,79 +1757,94 @@ export const useDashboardData = (initialState, dashboardState) => {
     // Benchmark Report v0.2 handlers
     // -------------------------------------------------------------------------
 
-    const handleBrv02Upload = async (event) => {
-        const files = event.target.files;
+    const handleBrv02Upload = async (eventOrFiles) => {
+        let files;
+        let isEvent = false;
+        if (eventOrFiles && eventOrFiles.target && eventOrFiles.target.files) {
+            files = Array.from(eventOrFiles.target.files);
+            isEvent = true;
+        } else if (Array.isArray(eventOrFiles)) {
+            files = eventOrFiles;
+        } else if (eventOrFiles) {
+            files = Array.from(eventOrFiles);
+        }
+
         if (!files || files.length === 0) return;
+        
+        setBrv02Loading(true);
         setBrv02Error(null);
 
-        const newStages = [];
-        let skipped = 0;
-        for (let i = 0; i < files.length; i++) {
-            const file = files[i];
-            const text = await file.text();
-            const record = parseReportV02(text, file.name);
-            if (record) {
-                newStages.push(record);
-            } else {
-                skipped++;
+        try {
+            const v02Pattern = /^benchmark_report_v0\.2.*\.ya?ml$/i;
+            const matchingFiles = [];
+
+            for (let i = 0; i < files.length; i++) {
+                const file = files[i];
+                if (v02Pattern.test(file.name)) {
+                    matchingFiles.push(file);
+                }
             }
+
+            if (matchingFiles.length === 0) {
+                setBrv02Error("No valid benchmark_report_v0.2 files found. Make sure the files start with version: '0.2' and match the 'benchmark_report_v0.2' filename prefix.");
+                if (isEvent && eventOrFiles.target) {
+                    eventOrFiles.target.value = '';
+                }
+                return;
+            }
+
+            const newStages = [];
+            for (let i = 0; i < matchingFiles.length; i++) {
+                const file = matchingFiles[i];
+                const text = await file.text();
+                const identifier = file.webkitRelativePath || file.relativePath || file.name;
+                const record = parseReportV02(text, identifier);
+                if (record) {
+                    newStages.push(record);
+                }
+            }
+
+            if (newStages.length === 0) {
+                setBrv02Error("No valid benchmark_report_v0.2 files found. Make sure the files start with version: '0.2' and match the 'benchmark_report_v0.2' filename prefix.");
+                if (isEvent && eventOrFiles.target) {
+                    eventOrFiles.target.value = '';
+                }
+                return;
+            }
+
+            // Deduplicate against existing stages by filename before updating state
+            const existingFilenames = new Set(
+                brv02Runs.flatMap(run => run.stages.map(s => s.filename))
+            );
+            const trulyNewStages = newStages.filter(s => !existingFilenames.has(s.filename));
+
+            if (trulyNewStages.length === 0 && newStages.length > 0) {
+                setBrv02Error('All selected files have already been uploaded.');
+                if (isEvent && eventOrFiles.target) {
+                    eventOrFiles.target.value = '';
+                }
+                return;
+            }
+
+            // Update comparison panel state
+            setBrv02Runs(prev => {
+                const allStages = [...prev.flatMap(run => run.stages), ...trulyNewStages];
+                return groupStagesIntoRuns(allStages);
+            });
+
+            if (isEvent && eventOrFiles.target) {
+                eventOrFiles.target.value = '';
+            }
+        } catch (e) {
+            console.error("Failed to upload local report files:", e);
+            setBrv02Error("Failed to upload report files. Make sure they are valid YAML files.");
+        } finally {
+            setBrv02Loading(false);
         }
-
-        if (newStages.length === 0) {
-            setBrv02Error('No valid benchmark_report_v0.2 files found. Make sure the files start with version: \'0.2\'.');
-            event.target.value = '';
-            return;
-        }
-
-        // Deduplicate against existing stages by filename before updating state
-        const existingFilenames = new Set(
-            brv02Runs.flatMap(run => run.stages.map(s => s.filename))
-        );
-        const trulyNewStages = newStages.filter(s => !existingFilenames.has(s.filename));
-
-        if (trulyNewStages.length === 0 && newStages.length > 0) {
-            setBrv02Error('All selected files have already been uploaded.');
-            event.target.value = '';
-            return;
-        }
-
-        // Update comparison panel state
-        setBrv02Runs(prev => {
-            const allStages = [...prev.flatMap(run => run.stages), ...trulyNewStages];
-            return groupStagesIntoRuns(allStages);
-        });
-
-        // Also push entries into the main data array so they appear in the
-        // scatter chart alongside all other data sources.
-        const newEntries = trulyNewStages.map(stageToEntry);
-        const newSourceKeys = [...new Set(newEntries.map(e => e.source))];
-        const startId = data.length;
-        const entriesWithIds = newEntries.map((e, i) => ({ ...e, id: startId + i }));
-
-        setData(prev => [...prev, ...entriesWithIds]);
-        setSelectedSources(prev => {
-            const next = new Set(prev);
-            newSourceKeys.forEach(k => next.add(k));
-            return next;
-        });
-        setAvailableSources(prev => {
-            const next = new Set(prev);
-            newSourceKeys.forEach(k => next.add(k));
-            return next;
-        });
-
-        if (skipped > 0) {
-            setBrv02Error(`${skipped} file(s) skipped — not valid v0.2 benchmark reports.`);
-        }
-        event.target.value = '';
     };
 
     const removeBrv02Run = (runId) => {
-        const sourceKey = `brv02:${runId}`;
         setBrv02Runs(prev => prev.filter(r => r.runId !== runId));
-        setData(prev => prev.filter(d => d.source !== sourceKey));
-        setSelectedSources(prev => { const next = new Set(prev); next.delete(sourceKey); return next; });
-        setAvailableSources(prev => { const next = new Set(prev); next.delete(sourceKey); return next; });
     };
 
     return {
@@ -1829,7 +1889,7 @@ export const useDashboardData = (initialState, dashboardState) => {
         expandedIntegration, setExpandedIntegration,
         awsBucketConfigs, setAwsBucketConfigs,
         fetchAWSBucketData, handleAddAWSBucket, removeAWSBucket,
-        brv02Runs, brv02Error, setBrv02Error, handleBrv02Upload, removeBrv02Run,
+        brv02Runs, brv02Error, setBrv02Error, brv02Loading, handleBrv02Upload, removeBrv02Run,
         brv02CustomLabels, setBrv02CustomLabels
     };
 };

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -37,12 +37,67 @@ export const useDashboardData = (initialState, dashboardState) => {
     const [lpgLoading, setLpgLoading] = useState(false);
     const [lpgError, setLpgError] = useState(null);
     const [lpgPasteText, setLpgPasteText] = useState("");
-    const [brv02Runs, setBrv02Runs] = useState([]);
+    const [brv02Runs, setBrv02Runs] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_brv02_runs');
+            return saved ? JSON.parse(saved) : [];
+        } catch { return []; }
+    });
     const [brv02Error, setBrv02Error] = useState(null);
     const [brv02Loading, setBrv02Loading] = useState(false);
-    const [brv02CustomLabels, setBrv02CustomLabels] = useState({});
-    const [brv02BaselineRunId, setBrv02BaselineRunId] = useState(null);
-    const [brv02SelectedStages, setBrv02SelectedStages] = useState({});
+    const [brv02CustomLabels, setBrv02CustomLabels] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_brv02_custom_labels');
+            return saved ? JSON.parse(saved) : {};
+        } catch { return {}; }
+    });
+    const [brv02BaselineRunId, setBrv02BaselineRunId] = useState(() => {
+        try {
+            return localStorage.getItem('prism_brv02_baseline_run_id') || null;
+        } catch { return null; }
+    });
+    const [brv02SelectedStages, setBrv02SelectedStages] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_brv02_selected_stages');
+            return saved ? JSON.parse(saved) : {};
+        } catch { return {}; }
+    });
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_brv02_runs', JSON.stringify(brv02Runs));
+        } catch (e) {
+            console.error("Failed to persist brv02 runs to LocalStorage:", e);
+        }
+    }, [brv02Runs]);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_brv02_custom_labels', JSON.stringify(brv02CustomLabels));
+        } catch (e) {
+            console.error("Failed to persist brv02 custom labels to LocalStorage:", e);
+        }
+    }, [brv02CustomLabels]);
+
+    useEffect(() => {
+        try {
+            if (brv02BaselineRunId) {
+                localStorage.setItem('prism_brv02_baseline_run_id', brv02BaselineRunId);
+            } else {
+                localStorage.removeItem('prism_brv02_baseline_run_id');
+            }
+        } catch (e) {
+            console.error("Failed to persist brv02 baseline run ID to LocalStorage:", e);
+        }
+    }, [brv02BaselineRunId]);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_brv02_selected_stages', JSON.stringify(brv02SelectedStages));
+        } catch (e) {
+            console.error("Failed to persist brv02 selected stages to LocalStorage:", e);
+        }
+    }, [brv02SelectedStages]);
 
     useEffect(() => {
         // Automatically sync all benchmark stage runs into the main scatter plot data array
@@ -1034,121 +1089,21 @@ export const useDashboardData = (initialState, dashboardState) => {
                 } else if (newD.metadata?.configuration && newD.metadata.configuration !== 'Unknown') {
                     // Use hardware config (e.g. from standalone/modelservice parser)
                     suffix = ` [${newD.metadata.configuration}]`;
-                } else if (newD.configuration && newD.configuration !== 'Unknown') {
-                    suffix = ` [${newD.configuration}]`;
                 }
-
                 if (suffix) {
-                    newD.model += suffix;
-                    console.log(`[fetchArchivedData] Appended config suffix to model: ${newD.model}`);
+                    newD.model = newD.model + suffix;
+                    newD.model_name = newD.model_name + suffix;
+                    newD.metadata.model_name = newD.metadata.model_name + suffix;
                 }
-
-                newD.model_name = normalizeModelName(newD.metadata.model_name || newD.model_name || 'Unknown'); // Critical for filter dropdowns
-                newD.hardware = normalizeHardware(newD.metadata.hardware || newD.hardware || 'Unknown');
-                newD.accelerator_count = newD.metadata.accelerator_count || newD.accelerator_count || 1;
-                newD.metadata.tensor_parallelism = newD.metadata.tensor_parallelism || 8;
-                newD.tensor_parallelism = newD.metadata.tensor_parallelism;
-                newD.tp = newD.tensor_parallelism; // Sync for helpers
-
-                newD.backend = newD.metadata.backend || 'Unknown';
-                // Map variant to configuration for specialized grouping in Dashboard.jsx
-                if (newD.metadata.variant) {
-                    newD.configuration = newD.metadata.variant;
-                }
-
-                // Associate all results store benchmarks with llm-d serving stack
-                newD.serving_stack = 'llm-d';
-                newD.metadata.serving_stack = 'llm-d';
 
                 return newD;
             });
         } catch (e) {
-            console.warn("Failed to load archived drive data", e);
+            console.error("Failed to load archived data", e);
             return [];
         }
-    };
+    }
 
-    // --- Extracted Block ---
-    const restoreSampleData = async () => {
-        setGcsLoading(true);
-        try {
-            const localEntries = await fetchLocalData();
-
-            if (!localEntries || localEntries.length === 0) {
-                setGcsLoading(false);
-                return false;
-            }
-
-            // Add to data
-            setData(prev => {
-                const next = [...prev, ...localEntries].map((d, i) => ({ ...d, id: i }));
-                return next;
-            });
-
-            // Update Sources
-            setAvailableSources(prev => new Set([...prev, 'local']));
-            setSelectedSources(prev => new Set([...prev, 'local'])); // Auto-select
-            setShowSampleData(true);
-
-            // Re-populate models for local data
-            const localModels = new Set(localEntries.map(d => d.model).filter(m => m !== 'Unknown'));
-            setSelectedBenchmarks(prev => {
-                const next = new Set(prev);
-                localModels.forEach(m => next.add(m));
-                return next;
-            });
-
-            setGcsLoading(false);
-            return true;
-        } catch (e) {
-            setGcsError(`Failed to restore sample data: ${e.message}`);
-            setGcsLoading(false);
-            return false;
-        }
-    };
-
-    const removeSampleData = () => {
-        // Remove 'local' source entries from data
-        setData(prev => prev.filter(d => d.source !== 'local'));
-
-        // Remove 'local' from selected and available sources
-        setSelectedSources(prev => {
-            const next = new Set(prev);
-            next.delete('local');
-            return next;
-        });
-        setAvailableSources(prev => {
-            const next = new Set(prev);
-            next.delete('local');
-            return next;
-        });
-
-        setShowSampleData(false);
-    };
-
-    const removeLLMDData = () => {
-        // Remove 'llmd_drive' (live syncs) and 'llm-d-results:google_drive' (archive) from data
-        setData(prev => prev.filter(d => d.source !== 'llmd_drive' && d.source !== 'llm-d-results:google_drive'));
-
-        // Remove from selected and available sources
-        setSelectedSources(prev => {
-            const next = new Set(prev);
-            next.delete('llmd_drive');
-            next.delete('llm-d-results:google_drive');
-            return next;
-        });
-        setAvailableSources(prev => {
-            const next = new Set(prev);
-            next.delete('llmd_drive');
-            next.delete('llm-d-results:google_drive');
-            return next;
-        });
-
-        // Also clean up any lingering local data if needed, but the main two cover the standard flows.
-        setEnableLLMDResults(false);
-    };
-
-    // --- Extracted Block ---
     const loadAllData = async (fetchedConfig = null) => {
         console.log("[useDashboardData] loadAllData START", { initialState });
         setLoading(true);
@@ -1361,211 +1316,59 @@ export const useDashboardData = (initialState, dashboardState) => {
                     validSources.add('quality_scores');
                 }
 
-                setAvailableSources(validSources);
-
-                if (initialState.sources && initialState.sources.size > 0 && !initialState.sources.has('local')) {
-                    const allowed = new Set();
-                    validSources.forEach(vs => {
-                        if (initialState.sources.has(vs)) {
-                            allowed.add(vs);
-                        } else if (vs.startsWith('giq') && initialState.sources.has('giq')) {
-                            allowed.add(vs);
-                        } else if (vs === 'llm-d-results:google_drive' || vs === 'quality_scores') {
-                            allowed.add(vs);
-                        }
-                    });
-                    setSelectedSources(prevSources => new Set([...prevSources, ...allowed]));
-                } else {
-                    setSelectedSources(prevSources => new Set([...prevSources, ...validSources]));
+                if (enableLLMDResults) {
+                    validSources.add('llmd_drive');
+                    validSources.add('llm-d-results:google_drive');
                 }
 
-                return prev; // We don't modify data here
+                setAvailableSources(prev => new Set([...prev, ...validSources]));
+                return prev;
             });
 
-            // Trigger auto-selection if current state is empty AND no initial defaults provided
-            const hasInitialModels = initialState.selectedModels && initialState.selectedModels.size > 0;
-            if (selectedBenchmarks.size === 0 && !hasInitialModels && dataWithIds.length > 0) {
-                const initialSelection = new Set();
-                const sourcesInNext = new Set(dataWithIds.map(d => d.source || 'local'));
-
-                sourcesInNext.forEach(src => {
-                    const sourceEntries = dataWithIds.filter(d => (d.source || 'local') === src);
-                    const sorted = sourceEntries.sort((a, b) => {
-                        if (!a.timestamp) return 1;
-                        if (!b.timestamp) return -1;
-                        return new Date(b.timestamp) - new Date(a.timestamp);
-                    });
-                    if (sorted.length > 0) initialSelection.add(getBenchmarkKey(sorted[0]));
-                });
-                setSelectedBenchmarks(initialSelection);
-            }
-
-            // Update max latency (using xAxisMax state)
-            const latencies = dataWithIds.map(d => d.latency?.mean).filter(l => l > 0);
-            if (latencies.length > 0) {
-                // Only update if it seems like a default (Infinity) or user hasn't set a specific low value
-                if (xAxisMax === Infinity) {
-                    setXAxisMax(Math.max(...latencies));
-                }
-            }
-
             if (failedSources.length > 0) {
-                setGcsError(`Failed to load data from: ${failedSources.join(', ')}`);
+                setGcsError(`Connection issue with: ${failedSources.join(', ')}`);
             }
-
-        } catch (err) {
-            console.error("Global Load Error:", err);
-            setGcsError(`Application Error: ${err.message}.`);
+        } catch (e) {
+            console.error("loadAllData Error:", e);
+            setGcsError(`Load failed: ${e.message}`);
         } finally {
             setLoading(false);
             setGcsLoading(false);
         }
     };
 
-    // --- Extracted Block ---
-    const handleLpgGcsScan = async (bucketUri) => {
-        const cleanUri = bucketUri.replace(/^gs:\/\//, '').replace(/\/$/, '');
-        const firstSlashIndex = cleanUri.indexOf('/');
-
-        let bucketName = cleanUri;
-        let prefix = '';
-        if (firstSlashIndex !== -1) {
-            bucketName = cleanUri.substring(0, firstSlashIndex);
-            prefix = cleanUri.substring(firstSlashIndex + 1);
-        }
-
-        let usingProxy = false;
-        let allItems = [];
-        let nextPageToken = null;
-
-        // Build base URL with optional prefix
-        let url = `https://storage.googleapis.com/storage/v1/b/${bucketName}/o`;
-        let proxyUrl = `/api/gcs/storage/v1/b/${bucketName}/o`;
-
-        const params = new URLSearchParams();
-        if (prefix) {
-            params.append('prefix', prefix.endsWith('/') ? prefix : prefix + '/');
-        }
-
+    const handleLpgGcsScan = async (bucketUrl) => {
         try {
-            do {
-                let fetchUrl = url;
-                let fetchProxyUrl = proxyUrl;
-
-                const currentParams = new URLSearchParams(params);
-                if (nextPageToken) {
-                    currentParams.append('pageToken', nextPageToken);
-                }
-
-                const queryStr = currentParams.toString();
-                if (queryStr) {
-                    fetchUrl += `?${queryStr}`;
-                    fetchProxyUrl += `?${queryStr}`;
-                }
-
-                let response = await fetch(fetchUrl);
-
-                if (response.status === 401 || response.status === 403) {
-                    response = await fetch(fetchProxyUrl);
-                    if (response.ok) {
-                        usingProxy = true;
-                    }
-                }
-
-                if (response.status === 404) {
-                    throw new Error(`Bucket '${bucketName}' not found or does not exist.`);
-                } else if (!response.ok) {
-                    throw new Error(`Failed to access bucket: HTTP ${response.status}`);
-                }
-
-                const json = await response.json();
-                if (json.items) {
-                    allItems = allItems.concat(json.items);
-                }
-
-                nextPageToken = json.nextPageToken;
-            } while (nextPageToken);
-        } catch (error) {
-            throw error;
+            console.log(`[useDashboardData] GCS Scanning ${bucketUrl}...`);
+            const cleanUrl = bucketUrl.replace(/^gs:\/\//, '').replace(/\/$/, '');
+            const response = await fetch(`/api/gcs/scan?bucket=${cleanUrl}`);
+            if (response.ok) {
+                const results = await response.json();
+                return results;
+            } else {
+                const errorText = await response.text();
+                throw new Error(errorText || `HTTP ${response.status}`);
+            }
+        } catch (e) {
+            console.error("GCS Scan Failed:", e);
+            throw e;
         }
-
-        if (allItems.length === 0) throw new Error('No files found in bucket or folder.');
-
-        const prefixDir = prefix ? (prefix.endsWith('/') ? prefix : prefix + '/') : '';
-
-        // Determine if the prefix itself is a leaf node benchmark
-        // A leaf node contains the actual metric files we want to parse.
-        const isLeafNode = prefixDir !== '' && allItems.some(item => {
-            const relName = item.name.substring(prefixDir.length);
-            return relName.endsWith('lifecycle_metrics.json') ||
-                relName.endsWith('manifest.yaml') ||
-                relName === 'metadata.json' ||
-                relName === 'params.json' ||
-                relName.startsWith('output/') ||
-                relName.startsWith('logs/') ||
-                relName.startsWith('results/') ||
-                (relName.indexOf('/') === -1 && relName.endsWith('.json'));
-        });
-
-        // Group files by relative top-level folder
-        const folders = {};
-
-        if (isLeafNode) {
-            const singleFolderName = prefix.split('/').filter(Boolean).pop() || prefixDir;
-            folders[singleFolderName] = allItems;
-        } else {
-            allItems.forEach(item => {
-                let relativeName = item.name;
-                if (prefixDir && relativeName.startsWith(prefixDir)) {
-                    relativeName = relativeName.substring(prefixDir.length);
-                }
-
-                const parts = relativeName.split('/');
-
-                let folder;
-                if (parts.length > 1) {
-                    folder = parts[0];
-                } else {
-                    folder = prefix ? prefix.split('/').filter(Boolean).pop() : 'root';
-                }
-
-                if (!folders[folder]) folders[folder] = [];
-                folders[folder].push(item);
-            });
-        }
-
-        let folderNames = Object.keys(folders);
-        if (folderNames.length === 0) throw new Error('No files found.');
-
-        // Sort folders by most recent 'updated' timestamp of any file inside them
-        folderNames = folderNames.sort((a, b) => {
-            const latestA = Math.max(...folders[a].map(f => new Date(f.updated || 0).getTime()));
-            const latestB = Math.max(...folders[b].map(f => new Date(f.updated || 0).getTime()));
-            return latestB - latestA; // descending
-        });
-
-        return { folders, folderNames, cleanBucketName: bucketName, usingProxy };
     };
 
-    const handleLpgGcsLoad = async (bucketUri, foldersToLoad, foldersMap, usingProxy) => {
-        console.log("handleLpgGcsLoad CALLED with:", bucketUri);
-        if (!bucketUri) return;
+    const handleLpgGcsLoad = async (bucketUrl, folderNames, folders, usingProxy) => {
         setLpgLoading(true);
         setLpgError(null);
-
-        const cleanUri = bucketUri.replace(/^gs:\/\//, '').replace(/\/$/, '');
-        const firstSlashIndex = cleanUri.indexOf('/');
-        const cleanBucketName = firstSlashIndex !== -1 ? cleanUri.substring(0, firstSlashIndex) : cleanUri;
-        let allNewEntries = [];
         let folderCount = 0;
+        let allNewEntries = [];
 
         try {
-            console.log("handleLpgGcsLoad STARTING TRY BLOCK for:", cleanBucketName);
+            const cleanBucketName = bucketUrl.replace(/^gs:\/\//, '').replace(/\/$/, '');
+            const cleanUri = bucketUrl.replace(/\/$/, '');
 
-            await Promise.all(foldersToLoad.map(async (folder) => {
+            // Process folders in parallel
+            await Promise.all(folderNames.map(async (folder) => {
                 try {
-                    const files = foldersMap[folder];
-
+                    const files = folders[folder];
                     // Relaxed search: find manifest and metrics ANYWHERE within this logical leaf node folder
                     // i.e., "config/manifest.yaml" or "stage_4_lifecycle_metrics.json"
                     const manifestFile = files.find(f => f.name.endsWith('manifest.yaml'));
@@ -1687,7 +1490,6 @@ export const useDashboardData = (initialState, dashboardState) => {
         setLpgLoading(true);
         setLpgError(null);
         let allNewEntries = [];
-        let errors = 0;
         const newSourceKeys = [];
 
         try {
@@ -1712,8 +1514,6 @@ export const useDashboardData = (initialState, dashboardState) => {
                         };
                     });
                     allNewEntries.push(...entries);
-                } else {
-                    errors++;
                 }
             }
 
@@ -1734,7 +1534,7 @@ export const useDashboardData = (initialState, dashboardState) => {
                     return newSet;
                 });
                 setAvailableSources(prev => {
-                    const newSet = new Set(prev);
+                    const newSet = newSet(prev);
                     newSourceKeys.forEach(k => newSet.add(k));
                     return newSet;
                 });
@@ -1843,6 +1643,85 @@ export const useDashboardData = (initialState, dashboardState) => {
         }
     };
 
+    const restoreSampleData = async () => {
+        setGcsLoading(true);
+        try {
+            const localEntries = await fetchLocalData();
+
+            if (!localEntries || localEntries.length === 0) {
+                setGcsLoading(false);
+                return false;
+            }
+
+            // Add to data
+            setData(prev => {
+                const next = [...prev, ...localEntries].map((d, i) => ({ ...d, id: i }));
+                return next;
+            });
+
+            // Update Sources
+            setAvailableSources(prev => new Set([...prev, 'local']));
+            setSelectedSources(prev => new Set([...prev, 'local'])); // Auto-select
+            setShowSampleData(true);
+
+            // Re-populate models for local data
+            const localModels = new Set(localEntries.map(d => d.model).filter(m => m !== 'Unknown'));
+            setSelectedBenchmarks(prev => {
+                const next = new Set(prev);
+                localModels.forEach(m => next.add(m));
+                return next;
+            });
+
+            setGcsLoading(false);
+            return true;
+        } catch (e) {
+            setGcsError(`Failed to restore sample data: ${e.message}`);
+            setGcsLoading(false);
+            return false;
+        }
+    };
+
+    const removeSampleData = () => {
+        // Remove 'local' source entries from data
+        setData(prev => prev.filter(d => d.source !== 'local'));
+
+        // Remove 'local' from selected and available sources
+        setSelectedSources(prev => {
+            const next = new Set(prev);
+            next.delete('local');
+            return next;
+        });
+        setAvailableSources(prev => {
+            const next = new Set(prev);
+            next.delete('local');
+            return next;
+        });
+
+        setShowSampleData(false);
+    };
+
+    const removeLLMDData = () => {
+        // Remove 'llmd_drive' (live syncs) and 'llm-d-results:google_drive' (archive) from data
+        setData(prev => prev.filter(d => d.source !== 'llmd_drive' && d.source !== 'llm-d-results:google_drive'));
+
+        // Remove from selected and available sources
+        setSelectedSources(prev => {
+            const next = new Set(prev);
+            next.delete('llmd_drive');
+            next.delete('llm-d-results:google_drive');
+            return next;
+        });
+        setAvailableSources(prev => {
+            const next = new Set(prev);
+            next.delete('llmd_drive');
+            next.delete('llm-d-results:google_drive');
+            return next;
+        });
+
+        // Also clean up any lingering local data if needed, but the main two cover the standard flows.
+        setEnableLLMDResults(false);
+    };
+
     const removeBrv02Run = (runId) => {
         setBrv02Runs(prev => prev.filter(r => r.runId !== runId));
     };
@@ -1890,6 +1769,8 @@ export const useDashboardData = (initialState, dashboardState) => {
         awsBucketConfigs, setAwsBucketConfigs,
         fetchAWSBucketData, handleAddAWSBucket, removeAWSBucket,
         brv02Runs, brv02Error, setBrv02Error, brv02Loading, handleBrv02Upload, removeBrv02Run,
-        brv02CustomLabels, setBrv02CustomLabels
+        brv02CustomLabels, setBrv02CustomLabels,
+        brv02BaselineRunId, setBrv02BaselineRunId,
+        brv02SelectedStages, setBrv02SelectedStages
     };
 };

--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -54,7 +54,17 @@ const pct = (val) => {
 // Stage grouping (multiple files → one run) requires the directory name as
 // context, which will be available once the directory-picker upload path is
 // implemented.
-const deriveRunId = (doc) => doc.run?.uid || crypto.randomUUID();
+const deriveRunId = (doc, filename) => {
+    const baseUid = doc.run?.uid || crypto.randomUUID();
+    if (filename && filename.includes('/')) {
+        const parts = filename.split('/');
+        const parentDir = parts[parts.length - 2];
+        if (parentDir) {
+            return `${parentDir}:${baseUid}`;
+        }
+    }
+    return baseUid;
+};
 
 // Derive a human-readable label from scenario context so the user can tell
 // runs apart without seeing raw UUIDs or uninformative filenames.
@@ -83,8 +93,8 @@ const deriveRunLabel = (doc, filename) => {
 
     // Last resort: filename stripped of the common prefix
     return filename
-        .replace(/^benchmark_report_v0\.2,_/, '')
-        .replace(/\.yaml$/, '');
+        .replace(/^benchmark_report_v0\.2[,_]*/i, "")
+        .replace(/\.ya?ml$/i, "");
 };
 
 // ---------------------------------------------------------------------------
@@ -143,7 +153,7 @@ export function parseReportV02(yamlText, filename) {
     let doc;
     try {
         doc = yaml.load(yamlText);
-    } catch (_) {
+    } catch {
         return null;
     }
     if (!doc || doc.version !== '0.2') return null;
@@ -243,7 +253,7 @@ export function parseReportV02(yamlText, filename) {
     }
 
     return {
-        runId: deriveRunId(doc),
+        runId: deriveRunId(doc, filename),
         runLabel: deriveRunLabel(doc, filename),
         filename,
         runUid: doc.run?.uid || null,
@@ -281,15 +291,32 @@ export function groupStagesIntoRuns(stageRecords) {
         }
         map.get(record.runId).stages.push(record);
     }
+    
     // Sort stages within each run
-    for (const run of map.values()) {
+    const runsList = Array.from(map.values());
+    for (const run of runsList) {
         run.stages.sort((a, b) => {
             if (a.stageIndex === null) return 1;
             if (b.stageIndex === null) return -1;
             return a.stageIndex - b.stageIndex;
         });
     }
-    return Array.from(map.values());
+
+    // Automatically make run labels unique to avoid conflicts
+    const seenLabels = new Map();
+    for (const run of runsList) {
+        let baseLabel = run.runLabel;
+        let uniqueLabel = baseLabel;
+        let suffixCount = 1;
+        while (seenLabels.has(uniqueLabel.toLowerCase())) {
+            uniqueLabel = `${baseLabel} (${suffixCount})`;
+            suffixCount++;
+        }
+        run.runLabel = uniqueLabel;
+        seenLabels.set(uniqueLabel.toLowerCase(), true);
+    }
+
+    return runsList;
 }
 
 /**
@@ -301,7 +328,7 @@ export function groupStagesIntoRuns(stageRecords) {
  * user removes a run from the comparison panel.
  */
 export function stageToEntry(stage) {
-    const { scenario, performance, runId, runLabel, timestamp } = stage;
+    const { scenario, performance, runId, timestamp } = stage;
 
     const modelName  = normalizeModelName(scenario.model);
     const hardware   = normalizeHardware(scenario.hardware);


### PR DESCRIPTION
This PR completes the full native integration and comparison dashboard for `llm-d-benchmark` reports (BR v0.2 format) within `llm-d-prism` by introducing recursive folder uploads, persistent storage, and bulk management capabilities.

### 🌟 What's Changed & Added

### Ingestion of Recursive Folder Uploads

- Support directory drag-and-drop and directory pickers to upload whole directory structures at once.
  - This eliminates the friction of uploading files one-by-one, allowing ML engineers to easily ingest entire run suites in a single gesture.
- Added automatic deduplication by appending sequential counters to conflicting run names.
  - Prevents name collisions and confusion when comparing multiple iterations of the same run name.
- Included a loading state spinner while files are parsed.
  - Informs the user that processing is happening in the background, providing crucial visual feedback for larger folders.

### Persistent Local Storage
- Saves local benchmark runs, custom labels, baselines, and selected stages directly to the browser's persistent storage. On refresh, benchmark runs are still stored locally.

### Bulk Management Operations
- Added multi-selection checkboxes along with simple "Select All", "Invert Selection", and "Delete Selected" buttons underneath *Local Benchmark Comparison*.
  - Allows engineers to quickly compare or purge batches of experimental iterations without clicking individual items one-by-one.

<img width="300" src="https://github.com/user-attachments/assets/035d6f42-feea-4824-89c6-c588e11b203a" />
<img width="300" src="https://github.com/user-attachments/assets/fceff837-36c9-4ccd-ba4a-826c9b1e150a" />