### PR TITLE
feat: introduce dedicated Manage Benchmarks view

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# Agent Reference & Dev Notes
+
+This file serves as a reference for agents and developers working on the `llm-d-prism` codebase.
+
+## Dataset & Reference Paths
+
+- **inference-perf outputs:** Reference runs/logs can be found in:
+  `../../kubernetes-sigs/inference-perf/reports-*`
+- **llm-d-benchmark results:** Benchmark result references are located at:
+  `devutils/llm-d-benchmark-results`
+
+## Current Capabilities & Roadmap (Updated for PR #58)
+
+- **Completed in PR #58:**
+  - **Parser (`src/utils/benchmarkReportV02Parser.js`):** A native, robust YAML parser for the `llm-d-benchmark` Benchmark Report v0.2 schema. It supports all five major harnesses (`inference-perf`, `guidellm`, `vllm-benchmark`, `inferencemax`, `nop`).
+  - **Enhanced BRV0.2 Parser and Deduplicator:** Upgraded run ID derivation with a file/scenario-descriptor prefix, modernized common prefix/suffix stripping, and added auto-suffixing to resolve naming collisions dynamically for duplicate run labels.
+  - **Comparison UI (`src/components/BenchmarkComparisonDashboard.jsx`):** A rich comparison dashboard featuring grouped bar charts for request performance and observability metrics, baseline toggling (★), and side-by-side metric tables with % diff comparison badges.
+  - **Control Panel (`src/components/DataConnections/BenchmarkReportPanel.jsx`):** A dedicated connection panel supporting drag-and-drop for `.yaml` files, inline renaming with collision safety, and stage selectors.
+  - **Scatter Plot Integration:** Ingested v0.2 runs are automatically mapped (`stageToEntry`) and displayed in the main scatter chart under the `brv02:<run-uid>` tag.
+
+- **Completed in PR #64 (Recursive Folder Ingestion & Persistence):**
+  - **Recursive Folder Batch Ingestion:** Enabled dragging-and-dropping entire directories or selecting folders via a directory picker, recursively scanning subdirectories to batch-ingest benchmark files.
+  - **Collision-Resistant Unique Labeling:** Added deduplication logic that appends counter suffixes (e.g. `(1)`) to avoid name clashes upon folder upload.
+  - **Enhanced Local Storage State Persistence:** Expanded state persistence to cover `showSelectedOnly`, selected benchmarks, active search filters, and baseline benchmark selections, so user states are fully preserved on tab closure or reloads.
+  - **Bulk Run Management:** Integrated checkbox selection for uploaded runs, featuring fast "Select All", "Invert Selection", and "Delete Selected" bulk management controls.
+  - **Visual Processing Feedback:** Added a loading spinner during directory crawling and parser execution.
+  - **Corrected Switch UI State:** Refactored sidebar drawer toggles so their visual ON/OFF states and transition knobs accurately align with the actual data/connection state.
+
+- **Completed (Benchmark Selection Decoupling & Sidebar Navigation Restructure):**
+  - **Manage Benchmarks Page (`src/components/ManageBenchmarks.jsx`):** Decoupled the benchmark browser filter controls and selection list into a separate, dedicated "Manage Benchmarks" page. Integrated GCS/AWS/GIQ connection configuration directly on this management page.
+  - **Shared App-Wide Selection States (`src/App.jsx`):** Lifted `dashboardState` and `dashboardData` hooks up to the main application context, allowing selections made in the management page to seamlessly carry over to the old results page.
+  - **Component Isolation for Layouts:** Duplicated and isolated the `FilterPanel` and `UnifiedDataTable` components into `src/components/Dashboard/` (retaining the classic table layout) and `src/components/ManageBenchmarks/` (using the new expanded card layout), allowing both views to coexist with their respective designs.
+  - **Classic Flat Dashboard Layout (`src/components/Dashboard.jsx`):** Restored the primary dashboard to its original `main` branch state, ensuring the classic flat layout, side-by-side spec comparison table, and performance metric scatter plots remain intact. Replaced the "Connections" button with a "Manage" button that links to the new management page.
+  - **Enhanced Navigation Sidebar (`src/components/LeftNavigation.jsx`):** Created a new `"Management"` sidebar section to offer a direct path to the new `"Manage Benchmarks"` view.
+  - **Omitted Share Functionality:** Removed the "Share view" button from the management view to keep its interface focused strictly on data selection and ingestion.
+
+- **Completed (Manage Benchmarks Quality of Life Enhancements):**
+  - **Inline Run Management:** Moved the Delete, Baseline (★), and Rename (pencil) controls for BRV2.0 uploaded runs out of the Connections sidebar directly into the benchmark rows within `UnifiedDataTable.jsx`.
+  - **Bulk Delete for Selected Local Runs:** Added a "Delete Selected" button that appears when benchmarks are selected. If any non-local (read-only) benchmark is selected, the button is greyed out with a custom stylish tooltip stating "Non-local data sources are read-only." on hover. If only local runs are selected, clicking it deletes them all simultaneously and clears the active selection.
+  - **Drag-to-Select Capabilities:** Replaced basic checkbox clicks with OS-native style "rubber-banding". Users can click and hold a row's checkbox, then drag their mouse to quickly select or deselect multiple contiguous benchmarks. Fully supports viewport scrolling by dynamically re-computing bounding boxes and updating active selections during active scroll events.
+  - **Simplified Upload Interface:** Stripped the list of uploaded runs from `BenchmarkReportPanel.jsx`, reducing it to exclusively act as a clean file/folder dropzone.
+  - **Integration Source Type Categorization:** Added structured source classifications (`Local`, `Cloud`, `Built-in`) with matching colored status pills (amber for Local, cyan for Cloud, and emerald for Built-in) across the Connections panel to give clear visual distinction to different benchmark origins.
+  - **UI/UX Polish:** Transformed the "Manage Benchmarks" sidebar navigation icon to a more descriptive `Database` icon, removed redundant filter buttons in the classic dashboard, and preserved model row expansion states within the benchmarks table.
+
+- **Completed (Run Grouping & UUID Formatting for Uploaded Reports):**
+  - **Accurate UUID Rendering:** Fixed `stageToEntry` in `benchmarkReportV02Parser.js` to properly pass `run_id` to the base `createEntry` schema. Previously, uploaded runs displayed internal sequential integer IDs (e.g. `270`) instead of their actual UUIDs within the Manage Benchmarks dashboard.
+  - **Directory-Based Run Identification:** Rewrote `deriveRunId` and `deriveRunLabel` to directly consume parent directory names when files are uploaded as folders (e.g. producing `llm-d-benchmark-results/h100_with_igw` as the origin label).
+  - **Stable Stage Grouping:** Eliminated the buggy automatic suffixing `(1)`, `(2)` logic which was falsely fracturing single runs into multiple isolated run folders. By using the directory as the strict grouping mechanism (`runId`), all stages parsed from a single folder now accurately group under one combined label.
+
+## Development Instructions
+
+- Use `nix shell nixpkgs#nodejs -c npm run lint` to lint this project. Only care about lint messages specific to your modifications. DO NOT FIX PREVIOUS LINT ISSUES.
+- Use the `gbrowser` skill to automate testing of a webpage.
+- The development servers are managed via `docker compose`. Assume that the `docker compose` stack is always running; if it is not, error out and inform the user immediately. Use `docker compose logs` to retrieve server logs.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,8 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import { Loader } from 'lucide-react';
 import Dashboard from './components/Dashboard';
+import ManageBenchmarks from './components/ManageBenchmarks';
 import ErrorBoundary from './components/ErrorBoundary';
 import PrismHome from './components/PrismHome';
 import Milestone1Dashboard from './components/Milestone1Dashboard';
@@ -21,9 +23,14 @@ import SchemaExplorer from './components/SchemaExplorer';
 import WorkloadCatalog from './components/WorkloadCatalog';
 
 import LeftNavigation from './components/LeftNavigation';
+import { useDashboardState } from './hooks/useDashboardState';
+import { useDashboardData } from './hooks/useDashboardData';
 
 function App() {
   const mainRef = useRef(null);
+  const dashboardState = useDashboardState();
+  const dashboardData = useDashboardData(dashboardState.initialState, dashboardState);
+
   const [currentView, setCurrentView] = useState(() => {
     const params = new URLSearchParams(window.location.search);
     // Legacy 'benchmark-comparison' deep links land on the Benchmark Browser,
@@ -33,6 +40,31 @@ function App() {
   }); // 'home' | 'benchmark-browser' | 'intelligent-routing' | 'schema-explorer' | 'workload-catalog' | 'guided-analysis'
 
   const [isMobileNavOpen, setIsMobileNavOpen] = useState(false);
+  const [bypassLoading, setBypassLoading] = useState(false);
+
+  const { fetchConfig, loadAllData, enableLLMDResults, loading, isRestoringConnections, gcsProfiles } = dashboardData;
+  const hasFetchedConfig = useRef(false);
+
+  useEffect(() => {
+    const initialize = async () => {
+      if (!hasFetchedConfig.current) {
+        hasFetchedConfig.current = true;
+        const config = await fetchConfig();
+        loadAllData(config);
+      } else {
+        loadAllData();
+      }
+    };
+    initialize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [enableLLMDResults]);
+
+  useEffect(() => {
+    const root = window.document.documentElement;
+    root.classList.add('dark');
+    localStorage.setItem('app-theme', 'dark');
+  }, []);
+
 
   const handleNavigate = (view) => {
     setCurrentView(view);
@@ -53,17 +85,40 @@ function App() {
     }
   };
 
+  const activeLoading = loading || isRestoringConnections || (gcsProfiles && gcsProfiles.some(p => p.loading));
+  const shouldShowLoading = activeLoading && !bypassLoading && (currentView === 'benchmark-browser' || currentView === 'manage-benchmarks');
+
   return (
     <ErrorBoundary>
       <div className="min-h-screen bg-slate-950 w-full overflow-hidden font-sans relative flex flex-col">
         <LeftNavigation currentView={currentView} onNavigate={handleNavigate} isMobileOpen={isMobileNavOpen} />
         <main ref={mainRef} className="flex-1 overflow-y-auto flex flex-col relative w-full h-screen">
-          {currentView === 'home' && <PrismHome onNavigate={handleNavigate} />}
-          {currentView === 'intelligent-routing' && <Milestone1Dashboard onNavigateBack={() => handleNavigate('home')} onNavigate={handleNavigate} onToggleMobileNav={() => setIsMobileNavOpen(!isMobileNavOpen)} />}
-          {currentView === 'benchmark-browser' && <Dashboard onNavigateBack={() => handleNavigate('home')} />}
-          {currentView === 'schema-explorer' && <SchemaExplorer onNavigateBack={() => handleNavigate('home')} />}
-          {currentView === 'workload-catalog' && <WorkloadCatalog onNavigateBack={() => handleNavigate('home')} />}
-          {currentView === 'guided-analysis' && <div className="p-8 text-center text-slate-400 mt-20">Guided Analysis Coming Soon... <button onClick={() => handleNavigate('home')} className="underline ml-2 text-indigo-400">Back</button></div>}
+          {shouldShowLoading ? (
+            <div className="flex-1 flex flex-col items-center justify-center bg-slate-950 text-slate-100 transition-colors space-y-6 pl-28">
+                <Loader className="animate-spin text-blue-500" size={40} />
+                <div className="text-center space-y-2">
+                    <div className="text-lg font-semibold text-slate-200">
+                        Loading Benchmark Data...
+                    </div>
+                </div>
+                <button
+                    onClick={() => setBypassLoading(true)}
+                    className="text-xs text-slate-500 hover:text-slate-300 underline transition-colors"
+                >
+                    Skip Waiting (Data may successfully arrive later)
+                </button>
+            </div>
+          ) : (
+            <>
+              {currentView === 'home' && <PrismHome onNavigate={handleNavigate} />}
+              {currentView === 'intelligent-routing' && <Milestone1Dashboard onNavigateBack={() => handleNavigate('home')} onNavigate={handleNavigate} onToggleMobileNav={() => setIsMobileNavOpen(!isMobileNavOpen)} />}
+              {currentView === 'benchmark-browser' && <Dashboard onNavigateBack={() => handleNavigate('home')} onNavigate={handleNavigate} dashboardState={dashboardState} dashboardData={dashboardData} />}
+              {currentView === 'manage-benchmarks' && <ManageBenchmarks onNavigateBack={() => handleNavigate('benchmark-browser')} onNavigate={handleNavigate} dashboardState={dashboardState} dashboardData={dashboardData} />}
+              {currentView === 'schema-explorer' && <SchemaExplorer onNavigateBack={() => handleNavigate('home')} />}
+              {currentView === 'workload-catalog' && <WorkloadCatalog onNavigateBack={() => handleNavigate('home')} />}
+              {currentView === 'guided-analysis' && <div className="p-8 text-center text-slate-400 mt-20">Guided Analysis Coming Soon... <button onClick={() => handleNavigate('home')} className="underline ml-2 text-indigo-400">Back</button></div>}
+            </>
+          )}
         </main>
       </div>
     </ErrorBoundary>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -134,9 +134,10 @@ const MOCK_FALLBACK_DATA_LEGACY = [
     }
 ];
 
-const Dashboard = ({ onNavigateBack }) => {
+const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dashboardData: propData }) => {
 
-    const dashboardState = useDashboardState();
+    const localState = useDashboardState();
+    const dashboardState = propState || localState;
     const {
         initialState,
         chartColorMode, setChartColorMode,
@@ -156,7 +157,7 @@ const Dashboard = ({ onNavigateBack }) => {
         isLogScaleX, setIsLogScaleX,
         zoomDomain, setZoomDomain,
         showDataPanel, setShowDataPanel,
-        showFilterPanel, setShowFilterPanel,
+        showFilterPanel,
         isInspectorOpen, setIsInspectorOpen,
         qualityInspectOpen, setQualityInspectOpen,
         selectedBenchmarks, setSelectedBenchmarks,
@@ -165,7 +166,8 @@ const Dashboard = ({ onNavigateBack }) => {
         generateShareUrl
     } = dashboardState;
 
-    const dashboardData = useDashboardData(initialState, dashboardState);
+    const localData = useDashboardData(initialState, dashboardState);
+    const dashboardData = propData || localData;
     const {
         data: liveData, setData,
         loading, setLoading,
@@ -220,7 +222,6 @@ const Dashboard = ({ onNavigateBack }) => {
 
     // ... existing state ...
     const [apiError, setApiError] = useState(null);
-    const [bypassLoading, setBypassLoading] = useState(false);
     const [shareToast, setShareToast] = useState(false);
     const [toastMessage, setToastMessage] = useState('');
     const [hoveredDataPoint, setHoveredDataPoint] = useState(null);
@@ -237,33 +238,7 @@ const Dashboard = ({ onNavigateBack }) => {
 
     // Persistent State
 
-    const [theme, setTheme] = useState('dark');
-
-    // Milestone 1: LLM-D Results Store State
-
-
-    useEffect(() => {
-        localStorage.setItem('enableLLMDResults', JSON.stringify(enableLLMDResults));
-    }, [enableLLMDResults]);
-
-    useEffect(() => {
-        if (baselineBenchmarkKey) {
-            localStorage.setItem('baselineBenchmarkKey', baselineBenchmarkKey);
-        } else {
-            localStorage.removeItem('baselineBenchmarkKey');
-        }
-    }, [baselineBenchmarkKey]);
-
-
-    useEffect(() => {
-        const root = window.document.documentElement;
-        if (theme === 'dark') {
-            root.classList.add('dark');
-        } else {
-            root.classList.remove('dark');
-        }
-        localStorage.setItem('app-theme', theme);
-    }, [theme]);
+    const theme = 'dark';
 
     // API KEY Access (Vite vs CRA Compat)
     // Note: User has REACT_APP_ in .env.local but Vite expects VITE_.
@@ -345,28 +320,6 @@ const Dashboard = ({ onNavigateBack }) => {
 
 
     // Google Drive Fetching Logic (Milestone 1)
-
-
-
-
-
-    // Track if we've already fetched the server config so we don't overwrite saved filters on re-renders
-    const hasFetchedConfig = useRef(false);
-
-    // Initial Load & Reload on Toggle
-    useEffect(() => {
-        const initialize = async () => {
-            if (!hasFetchedConfig.current) {
-                hasFetchedConfig.current = true;
-                const config = await fetchConfig();
-                loadAllData(config);
-            } else {
-        // If toggled after initial load, use already-populated React state
-                loadAllData();
-            }
-        };
-        initialize();
-    }, [enableLLMDResults]);
 
     // Auto-select new models when selectedSources changes
     // Auto-select new models when selectedSources changes - DISABLED to respect user selection
@@ -898,11 +851,7 @@ const Dashboard = ({ onNavigateBack }) => {
             servingStack: {},
             optimizations: {},
             origins: {},
-            components: {
-                "Inference Gateway": 1,
-                "Inference Scheduler": 0,
-                "LeaderWorkerSet": 0
-            },
+            components: {},
             pdRatio: {}
         };
 
@@ -955,6 +904,13 @@ const Dashboard = ({ onNavigateBack }) => {
             if (ignoreKey !== 'origins' && activeFilters.origins && activeFilters.origins.size > 0) {
                 const origin = d.source_info?.origin || d.source;
                 if (!activeFilters.origins.has(origin)) return false;
+            }
+
+            if (ignoreKey !== 'components' && activeFilters.components && activeFilters.components.size > 0) {
+                const comps = d.components || d.metadata?.components;
+                if (!comps || !Array.isArray(comps) || comps.length === 0) return false;
+                const hasMatchingComp = comps.some(c => activeFilters.components.has(c));
+                if (!hasMatchingComp) return false;
             }
 
             return true;
@@ -1022,15 +978,20 @@ const Dashboard = ({ onNavigateBack }) => {
             if (origin && check(d, 'origins')) {
                 add('origins', origin, modelId);
             }
+
+            const comps = d.components || d.metadata?.components || [];
+            if (comps.length > 0 && check(d, 'components')) {
+                comps.forEach(c => add('components', c, modelId));
+            }
         });
 
         // Convert Sets to counts
         const finalCounts = {
             models: {}, hardware: {}, machines: {}, precisions: {}, tp: {}, isl: {}, osl: {}, ratio: {}, acc_count: {}, modelServer: {}, useCase: {}, servingStack: {}, optimizations: {}, origins: {},
-            components: tempCounts.components,
+            components: {},
             pdRatio: tempCounts.pdRatio
         };
-        ['models', 'hardware', 'machines', 'precisions', 'tp', 'isl', 'osl', 'ratio', 'acc_count', 'modelServer', 'useCase', 'servingStack', 'optimizations', 'pdRatio', 'origins'].forEach(cat => {
+        ['models', 'hardware', 'machines', 'precisions', 'tp', 'isl', 'osl', 'ratio', 'acc_count', 'modelServer', 'useCase', 'servingStack', 'optimizations', 'pdRatio', 'origins', 'components'].forEach(cat => {
             Object.keys(tempCounts[cat]).forEach(key => {
                 finalCounts[cat][key] = tempCounts[cat][key].size;
             });
@@ -1092,6 +1053,13 @@ const Dashboard = ({ onNavigateBack }) => {
             if (activeFilters.pdRatio.size > 0) {
                 const ratio = d.pd_ratio || d.metadata?.pd_ratio || 'Aggregated';
                 if (!activeFilters.pdRatio.has(ratio)) return false;
+            }
+
+            if (activeFilters.components && activeFilters.components.size > 0) {
+                const comps = d.components || d.metadata?.components;
+                if (!comps || !Array.isArray(comps) || comps.length === 0) return false;
+                const hasMatchingComp = comps.some(c => activeFilters.components.has(c));
+                if (!hasMatchingComp) return false;
             }
 
             if (activeFilters.origins.size > 0) {
@@ -1699,56 +1667,7 @@ const Dashboard = ({ onNavigateBack }) => {
         setZoomDomain(null);
     }, [chartMode, tputType]);
 
-    // Aggregated Loading State
-    const activeLoading = loading || isRestoringConnections || gcsProfiles.some(p => p.loading);
-
-    if (activeLoading && !bypassLoading) {
-        // Determine what is loading
-        const loadingItems = [];
-
-        const loadingProfiles = gcsProfiles.filter(p => p.loading);
-
-        // Check for GIQ
-        if (loadingProfiles.some(p => p.type === 'giq')) {
-            loadingItems.push("GIQ");
-        }
-
-        // Check for Custom Connections
-        const customProfiles = loadingProfiles.filter(p => p.type === 'gcs');
-
-        if (customProfiles.length > 0) {
-            loadingItems.push("Custom Connection");
-        }
-
-        // Fallback or App Init
-        if (loadingItems.length === 0 && loading) {
-            loadingItems.push("Application Core");
-        }
-
-        const uniqueItems = [...new Set(loadingItems)];
-
-        return (
-            <div className="flex flex-col items-center justify-center h-screen bg-slate-50 dark:bg-slate-900 transition-colors space-y-6">
-                <Loader className="animate-spin text-blue-500" size={40} />
-
-                <div className="text-center space-y-2">
-                    <div className="text-lg text-slate-700 dark:text-slate-200 font-semibold">
-                        Loading Benchmark Data...
-                    </div>
-
-                </div>
-
-                <button
-                    onClick={() => setBypassLoading(true)}
-                    className="text-xs text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 underline transition-colors"
-                >
-                    Skip Waiting (Data may successfully arrive later)
-                </button>
-            </div>
-        );
-    }
-
-
+    const hasLocalBenchmarks = Array.from(selectedSources || []).some(source => source === 'local' || source.startsWith('brv02:'));
 
     return (
         <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col font-sans antialiased relative overflow-x-hidden pt-16">
@@ -1791,17 +1710,10 @@ const Dashboard = ({ onNavigateBack }) => {
 
                 <div className="flex items-center space-x-4">
                     <button
-                        onClick={() => setShowFilterPanel(!showFilterPanel)}
-                        className={`px-4 py-2 text-sm font-medium rounded-md border transition-colors flex items-center ${showFilterPanel ? 'bg-blue-500/20 text-blue-400 border-blue-500/30' : 'text-slate-300 bg-slate-800 hover:bg-slate-700 border-slate-700'}`}
+                        onClick={() => onNavigate && onNavigate('manage-benchmarks')}
+                        className="px-4 py-2 text-sm font-medium rounded-md border text-slate-300 bg-slate-800 hover:bg-slate-700 border-slate-700 transition-colors flex items-center"
                     >
-                        <Filter className="w-4 h-4 mr-2" /> {showFilterPanel ? 'Hide filters' : 'Show filters'}
-                    </button>
-                    
-                    <button
-                        onClick={() => setShowDataPanel(!showDataPanel)}
-                        className={`px-4 py-2 text-sm font-medium rounded-md border transition-colors flex items-center ${showDataPanel ? 'bg-blue-500/20 text-blue-400 border-blue-500/30' : 'text-slate-300 bg-slate-800 hover:bg-slate-700 border-slate-700'}`}
-                    >
-                        <Database className="w-4 h-4 mr-2" /> Connections
+                        <Database className="w-4 h-4 mr-2" /> Manage
                     </button>
 
                     <a 
@@ -1813,28 +1725,36 @@ const Dashboard = ({ onNavigateBack }) => {
                         <MessageCircle className="w-4 h-4 mr-2" /> Contact us
                     </a>
 
-                    <button 
-                        onClick={() => { 
-                            const shareUrl = generateShareUrl(bucketConfigs, apiConfigs, selectedSources);
-                            navigator.clipboard.writeText(shareUrl).then(() => {
-                                setShareToast(true); 
-                                setToastMessage('Link copied to clipboard!'); 
-                                setTimeout(() => setShareToast(false), 2000); 
-                            }).catch(err => {
-                                setShareToast(true); 
-                                setToastMessage('Failed to copy link'); 
-                                setTimeout(() => setShareToast(false), 2000); 
-                            });
-                        }} 
-                        className="px-4 py-2 text-sm font-medium rounded-md text-slate-300 bg-slate-800 hover:bg-slate-700 transition-colors flex items-center border border-slate-700 relative"
-                    >
-                        <Share2 className="w-4 h-4 mr-2" /> Share view 
-                        {shareToast && (
-                            <div className="absolute -bottom-10 right-0 bg-blue-600 text-white text-xs font-bold px-3 py-1.5 rounded shadow-lg z-50 flex items-center whitespace-nowrap">
-                                {toastMessage}
+                    <div className="relative group flex">
+                        <button 
+                            onClick={() => { 
+                                if (hasLocalBenchmarks) return;
+                                const shareUrl = generateShareUrl(bucketConfigs, apiConfigs, selectedSources);
+                                navigator.clipboard.writeText(shareUrl).then(() => {
+                                    setShareToast(true); 
+                                    setToastMessage('Link copied to clipboard!'); 
+                                    setTimeout(() => setShareToast(false), 2000); 
+                                }).catch(err => {
+                                    setShareToast(true); 
+                                    setToastMessage('Failed to copy link'); 
+                                    setTimeout(() => setShareToast(false), 2000); 
+                                });
+                            }} 
+                            className={`px-4 py-2 text-sm font-medium rounded-md flex items-center border relative transition-colors ${hasLocalBenchmarks ? 'text-slate-500 bg-slate-800 border-slate-700 cursor-not-allowed' : 'text-slate-300 bg-slate-800 hover:bg-slate-700 border-slate-700'}`}
+                        >
+                            <Share2 className="w-4 h-4 mr-2" /> Share view 
+                            {shareToast && !hasLocalBenchmarks && (
+                                <div className="absolute -bottom-10 right-0 bg-blue-600 text-white text-xs font-bold px-3 py-1.5 rounded shadow-lg z-50 flex items-center whitespace-nowrap">
+                                    {toastMessage}
+                                </div>
+                            )}
+                        </button>
+                        {hasLocalBenchmarks && (
+                            <div className="absolute -bottom-10 right-0 bg-slate-800 border border-slate-700 text-slate-300 text-xs font-medium px-3 py-1.5 rounded shadow-lg z-50 flex items-center whitespace-nowrap opacity-0 group-hover:opacity-100 transition-opacity pointer-events-none">
+                                Local benchmark results cannot be shared yet.
                             </div>
                         )}
-                    </button>
+                    </div>
                 </div>
             </header>
 

--- a/src/components/Dashboard/FilterPanel.jsx
+++ b/src/components/Dashboard/FilterPanel.jsx
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
-import { Filter } from 'lucide-react';
+import React, { useState } from 'react';
+import { Filter, ChevronUp, ChevronDown } from 'lucide-react';
 import { MultiSelectDropdown } from '../common';
 import { USE_CASE_META, formatOriginLabel } from '../../utils/dashboardHelpers';
 
@@ -38,30 +38,43 @@ export const FilterPanel = ({
     setBaselineBenchmarkKey,
     UnifiedDataTable
 }) => {
+    const [isFiltersExpanded, setIsFiltersExpanded] = useState(true);
+
     if (!showFilterPanel) return null;
 
     return (
         <div className="bg-white dark:bg-slate-800 rounded-lg border border-slate-200 dark:border-slate-700 p-3 shadow-sm mb-4 transition-colors">
             {/* Header & Controls */}
-            <div className="flex flex-col gap-3 mb-3">
-                <div className="flex justify-between items-center">
+            <div className={`flex flex-col ${isFiltersExpanded ? 'gap-3 mb-3' : ''}`}>
+                <div className={`flex justify-between items-center ${!isFiltersExpanded ? 'py-1.5' : ''}`}>
                     <h2 className="text-sm font-semibold text-slate-500 dark:text-slate-200 uppercase tracking-wider flex items-center gap-2">
                         <Filter size={14} />
                         Benchmark Filter
+                        <button
+                            onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
+                            className="ml-1 p-0.5 rounded-md hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors cursor-pointer text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+                            title={isFiltersExpanded ? "Collapse filters" : "Expand filters"}
+                        >
+                            {isFiltersExpanded ? <ChevronUp size={16} /> : <ChevronDown size={16} />}
+                        </button>
                     </h2>
-                    <div className="w-56 opacity-60 hover:opacity-100 transition-opacity">
-                        <MultiSelectDropdown 
-                            label="Origin / Folder"
-                            options={filterOptions.origins || []}
-                            selected={activeFilters.origins}
-                            onChange={(val) => toggleFilter('origins', val)}
-                            counts={facetCounts.origins || {}}
-                            formatLabel={formatOriginLabel}
-                        />
-                    </div>
+                    {isFiltersExpanded && (
+                        <div className="w-56 opacity-60 hover:opacity-100 transition-opacity">
+                            <MultiSelectDropdown 
+                                label="Origin / Folder"
+                                options={filterOptions.origins || []}
+                                selected={activeFilters.origins}
+                                onChange={(val) => toggleFilter('origins', val)}
+                                counts={facetCounts.origins || {}}
+                                formatLabel={formatOriginLabel}
+                            />
+                        </div>
+                    )}
                 </div>
                 {/* Filter Groups - Compact Layout */}
-                <div className="flex flex-col md:flex-row gap-4 border-t border-slate-200 dark:border-slate-700/50 pt-2">
+                {isFiltersExpanded && (
+                    <>
+                        <div className="flex flex-col md:flex-row gap-4 border-t border-slate-200 dark:border-slate-700/50 pt-2">
                     
                     {/* Section 1: Application / Model Server */}
                     <div className="flex-1 min-w-[200px]">
@@ -228,6 +241,8 @@ export const FilterPanel = ({
                 baselineBenchmarkKey={baselineBenchmarkKey}
                 setBaselineBenchmarkKey={setBaselineBenchmarkKey}
             />
+            </>
+            )}
         </div>
       </div>
     );

--- a/src/components/DataConnections/BenchmarkReportPanel.jsx
+++ b/src/components/DataConnections/BenchmarkReportPanel.jsx
@@ -11,74 +11,76 @@
 // limitations under the License.
 
 import React from "react";
-import { FileJson, X, AlertCircle, Pencil, Star } from "lucide-react";
-
-const stageSummary = (stage) => {
-    if (!stage) return '—';
-    const idx = stage.stageIndex !== null ? `Stage ${stage.stageIndex}` : 'Stage —';
-    const qps = stage.scenario?.rateQps != null ? ` · ${stage.scenario.rateQps} QPS` : '';
-    return `${idx}${qps}`;
-};
+import { FileJson, X, AlertCircle, Loader } from "lucide-react";
 
 export const BenchmarkReportPanel = ({
-    runs, error, setError, onUpload, onRemoveRun,
-    customLabels, setCustomLabels,
-    getRunBenchmarkKey, baselineBenchmarkKey, setBaselineBenchmarkKey,
+    error, setError, onUpload,
+    loading = false,
 }) => {
-    const [editingRunId, setEditingRunId] = React.useState(null);
-    const [editingValue, setEditingValue] = React.useState('');
-    const [collisionEdit, setCollisionEdit] = React.useState(false);
+    const [isDragging, setIsDragging] = React.useState(false);
 
-    const getLabel = (run) => customLabels[run.runId] || run.runLabel;
-
-    const startEdit = (run) => {
-        setEditingRunId(run.runId);
-        setEditingValue(getLabel(run));
+    const handleDragOver = (e) => {
+        e.preventDefault();
+        setIsDragging(true);
     };
 
-    const commitEdit = () => {
-        if (editingRunId) {
-            const trimmed = editingValue.trim();
-            if (trimmed) {
-                setCustomLabels(prev => ({ ...prev, [editingRunId]: trimmed }));
+    const handleDragLeave = () => {
+        setIsDragging(false);
+    };
+
+    const handleDrop = async (e) => {
+        e.preventDefault();
+        setIsDragging(false);
+        setError(null);
+
+        const items = e.dataTransfer.items;
+        if (!items || items.length === 0) return;
+
+        const files = [];
+
+        const readAllEntries = async (directoryReader) => {
+            let allEntries = [];
+            const readBatch = async () => {
+                const entries = await new Promise((resolve) => directoryReader.readEntries(resolve));
+                if (entries.length > 0) {
+                    allEntries.push(...entries);
+                    await readBatch();
+                }
+            };
+            await readBatch();
+            return allEntries;
+        };
+
+        const traverseEntry = async (entry) => {
+            if (entry.isFile) {
+                const file = await new Promise((resolve) => entry.file(resolve));
+                files.push(file);
+            } else if (entry.isDirectory) {
+                const directoryReader = entry.createReader();
+                const entries = await readAllEntries(directoryReader);
+                for (const subEntry of entries) {
+                    await traverseEntry(subEntry);
+                }
             }
-        }
-        setEditingRunId(null);
-        setCollisionEdit(false);
-    };
+        };
 
-    const cancelEdit = () => {
-        setEditingRunId(null);
-        setCollisionEdit(false);
-    };
-
-    // Track which run IDs were present on the previous render so we can
-    // identify newly added runs.
-    const prevRunIdsRef = React.useRef(new Set());
-
-    // When new runs are added, check for label collisions and auto-trigger
-    // rename mode on any new run whose label matches an existing one.
-    React.useEffect(() => {
-        const prevIds = prevRunIdsRef.current;
-        const newRuns = runs.filter(r => !prevIds.has(r.runId));
-
-        if (newRuns.length > 0 && !editingRunId) {
-            for (const newRun of newRuns) {
-                const newLabel = getLabel(newRun);
-                const hasCollision = runs.some(
-                    r => r.runId !== newRun.runId && getLabel(r) === newLabel
-                );
-                if (hasCollision) {
-                    setEditingRunId(newRun.runId);
-                    setEditingValue(newLabel);
-                    setCollisionEdit(true);
-                    break;
+        const promises = [];
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (item.kind === 'file') {
+                const entry = item.webkitGetAsEntry();
+                if (entry) {
+                    promises.push(traverseEntry(entry));
                 }
             }
         }
 
-        prevRunIdsRef.current = new Set(runs.map(r => r.runId));
-    }, [runs, editingRunId]);
+        await Promise.all(promises);
+        
+        if (files.length > 0) {
+            onUpload(files);
+        }
+    };
 
     return (
         <div className="border-t border-slate-200 dark:border-slate-700 bg-slate-100 dark:bg-slate-800/50 p-4 animate-in slide-in-from-top-2 duration-200">
@@ -95,158 +97,65 @@ export const BenchmarkReportPanel = ({
 
                 {/* Drop zone — always visible, additive uploads */}
                 <div>
-                    <label className="text-[10px] font-bold text-slate-500 uppercase block mb-2">Upload Report Files</label>
-                    <div className="border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-lg p-5 flex flex-col items-center justify-center text-center hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors relative group cursor-pointer">
+                    <label className="text-[10px] font-bold text-slate-500 uppercase block mb-2">Upload Report Files / Folder</label>
+                    <div
+                        onDragOver={handleDragOver}
+                        onDragLeave={handleDragLeave}
+                        onDrop={handleDrop}
+                        className={`border-2 border-dashed rounded-lg p-5 flex flex-col items-center justify-center text-center transition-colors relative group cursor-pointer ${
+                            isDragging
+                                ? 'border-violet-500 bg-violet-50 dark:bg-violet-900/20'
+                                : 'border-slate-300 dark:border-slate-600 hover:bg-slate-50 dark:hover:bg-slate-800/50'
+                        }`}
+                    >
                         <input
                             type="file"
                             multiple
                             accept=".yaml,.yml"
                             className="absolute inset-0 w-full h-full opacity-0 cursor-pointer"
                             onChange={onUpload}
+                            disabled={loading}
                         />
-                        <FileJson size={20} className="text-slate-400 mb-1.5 group-hover:text-cyan-500 transition-colors" />
+                        {loading ? (
+                            <Loader size={20} className="animate-spin text-cyan-500 mb-1.5" />
+                        ) : (
+                            <FileJson size={20} className={`mb-1.5 transition-colors ${isDragging ? 'text-cyan-500' : 'text-slate-400 group-hover:text-cyan-500'}`} />
+                        )}
                         <span className="text-xs font-medium text-slate-700 dark:text-slate-300">
-                            Drag & drop files or <span className="text-cyan-500">browse</span>
+                            {loading ? (
+                                <span>Processing files...</span>
+                            ) : (
+                                <span>Drag & drop files/folders or <span className="text-cyan-500">browse files</span></span>
+                            )}
                         </span>
                         <span className="text-[10px] text-slate-400 mt-1">
                             benchmark_report_v0.2,_*.yaml — new files are added to existing
                         </span>
                     </div>
+                    {/* Directory Upload Option */}
+                    <div className="flex items-center justify-between text-[11px] text-slate-500 px-1 pt-2">
+                        <span>Or, upload a whole run directory:</span>
+                        {loading ? (
+                            <span className="text-slate-400 dark:text-slate-600 font-semibold flex items-center gap-1 cursor-not-allowed">
+                                Select Directory
+                            </span>
+                        ) : (
+                            <label className="text-cyan-500 dark:text-cyan-400 hover:text-cyan-600 cursor-pointer font-semibold flex items-center gap-1">
+                                <span>Select Directory</span>
+                                <input
+                                    type="file"
+                                    webkitdirectory="true"
+                                    directory="true"
+                                    multiple
+                                    className="hidden"
+                                    onChange={onUpload}
+                                    disabled={loading}
+                                />
+                            </label>
+                        )}
+                    </div>
                 </div>
 
-                {/* Uploaded runs list */}
-                {runs.length > 0 && (
-                    <div className="space-y-2">
-                        <label className="text-[10px] font-bold text-slate-500 uppercase block">
-                            Uploaded Runs ({runs.length})
-                        </label>
-                        {runs.map(run => {
-                            const runKey = getRunBenchmarkKey ? getRunBenchmarkKey(run.runId) : null;
-                            const isBaseline = !!runKey && runKey === baselineBenchmarkKey;
-                            const canSetBaseline = !!runKey && !!setBaselineBenchmarkKey;
-                            return (
-                                <div
-                                    key={run.runId}
-                                    className={`rounded-md border px-3 py-2 text-xs flex flex-col gap-1.5 ${
-                                        isBaseline
-                                            ? 'border-purple-400 dark:border-purple-500 ring-1 ring-purple-400/40 bg-purple-50/40 dark:bg-purple-950/30'
-                                            : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900'
-                                    }`}
-                                >
-                                    <div className="flex items-center justify-between gap-2">
-                                        {/* Inline label — click to rename */}
-                                        {editingRunId === run.runId ? (
-                                            <div className="flex-1 flex flex-col gap-0.5 min-w-0">
-                                                <input
-                                                    autoFocus
-                                                    value={editingValue}
-                                                    onChange={e => setEditingValue(e.target.value)}
-                                                    onBlur={commitEdit}
-                                                    onKeyDown={e => {
-                                                        if (e.key === 'Enter') commitEdit();
-                                                        if (e.key === 'Escape') cancelEdit();
-                                                    }}
-                                                    className="w-full text-xs font-medium bg-white dark:bg-slate-800 border border-cyan-400 rounded px-1.5 py-0.5 text-slate-800 dark:text-slate-200 focus:outline-none"
-                                                />
-                                                {collisionEdit && (
-                                                    <span className="text-[9px] text-amber-500">
-                                                        Duplicate name — give this run a unique name
-                                                    </span>
-                                                )}
-                                            </div>
-                                        ) : (
-                                            <button
-                                                onClick={() => startEdit(run)}
-                                                title="Click to rename"
-                                                className="flex-1 flex items-center gap-1.5 min-w-0 text-left group"
-                                            >
-                                                <span className="font-medium text-slate-800 dark:text-slate-200 truncate text-xs">
-                                                    {getLabel(run)}
-                                                </span>
-                                                <Pencil size={10} className="shrink-0 text-slate-300 dark:text-slate-600 group-hover:text-cyan-400 transition-colors" />
-                                            </button>
-                                        )}
-                                        <div className="flex items-center gap-1 shrink-0">
-                                            <button
-                                                onClick={() => {
-                                                    if (!canSetBaseline) return;
-                                                    setBaselineBenchmarkKey(isBaseline ? null : runKey);
-                                                }}
-                                                disabled={!canSetBaseline}
-                                                title={
-                                                    !canSetBaseline
-                                                        ? 'Run not yet selected — open Benchmark Browser to enable baseline'
-                                                        : isBaseline
-                                                            ? 'Click to clear baseline'
-                                                            : 'Set as baseline (★) for Δ% comparison'
-                                                }
-                                                className={`p-1 rounded transition-colors ${
-                                                    !canSetBaseline
-                                                        ? 'text-slate-200 dark:text-slate-700 cursor-not-allowed'
-                                                        : isBaseline
-                                                            ? 'text-purple-500 dark:text-purple-400 hover:text-purple-700 dark:hover:text-purple-300'
-                                                            : 'text-slate-300 dark:text-slate-600 hover:text-purple-500 dark:hover:text-purple-400'
-                                                }`}
-                                            >
-                                                <Star size={14} fill={isBaseline ? 'currentColor' : 'none'} />
-                                            </button>
-                                            <button
-                                                onClick={() => {
-                                                    onRemoveRun(run.runId);
-                                                    setCustomLabels(prev => {
-                                                        const next = { ...prev };
-                                                        delete next[run.runId];
-                                                        return next;
-                                                    });
-                                                }}
-                                                title="Remove run"
-                                                className="p-1 rounded text-slate-300 hover:text-red-500 dark:text-slate-600 dark:hover:text-red-400 transition-colors"
-                                            >
-                                                <X size={12} />
-                                            </button>
-                                        </div>
-                                    </div>
-
-                                    {/* Stage summary — read-only since each stage now renders as its own scatter point */}
-                                    <div className="text-[10px] text-slate-400">
-                                        {run.stages.length === 1
-                                            ? stageSummary(run.stages[0])
-                                            : `${run.stages.length} stages plotted on chart`}
-                                    </div>
-
-                                    {/* Scenario summary */}
-                                    {run.stages[0] && (
-                                        <div className="text-[9px] text-slate-400 flex flex-wrap gap-x-2">
-                                            <span>{run.stages[0].scenario.model || '—'}</span>
-                                            <span>{run.stages[0].scenario.hardware || '—'}</span>
-                                            {run.stages[0].scenario.acceleratorCount != null && (
-                                                <span>×{run.stages[0].scenario.acceleratorCount} GPUs</span>
-                                            )}
-                                            {run.stages[0].scenario.tp != null && (
-                                                <span>TP{run.stages[0].scenario.tp}</span>
-                                            )}
-                                            {run.stages[0].timestamp && (
-                                                <span className="ml-auto font-mono text-slate-300 dark:text-slate-600">
-                                                    {new Date(run.stages[0].timestamp).toLocaleString(undefined, {
-                                                        month: 'short', day: 'numeric',
-                                                        hour: '2-digit', minute: '2-digit',
-                                                    })}
-                                                </span>
-                                            )}
-                                        </div>
-                                    )}
-                                </div>
-                            );
-                        })}
-                    </div>
-                )}
-
-                {/* Hint pointing at the chart */}
-                {runs.length > 0 && (
-                    <p className="text-[10px] text-slate-400 text-center py-1">
-                        Open the Benchmark Browser and pick a baseline (★) on a row to compare runs.
-                    </p>
-                )}
             </div>
         </div>
     );

--- a/src/components/DataConnections/CustomGCSPanel.jsx
+++ b/src/components/DataConnections/CustomGCSPanel.jsx
@@ -14,6 +14,7 @@
 
 import React from "react";
 import { ChevronDown, ChevronUp, Cloud, Eye, EyeOff, Trash2, RefreshCw, Loader, Plus, Database } from "lucide-react";
+import { getSourceTypeStyle } from "../../utils/dashboardHelpers";
 
 export const CustomGCSPanel = ({
     connectionType, setConnectionType, availableSources, gcsProfiles, 
@@ -68,16 +69,24 @@ export const CustomGCSPanel = ({
                                  <div className="p-4">
                                      <div className="flex justify-between items-start mb-2">
                                          <div className="flex items-center gap-2">
-                                             <div className="p-1.5 rounded-md bg-blue-100 dark:bg-blue-900/20">
-                                                 <Cloud size={16} className="text-blue-600 dark:text-blue-400" />
-                                             </div>
-                                             <div>
-                                                 <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{profile.alias || profile.bucketName}</h4>
-                                                 <div className="flex items-center gap-2">
-                                                      <span className="text-[10px] uppercase font-bold text-slate-500 bg-slate-200 dark:bg-slate-700 px-1.5 py-0.5 rounded">Custom GCS</span>
-                                                      <span className="text-[10px] text-green-600 dark:text-green-400 font-medium flex items-center gap-1">● Active</span>
-                                                 </div>
-                                             </div>
+                                              <div className="p-1.5 rounded-md bg-blue-100 dark:bg-blue-900/20">
+                                                  <Cloud size={16} className="text-blue-600 dark:text-blue-400" />
+                                              </div>
+                                              <div>
+                                                  <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{profile.alias || profile.bucketName}</h4>
+                                                  <div className="flex items-center gap-1">
+                                                       <span className="text-[10px] uppercase font-bold text-slate-500 bg-slate-200 dark:bg-slate-700 px-1.5 py-0.5 rounded">Custom GCS</span>
+                                                       {(() => {
+                                                           const style = getSourceTypeStyle('Cloud');
+                                                           return (
+                                                               <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded border ${style.bg} ${style.text} ${style.border}`}>
+                                                                   Cloud
+                                                               </span>
+                                                           );
+                                                       })()}
+                                                       <span className="text-[10px] text-green-600 dark:text-green-400 font-medium flex items-center gap-1">● Active</span>
+                                                  </div>
+                                              </div>
                                          </div>
                                     <div className="flex items-center gap-2">
                                         <div className="w-px h-3 bg-slate-200 dark:bg-slate-700 mx-1"></div>
@@ -149,16 +158,24 @@ export const CustomGCSPanel = ({
                                  <div className="p-4">
                                      <div className="flex justify-between items-start mb-2">
                                          <div className="flex items-center gap-2">
-                                             <div className="p-1.5 rounded-md bg-orange-100 dark:bg-orange-900/20">
-                                                 <Cloud size={16} className="text-orange-600 dark:text-orange-400" />
-                                             </div>
-                                             <div>
-                                                 <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{profile.alias || profile.bucketName}</h4>
-                                                 <div className="flex items-center gap-2">
-                                                      <span className="text-[10px] uppercase font-bold text-slate-500 bg-slate-200 dark:bg-slate-700 px-1.5 py-0.5 rounded">Custom AWS</span>
-                                                      <span className="text-[10px] text-green-600 dark:text-green-400 font-medium flex items-center gap-1">● Active</span>
-                                                 </div>
-                                             </div>
+                                              <div className="p-1.5 rounded-md bg-orange-100 dark:bg-orange-900/20">
+                                                  <Cloud size={16} className="text-orange-600 dark:text-orange-400" />
+                                              </div>
+                                              <div>
+                                                  <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{profile.alias || profile.bucketName}</h4>
+                                                  <div className="flex items-center gap-1">
+                                                       <span className="text-[10px] uppercase font-bold text-slate-500 bg-slate-200 dark:bg-slate-700 px-1.5 py-0.5 rounded">Custom AWS</span>
+                                                       {(() => {
+                                                           const style = getSourceTypeStyle('Cloud');
+                                                           return (
+                                                               <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded border ${style.bg} ${style.text} ${style.border}`}>
+                                                                   Cloud
+                                                               </span>
+                                                           );
+                                                       })()}
+                                                       <span className="text-[10px] text-green-600 dark:text-green-400 font-medium flex items-center gap-1">● Active</span>
+                                                  </div>
+                                              </div>
                                          </div>
                                     <div className="flex items-center gap-2">
                                         <div className="w-px h-3 bg-slate-200 dark:bg-slate-700 mx-1"></div>

--- a/src/components/DataConnectionsPanel.jsx
+++ b/src/components/DataConnectionsPanel.jsx
@@ -18,14 +18,14 @@ import { GIQPanel } from "./DataConnections/GIQPanel";
 import { LPGPanel } from "./DataConnections/LPGPanel";
 import { CustomGCSPanel } from "./DataConnections/CustomGCSPanel";
 import { BenchmarkReportPanel } from "./DataConnections/BenchmarkReportPanel";
-import { getBenchmarkKey } from "../utils/dashboardHelpers";
+import { getBenchmarkKey, getIntegrationSourceType, getSourceTypeStyle } from "../utils/dashboardHelpers";
 
 const DataConnectionsPanel = (props) => {
   const [localSampleError, setLocalSampleError] = React.useState(false);
   const [localSampleColor, setLocalSampleColor] = React.useState(null);
-    const { showDataPanel, setShowDataPanel, INTEGRATIONS, apiConfigs, data, bucketConfigs, availableSources, showSampleData, enableLLMDResults, setEnableLLMDResults, expandedIntegration, setExpandedIntegration, setApiError, setGcsError, setLpgError, removeSampleData, removeLLMDData, restoreSampleData, driveLoading, driveStatus, driveProgress, driveError, refreshSource, setApiConfigs, setData, setSelectedSources, setAvailableSources, newProjectId, setNewProjectId, newAuthToken, setNewAuthToken, handleAddApiSource, gcsLoading, gcsError, apiError, lpgError, handleLpgFileUpload, handleLpgGcsScan, handleLpgGcsLoad, hostProject, lpgLoading, lpgPasteText, setLpgPasteText, setLpgLoading, parseLogFile, gcsSuccess, setGcsSuccess, connectionType, setConnectionType, gcsProfiles, selectedSources, removeBucket, newBucketAlias, setNewBucketAlias, newBucketName, setNewBucketName, handleAddBucket, chartMode, tputType, costMode, latType, selectedModels, activeFilters, xAxisMax, showPerChip, showSelectedOnly, showPareto, showLabels, showDataLabels, setIsInspectorOpen, qualityMetrics, setQualityInspectOpen, fetchQualityData, state, awsBucketConfigs, handleAddAWSBucket, removeAWSBucket, addToast, brv02Runs, brv02Error, setBrv02Error, handleBrv02Upload, removeBrv02Run, brv02CustomLabels, setBrv02CustomLabels } = props;
-  const activationOrderRef = React.useRef(null);
-  const prevActiveIdsRef = React.useRef(new Set());
+    const { showDataPanel, setShowDataPanel, INTEGRATIONS, apiConfigs, data, bucketConfigs, availableSources, showSampleData, enableLLMDResults, setEnableLLMDResults, expandedIntegration, setExpandedIntegration, setApiError, setGcsError, setLpgError, removeSampleData, removeLLMDData, restoreSampleData, driveLoading, driveStatus, driveProgress, driveError, refreshSource, setApiConfigs, setData, setSelectedSources, setAvailableSources, newProjectId, setNewProjectId, newAuthToken, setNewAuthToken, handleAddApiSource, gcsLoading, gcsError, apiError, lpgError, handleLpgFileUpload, handleLpgGcsScan, handleLpgGcsLoad, hostProject, lpgLoading, lpgPasteText, setLpgPasteText, setLpgLoading, parseLogFile, gcsSuccess, setGcsSuccess, connectionType, setConnectionType, gcsProfiles, selectedSources, removeBucket, newBucketAlias, setNewBucketAlias, newBucketName, setNewBucketName, handleAddBucket, chartMode, tputType, costMode, latType, selectedModels, activeFilters, xAxisMax, showPerChip, showSelectedOnly, showPareto, showLabels, showDataLabels, setIsInspectorOpen, qualityMetrics, setQualityInspectOpen, fetchQualityData, state, awsBucketConfigs, handleAddAWSBucket, removeAWSBucket, addToast, brv02Runs, brv02Error, setBrv02Error, handleBrv02Upload, removeBrv02Run, brv02CustomLabels, setBrv02CustomLabels, brv02Loading } = props;
+  const [activeOrder, setActiveOrder] = React.useState(() => INTEGRATIONS ? INTEGRATIONS.map(i => i.id) : []);
+  const [prevActiveIds, setPrevActiveIds] = React.useState(new Set());
   
     const handleClearCache = async () => {
         try {
@@ -42,10 +42,6 @@ const DataConnectionsPanel = (props) => {
             console.error(e);
         }
     };
-
-  if (!activationOrderRef.current && INTEGRATIONS) {
-      activationOrderRef.current = INTEGRATIONS.map(i => i.id);
-  }
 
   // Helper to count logical benchmarks (unique curves) instead of raw data points
   const countLogicalBenchmarks = React.useCallback((items) => {
@@ -77,80 +73,93 @@ const DataConnectionsPanel = (props) => {
       return uniqueKeys.size;
   }, []);
 
-  const currentActiveIds = new Set();
-  const mappedIntegrations = INTEGRATIONS.map(integ => {
-      let isConnected = false;
-      let matchCount = 0;
-      let connectedBucket = null;
+  const mappedIntegrations = React.useMemo(() => {
+      return INTEGRATIONS.map(integ => {
+          let isConnected = false;
+          let matchCount = 0;
+          let connectedBucket = null;
 
-      const uniqueSources = Array.from(new Set(data.map(d => d.source || 'undefined')));
-      console.log("[DataConnections] Unique Sources in 'data':", uniqueSources);
+          if (integ.id === 'google_giq') {
+              isConnected = apiConfigs.length > 0;
+               const projectId = apiConfigs[0]?.projectId || (typeof apiConfigs[0] === 'string' ? apiConfigs[0] : null);
+               const pInfo = projectId ? gcsProfiles.find(p => p.bucketName === projectId) : null;
 
-      if (integ.id === 'google_giq') {
-          isConnected = apiConfigs.length > 0;
-           const projectId = apiConfigs[0]?.projectId || (typeof apiConfigs[0] === 'string' ? apiConfigs[0] : null);
-           const pInfo = projectId ? gcsProfiles.find(p => p.bucketName === projectId) : null;
-
-           if (pInfo && pInfo.profileCount !== undefined) {
-               matchCount = pInfo.profileCount;
-           } else {
-               const filtered = data.filter(d => d.source && d.source.startsWith('giq:'));
-               const uniqueProfiles = new Set(filtered.map(d => d.profile_id).filter(Boolean));
-               matchCount = uniqueProfiles.size;
-           }
-       } else if (integ.id === 'inferencemax') {
-          const config = bucketConfigs.find(b => {
-              if (typeof b === 'object' && b.alias === 'InferenceMax') return true;
-              const bName = typeof b === 'string' ? b : b.bucket;
-              return bName === 'seanhorgan-prism-inferencemax';
-          });
-          connectedBucket = config ? (typeof config === 'string' ? config : config.bucket) : null;
-          isConnected = !!connectedBucket;
-          if (connectedBucket) {
-              const filtered = data.filter(d => d.source === `gcs:${connectedBucket}`);
+               if (pInfo && pInfo.profileCount !== undefined) {
+                   matchCount = pInfo.profileCount;
+               } else {
+                   const filtered = data.filter(d => d.source && d.source.startsWith('giq:'));
+                   const uniqueProfiles = new Set(filtered.map(d => d.profile_id).filter(Boolean));
+                   matchCount = uniqueProfiles.size;
+               }
+           } else if (integ.id === 'inferencemax') {
+              const config = bucketConfigs.find(b => {
+                  if (typeof b === 'object' && b.alias === 'InferenceMax') return true;
+                  const bName = typeof b === 'string' ? b : b.bucket;
+                  return bName === 'seanhorgan-prism-inferencemax';
+              });
+              connectedBucket = config ? (typeof config === 'string' ? config : config.bucket) : null;
+              isConnected = !!connectedBucket;
+              if (connectedBucket) {
+                  const filtered = data.filter(d => d.source === `gcs:${connectedBucket}`);
+                  matchCount = countLogicalBenchmarks(filtered);
+              }
+          } else if (integ.id === 'lpg_lifecycle') {
+              const filtered = data.filter(d => d.source && (d.source === 'infperf' || d.source === 'inference-perf' || d.source.startsWith('lpg:')));
               matchCount = countLogicalBenchmarks(filtered);
+              isConnected = matchCount > 0;
+          } else if (integ.id === 'local_sample') {
+              const filtered = data.filter(d => d.source === 'local');
+              matchCount = countLogicalBenchmarks(filtered);
+              isConnected = showSampleData && matchCount > 0;
+          } else if (integ.id === 'llmd_results') {
+              const filtered = data.filter(d => d.source === 'llm-d-results:google_drive' || d.source === 'llmd_drive');
+              matchCount = countLogicalBenchmarks(filtered);
+              isConnected = enableLLMDResults || matchCount > 0;
+              integ.isArchive = matchCount > 0 && !enableLLMDResults;
+          } else if (integ.id === 'quality_scores') {
+              isConnected = selectedSources.has('quality_scores');
+              matchCount = qualityMetrics && isConnected ? qualityMetrics.modelCount || Object.keys(qualityMetrics.data).length : 0;
+          } else if (integ.id === 'benchmark_report_v02') {
+              matchCount = brv02Runs.length;
+              isConnected = matchCount > 0;
           }
-      } else if (integ.id === 'lpg_lifecycle') {
-          const filtered = data.filter(d => d.source && (d.source === 'infperf' || d.source === 'inference-perf' || d.source.startsWith('lpg:')));
-          matchCount = countLogicalBenchmarks(filtered);
-          isConnected = matchCount > 0;
-      } else if (integ.id === 'local_sample') {
-          const filtered = data.filter(d => d.source === 'local');
-          matchCount = countLogicalBenchmarks(filtered);
-          isConnected = showSampleData && matchCount > 0;
-      } else if (integ.id === 'llmd_results') {
-          const filtered = data.filter(d => d.source === 'llm-d-results:google_drive' || d.source === 'llmd_drive');
-          matchCount = countLogicalBenchmarks(filtered);
-          isConnected = enableLLMDResults || matchCount > 0;
-          integ.isArchive = matchCount > 0 && !enableLLMDResults;
-      } else if (integ.id === 'quality_scores') {
-          isConnected = selectedSources.has('quality_scores');
-          matchCount = qualityMetrics && isConnected ? qualityMetrics.modelCount || Object.keys(qualityMetrics.data).length : 0;
-      } else if (integ.id === 'benchmark_report_v02') {
-          matchCount = brv02Runs.length;
-          isConnected = matchCount > 0;
+
+          return { ...integ, isConnected, matchCount, connectedBucket };
+      });
+  }, [INTEGRATIONS, data, apiConfigs, gcsProfiles, bucketConfigs, countLogicalBenchmarks, showSampleData, enableLLMDResults, selectedSources, qualityMetrics, brv02Runs]);
+
+  React.useEffect(() => {
+      const currentActive = new Set(mappedIntegrations.filter(i => i.isConnected).map(i => i.id));
+      let changed = false;
+      const nextOrder = [...activeOrder];
+      currentActive.forEach(id => {
+          if (!prevActiveIds.has(id)) {
+              const idx = nextOrder.indexOf(id);
+              if (idx !== -1) {
+                  nextOrder.splice(idx, 1);
+                  nextOrder.push(id);
+                  changed = true;
+              }
+          }
+      });
+      if (changed) {
+          setActiveOrder(nextOrder);
       }
-
-      if (isConnected) currentActiveIds.add(integ.id);
-      return { ...integ, isConnected, matchCount, connectedBucket };
-  });
-
-  currentActiveIds.forEach(id => {
-      if (!prevActiveIdsRef.current.has(id)) {
-          activationOrderRef.current = activationOrderRef.current.filter(x => x !== id);
-          activationOrderRef.current.push(id);
+      
+      const hasDiff = currentActive.size !== prevActiveIds.size || [...currentActive].some(x => !prevActiveIds.has(x));
+      if (hasDiff) {
+          setPrevActiveIds(currentActive);
       }
-  });
-  prevActiveIdsRef.current = currentActiveIds;
+  }, [mappedIntegrations, prevActiveIds, activeOrder]);
 
-  const sortedIntegrations = mappedIntegrations.sort((a, b) => {
+  const sortedIntegrations = [...mappedIntegrations].sort((a, b) => {
       // 1. Active (Connected) first
       if (a.isConnected && !b.isConnected) return -1;
       if (!a.isConnected && b.isConnected) return 1;
       
       // 2. Both active: sort by activation order
       if (a.isConnected && b.isConnected) {
-          return activationOrderRef.current.indexOf(a.id) - activationOrderRef.current.indexOf(b.id);
+          return activeOrder.indexOf(a.id) - activeOrder.indexOf(b.id);
       }
       
       // 3. Both inactive: sort by default order
@@ -192,8 +201,17 @@ const DataConnectionsPanel = (props) => {
                                                     </div>
                                                     <div>
                                                         <h4 className="text-sm font-semibold text-slate-800 dark:text-slate-200">{integ.name}</h4>
-                                                        <div className="flex items-center gap-2">
+                                                        <div className="flex items-center gap-1">
                                                              <span className="text-[10px] font-bold text-slate-500 bg-slate-200 dark:bg-slate-700 px-1.5 py-0.5 rounded">{integ.type}</span>
+                                                             {(() => {
+                                                                 const type = getIntegrationSourceType(integ.id);
+                                                                 const style = getSourceTypeStyle(type);
+                                                                 return (
+                                                                     <span className={`text-[10px] font-bold px-1.5 py-0.5 rounded border ${style.bg} ${style.text} ${style.border}`}>
+                                                                         {type}
+                                                                     </span>
+                                                                 );
+                                                             })()}
                                                              {isConnected && (
                                                                  matchCount > 0 
                                                                  ? <span className="text-[10px] text-green-600 dark:text-green-400 font-medium flex items-center gap-1">● Active</span>
@@ -272,12 +290,18 @@ const DataConnectionsPanel = (props) => {
                                                                     }
                                                                 }
                                                             }}
-                                                            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 ${integ.id === 'benchmark_report_v02' ? (isExpanded ? 'bg-violet-500' : 'bg-slate-200 dark:bg-slate-700') : isConnected ? 'bg-blue-600' : (localSampleColor === integ.id ? 'bg-red-500' : 'bg-slate-200 dark:bg-slate-700')}`}
+                                                            className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer rounded-full border-2 border-transparent transition-colors duration-200 ease-in-out focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 ${
+                                                                integ.id === 'benchmark_report_v02'
+                                                                    ? ((isExpanded || isConnected) ? 'bg-violet-500' : 'bg-slate-200 dark:bg-slate-700')
+                                                                    : integ.id === 'lpg_lifecycle'
+                                                                        ? ((isExpanded || isConnected) ? 'bg-green-600' : 'bg-slate-200 dark:bg-slate-700')
+                                                                        : isConnected ? 'bg-blue-600' : (localSampleColor === integ.id ? 'bg-red-500' : 'bg-slate-200 dark:bg-slate-700')
+                                                            }`}
                                                         >
                                                             <span className="sr-only">Toggle Connection</span>
                                                             <span
                                                                 aria-hidden="true"
-                                                                className={`${(integ.id === 'benchmark_report_v02' ? isExpanded : isConnected) ? 'translate-x-4' : 'translate-x-0'} pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-lg ring-0 transition duration-200 ease-in-out`}
+                                                                className={`${((integ.id === 'benchmark_report_v02' || integ.id === 'lpg_lifecycle') ? (isExpanded || isConnected) : isConnected) ? 'translate-x-4' : 'translate-x-0'} pointer-events-none inline-block h-4 w-4 transform rounded-full bg-white shadow-lg ring-0 transition duration-200 ease-in-out`}
                                                             />
                                                         </button>
                                                     ) : (
@@ -364,30 +388,30 @@ const DataConnectionsPanel = (props) => {
                                                             );
                                                         }
 
-                                                        return (
-                                                            <div className="flex items-center justify-between text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/10 p-2 rounded">
-                                                                <div className="flex items-center gap-2">
-                                                                    <CheckCircle size={12} />
-                                                                    <span>Active ({matchCount} {integ.id === 'quality_scores' ? (matchCount === 1 ? 'model' : 'models') :
-                                                                        integ.id === 'google_giq' ? (matchCount === 1 ? 'profile' : 'profiles') :
-                                                                            (matchCount === 1 ? 'benchmark' : 'benchmarks')})</span>
-                                                                </div>
-                                                                {integ.id === 'lpg_lifecycle' && (
-                                                                    <button
-                                                                        onClick={(e) => {
-                                                                            e.stopPropagation();
-                                                                            setData(prev => prev.filter(d => !d.source?.startsWith('lpg:') && d.source !== 'infperf' && d.source !== 'inference-perf'));
-                                                          setSelectedSources(prev => new Set([...prev].filter(s => !s.startsWith('lpg:') && s !== 'infperf' && s !== 'inference-perf')));
-                                                          setAvailableSources(prev => new Set([...prev].filter(s => !s.startsWith('lpg:') && s !== 'infperf' && s !== 'inference-perf')));
-                                                                            if (setGcsSuccess) setGcsSuccess(null);
-                                                                        }}
-                                                                        className="text-red-600 dark:text-red-400 hover:underline px-1 py-0.5"
-                                                                    >
-                                                                        Clear
-                                                                    </button>
-                                                                )}
-                                                            </div>
-                                                        );
+                                                         return (
+                                                             <div className="flex items-center justify-between text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-900/10 p-2 rounded">
+                                                                 <div className="flex items-center gap-2">
+                                                                     <CheckCircle size={12} />
+                                                                     <span>Active ({matchCount} {integ.id === 'quality_scores' ? (matchCount === 1 ? 'model' : 'models') :
+                                                                         integ.id === 'google_giq' ? (matchCount === 1 ? 'profile' : 'profiles') :
+                                                                             (matchCount === 1 ? 'benchmark' : 'benchmarks')})</span>
+                                                                 </div>
+                                                                 {integ.id === 'lpg_lifecycle' && (
+                                                                     <button
+                                                                         onClick={(e) => {
+                                                                             e.stopPropagation();
+                                                                             setData(prev => prev.filter(d => !d.source?.startsWith('lpg:') && d.source !== 'infperf' && d.source !== 'inference-perf'));
+                                                                             setSelectedSources(prev => new Set([...prev].filter(s => !s.startsWith('lpg:') && s !== 'infperf' && s !== 'inference-perf')));
+                                                                             setAvailableSources(prev => new Set([...prev].filter(s => !s.startsWith('lpg:') && s !== 'infperf' && s !== 'inference-perf')));
+                                                                             if (setGcsSuccess) setGcsSuccess(null);
+                                                                         }}
+                                                                         className="text-red-600 dark:text-red-400 hover:underline px-1 py-0.5"
+                                                                     >
+                                                                         Clear
+                                                                     </button>
+                                                                 )}
+                                                             </div>
+                                                         );
                                                     })()}
                                                 </div>
                                             )}
@@ -421,22 +445,13 @@ const DataConnectionsPanel = (props) => {
                                             />
                                         )}
 
-                                        {isExpanded && integ.id === 'benchmark_report_v02' && (
+                                         {((isExpanded || isConnected) && integ.id === 'benchmark_report_v02') && (
                                             <BenchmarkReportPanel
-                                                runs={brv02Runs}
                                                 error={brv02Error}
                                                 setError={setBrv02Error}
                                                 onUpload={handleBrv02Upload}
-                                                onRemoveRun={removeBrv02Run}
-                                                customLabels={brv02CustomLabels}
-                                                setCustomLabels={setBrv02CustomLabels}
-                                                getRunBenchmarkKey={(runId) => {
-                                                    const entry = (data || []).find(d => d.source === `brv02:${runId}`);
-                                                    return entry ? getBenchmarkKey(entry) : null;
-                                                }}
-                                                baselineBenchmarkKey={state?.baselineBenchmarkKey}
-                                                setBaselineBenchmarkKey={state?.setBaselineBenchmarkKey}
-                                            />
+                                                loading={brv02Loading}
+                                             />
                                         )}
                                     </div>
                                 </div>

--- a/src/components/LeftNavigation.jsx
+++ b/src/components/LeftNavigation.jsx
@@ -37,6 +37,12 @@ const MENU_GROUPS = [
             { id: 'workload-catalog', label: 'Workload Catalog', icon: Activity, view: 'workload-catalog', disabled: false },
             { id: 'value-analysis', label: 'Value Analysis', icon: DollarSign, view: 'value-analysis', disabled: true }
         ]
+    },
+    {
+        title: "Management",
+        items: [
+            { id: 'manage-benchmarks', label: 'Manage Benchmarks', icon: Database, view: 'manage-benchmarks' }
+        ]
     }
 ];
 
@@ -60,7 +66,7 @@ export default function LeftNavigation({ currentView, onNavigate, isMobileOpen }
     };
 
     return (
-        <aside className={`fixed top-20 left-4 h-[calc(100vh-6rem)] ${isMobileOpen ? 'flex' : 'hidden md:flex'} flex-col border border-slate-800/80 bg-slate-900/80 backdrop-blur-xl rounded-2xl transition-all duration-300 z-50 shadow-2xl ${isExpanded ? 'w-80' : 'w-20'}`}>
+        <aside className={`fixed top-20 left-4 h-[calc(100vh-6rem)] flex flex-col border border-slate-800/80 bg-slate-900/80 backdrop-blur-xl rounded-2xl transition-all duration-300 z-50 shadow-2xl ${isExpanded ? 'w-80' : 'w-20'}`}>
 
             {/* Navigation Items */}
             <div className="flex-1 overflow-y-auto overflow-x-visible py-6 flex flex-col gap-8 px-3 no-scrollbar">

--- a/src/components/ManageBenchmarks.jsx
+++ b/src/components/ManageBenchmarks.jsx
@@ -1,0 +1,625 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { useMemo } from 'react';
+import { Database, Eye, ArrowLeft, MessageCircle, X, Loader } from 'lucide-react';
+import { FilterPanel } from './ManageBenchmarks/FilterPanel';
+import { UnifiedDataTable } from './ManageBenchmarks/UnifiedDataTable';
+import DataConnectionsPanel from './DataConnectionsPanel';
+import { INTEGRATIONS, getSourceTag, getBenchmarkKey, getBucket, getRatioType, getAcceleratorCount, getEffectiveTp, sortBuckets } from '../utils/dashboardHelpers';
+
+export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboardState, dashboardData }) {
+    const {
+        showFilterPanel,
+        showSelectedOnly,
+        setShowSelectedOnly,
+        selectedBenchmarks,
+        setSelectedBenchmarks,
+        activeFilters,
+        setActiveFilters,
+        showDataPanel,
+        setShowDataPanel,
+        baselineBenchmarkKey,
+        setBaselineBenchmarkKey
+    } = dashboardState;
+
+    const {
+        data,
+        selectedSources,
+        toasts,
+        removeToast,
+        addToast,
+        brv02Runs,
+        brv02CustomLabels,
+        setBrv02CustomLabels,
+        removeBrv02Run,
+        expandedModels,
+        setExpandedModels
+    } = dashboardData;
+
+// Filtered by source
+    const filteredBySource = useMemo(() => {
+        return data.filter(d => {
+            if (!selectedSources.has(d.source || 'local')) return false;
+
+            // Apply Connection/Source filter
+            if (activeFilters.connectionNames && activeFilters.connectionNames.size > 0) {
+                const connName = getSourceTag(d);
+                if (!activeFilters.connectionNames.has(connName)) return false;
+            }
+
+            // Apply Origin/Folder filter
+            if (activeFilters.origins && activeFilters.origins.size > 0) {
+                const origin = d.source_info?.origin || d.source;
+                if (!activeFilters.origins.has(origin)) return false;
+            }
+
+            // Apply Model filter
+            if (activeFilters.models && activeFilters.models.size > 0) {
+                const modelName = d.model_name || d.model;
+                if (!activeFilters.models.has(modelName)) return false;
+            }
+
+            // Apply Hardware filter
+            if (activeFilters.hardware && activeFilters.hardware.size > 0) {
+                if (!activeFilters.hardware.has(d.hardware)) return false;
+            }
+
+            // Apply Machine Type filter
+            if (activeFilters.machines && activeFilters.machines.size > 0) {
+                if (!activeFilters.machines.has(d.machine_type)) return false;
+            }
+
+            // Apply Precisions filter
+            if (activeFilters.precisions && activeFilters.precisions.size > 0) {
+                if (!activeFilters.precisions.has(d.precision)) return false;
+            }
+            
+            // Apply TP filter
+            if (activeFilters.tp && activeFilters.tp.size > 0) {
+                const tpVal = getEffectiveTp(d);
+                if (!tpVal || !activeFilters.tp.has(tpVal)) return false;
+            }
+
+            // Apply ISL filter
+            if (activeFilters.isl && activeFilters.isl.size > 0) {
+                if (!activeFilters.isl.has(getBucket(d.isl))) return false;
+            }
+
+            // Apply OSL filter
+            if (activeFilters.osl && activeFilters.osl.size > 0) {
+                if (!activeFilters.osl.has(getBucket(d.osl))) return false;
+            }
+
+            // Apply Ratio filter
+            if (activeFilters.ratio && activeFilters.ratio.size > 0) {
+                const r = getRatioType(d.isl, d.osl);
+                if (!activeFilters.ratio.has(r)) return false;
+            }
+
+            // Apply Accelerator Count filter
+            if (activeFilters.acc_count && activeFilters.acc_count.size > 0) {
+                const count = getAcceleratorCount(d);
+                if (!activeFilters.acc_count.has(count) && !activeFilters.acc_count.has(String(count)) && !activeFilters.acc_count.has(Number(count))) {
+                    return false;
+                }
+            }
+
+            // Apply Model Server filter
+            if (activeFilters.modelServer && activeFilters.modelServer.size > 0) {
+                const ms = d.model_server || d.backend || d.metadata?.model_server || d.metadata?.backend;
+                if (!ms || !activeFilters.modelServer.has(ms)) return false;
+            }
+
+            // Apply Use Case filter
+            if (activeFilters.useCase && activeFilters.useCase.size > 0) {
+                if (!activeFilters.useCase.has(d.use_case)) return false;
+            }
+
+            // Apply Serving Stack filter
+            if (activeFilters.servingStack && activeFilters.servingStack.size > 0) {
+                const ss = d.serving_stack || d.metadata?.serving_stack;
+                if (!ss || !activeFilters.servingStack.has(ss)) return false;
+            }
+
+            // Apply Optimizations filter
+            if (activeFilters.optimizations && activeFilters.optimizations.size > 0) {
+                let hasMet = false;
+                const isPD = d.architecture === 'disaggregated' || (d.pd_ratio && d.pd_ratio !== 'Aggregated' && d.pd_ratio !== 'N/A' && d.pd_ratio !== 'N/A:N/A');
+                if (activeFilters.optimizations.has("P/D Disaggregation") && isPD) hasMet = true;
+                if (activeFilters.optimizations.has("Approximate prefix aware routing")) {
+                    const ss = d.serving_stack || d.metadata?.serving_stack || '';
+                    if (ss.includes('llm-d') && d.source?.startsWith('giq:')) hasMet = true;
+                }
+                if (!hasMet) return false;
+            }
+
+            // Apply PD Ratio filter
+            if (activeFilters.pdRatio && activeFilters.pdRatio.size > 0) {
+                const ratio = d.pd_ratio || d.metadata?.pd_ratio || 'Aggregated';
+                if (!activeFilters.pdRatio.has(ratio)) return false;
+            }
+
+            // Apply Components filter
+            if (activeFilters.components && activeFilters.components.size > 0) {
+                const comps = d.components || d.metadata?.components;
+                if (!comps || !Array.isArray(comps) || comps.length === 0) return false;
+                const hasMatchingComp = comps.some(c => activeFilters.components.has(c));
+                if (!hasMatchingComp) return false;
+            }
+
+            return true;
+        });
+    }, [data, selectedSources, activeFilters]);
+
+    // Local copy of modelStats computation
+    const modelStats = useMemo(() => {
+        const stats = [];
+        const groups = new Map();
+
+        // Group filtered data by key
+        const baseData = filteredBySource;
+
+        baseData.forEach(d => {
+            const key = d.benchmarkKey || getBenchmarkKey(d);
+            if (!groups.has(key)) groups.set(key, []);
+            groups.get(key).push(d);
+        });
+
+        groups.forEach((groupingData, benchmarkKey) => {
+            const model = groupingData[0].model_name || groupingData[0].model;
+            const maxTput = Math.max(0, ...groupingData.map(x => Number(x.throughput || 0)).filter(t => !isNaN(t)));
+            const minLatEntries = groupingData.map(x => Number(x.latency?.mean || 0)).filter(l => !isNaN(l) && l > 0);
+            const minLat = minLatEntries.length > 0 ? Math.min(...minLatEntries) : 0;
+            const errCount = groupingData.reduce((acc, curr) => acc + Number(curr.error_count || 0), 0);
+            const hardware = groupingData.find(x => x.hardware && x.hardware !== 'Unknown' && x.hardware !== 'Unknown Hardware')?.hardware || 'Unknown Hardware';
+            const accelerator_count = groupingData.find(x => x.accelerator_count > 0)?.accelerator_count || 1;
+            const tensor_parallelism = groupingData.find(x => x.tensor_parallelism > 0)?.tensor_parallelism || 1;
+            const node_count = accelerator_count > 1 && tensor_parallelism > 1 ? Math.max(1, Math.round(accelerator_count / tensor_parallelism)) : accelerator_count;
+            const configuration = groupingData[0].metadata?.configuration || groupingData[0].configuration || 'Unknown';
+            const timestamps = groupingData.map(x => x.timestamp ? new Date(x.timestamp).getTime() : 0).filter(t => t > 0);
+            const latestTimestamp = timestamps.length > 0 ? Math.max(...timestamps) : 0;
+
+            stats.push({
+                benchmarkKey,
+                model,
+                configuration,
+                maxTput,
+                minLat,
+                errCount,
+                hardware,
+                accelerator_count,
+                tensor_parallelism,
+                node_count,
+                tp: tensor_parallelism,
+                timestamp: latestTimestamp,
+                data: groupingData
+            });
+        });
+
+        return stats;
+    }, [filteredBySource]);
+
+    // Compute facet options and counts for filtering
+    const filterOptions = useMemo(() => {
+        const options = {
+            models: new Set(),
+            hardware: new Set(),
+            machines: new Set(),
+            precisions: new Set(),
+            tp: new Set(),
+            isl: new Set(),
+            osl: new Set(),
+            ratio: new Set(),
+            acc_count: new Set(),
+            modelServer: new Set(),
+            useCase: new Set(),
+            servingStack: new Set(),
+            pdRatio: new Set(),
+            origins: new Set(),
+            connectionNames: new Set()
+        };
+
+        const baseData = data.filter(d => selectedSources.has(d.source || 'local'));
+
+        baseData.forEach(d => {
+            if (d.model_name) options.models.add(d.model_name);
+            if (d.hardware && d.hardware !== 'Unknown') {
+                options.hardware.add(d.hardware);
+                options.acc_count.add(getAcceleratorCount(d));
+            }
+            const ms = d.model_server || d.backend || d.metadata?.model_server || d.metadata?.backend;
+            if (ms && ms !== 'Unknown') options.modelServer.add(ms);
+
+            const ss = d.serving_stack || d.metadata?.serving_stack;
+            if (ss && ss !== 'Unknown') options.servingStack.add(ss);
+
+            if (d.machine_type && d.machine_type !== 'Unknown') options.machines.add(d.machine_type);
+            if (d.precision && d.precision !== 'Unknown') options.precisions.add(d.precision);
+
+            const tpVal = getEffectiveTp(d);
+            if (tpVal) options.tp.add(tpVal);
+
+            if (d.isl > 0) options.isl.add(getBucket(d.isl));
+            if (d.osl > 0) options.osl.add(getBucket(d.osl));
+
+            if (d.use_case && d.use_case !== 'Unknown') options.useCase.add(d.use_case);
+
+            if (d.isl > 0 && d.osl > 0) {
+                options.ratio.add(getRatioType(d.isl, d.osl));
+            }
+
+            const pd = d.pd_ratio || d.metadata?.pd_ratio || 'Aggregated';
+            options.pdRatio.add(pd);
+
+            const origin = d.source_info?.origin || d.source;
+            if (origin && origin !== 'Unknown') options.origins.add(origin);
+
+            const connName = getSourceTag(d);
+            if (connName && connName !== 'UNK') options.connectionNames.add(connName);
+        });
+
+        return {
+            models: [...options.models].sort(),
+            hardware: [...options.hardware].sort(),
+            machines: [...options.machines].sort(),
+            precisions: [...options.precisions].sort(),
+            tp: [...options.tp].sort((a, b) => {
+                const numA = parseInt(a.replace('TP', '')) || 0;
+                const numB = parseInt(b.replace('TP', '')) || 0;
+                return numA - numB;
+            }),
+            isl: sortBuckets([...options.isl]),
+            osl: sortBuckets([...options.osl]),
+            ratio: [...options.ratio].sort(),
+            acc_count: [...options.acc_count].sort((a, b) => Number(a) - Number(b)),
+            modelServer: [...options.modelServer].sort(),
+            useCase: [...options.useCase].sort(),
+            servingStack: [...options.servingStack].sort(),
+            pdRatio: [...options.pdRatio].sort((a, b) => {
+                if (a === 'Aggregated') return -1;
+                if (b === 'Aggregated') return 1;
+                const parse = s => String(s).split(':').map(Number);
+                const [pa, da] = parse(a);
+                const [pb, db] = parse(b);
+                if (isNaN(pa) || isNaN(pb)) return String(a).localeCompare(String(b));
+                if (pa !== pb) return pa - pb;
+                return da - db;
+            }),
+            origins: [...options.origins].sort(),
+            connectionNames: [...options.connectionNames].sort()
+        };
+    }, [data, selectedSources]);
+
+    const facetCounts = useMemo(() => {
+        // We use Sets of unique row benchmarkKeys so that the numbers shown in the
+        // dropdowns represent unique configurations (visible rows) rather than raw entries.
+        const tempCounts = {
+            models: {},
+            hardware: {},
+            machines: {},
+            precisions: {},
+            tp: {},
+            isl: {},
+            osl: {},
+            ratio: {},
+            acc_count: {},
+            modelServer: {},
+            useCase: {},
+            servingStack: {},
+            optimizations: {},
+            origins: {},
+            connectionNames: {},
+            components: {},
+            pdRatio: {}
+        };
+
+        const baseData = data.filter(d => selectedSources.has(d.source || 'local'));
+
+        // Helper to check if item satisfies all active filters EXCEPT the ignored category
+        const check = (d, ignoreKey) => {
+            if (ignoreKey !== 'connectionNames' && activeFilters.connectionNames && activeFilters.connectionNames.size > 0) {
+                const connName = getSourceTag(d);
+                if (!activeFilters.connectionNames.has(connName)) return false;
+            }
+
+            if (ignoreKey !== 'origins' && activeFilters.origins && activeFilters.origins.size > 0) {
+                const origin = d.source_info?.origin || d.source;
+                if (!activeFilters.origins.has(origin)) return false;
+            }
+
+            if (ignoreKey !== 'models' && activeFilters.models && activeFilters.models.size > 0) {
+                const modelName = d.model_name || d.model;
+                if (!activeFilters.models.has(modelName)) return false;
+            }
+
+            if (ignoreKey !== 'hardware' && activeFilters.hardware && activeFilters.hardware.size > 0) {
+                if (!activeFilters.hardware.has(d.hardware)) return false;
+            }
+
+            if (ignoreKey !== 'machines' && activeFilters.machines && activeFilters.machines.size > 0) {
+                if (!activeFilters.machines.has(d.machine_type)) return false;
+            }
+
+            if (ignoreKey !== 'precisions' && activeFilters.precisions && activeFilters.precisions.size > 0) {
+                if (!activeFilters.precisions.has(d.precision)) return false;
+            }
+            
+            if (ignoreKey !== 'tp' && activeFilters.tp && activeFilters.tp.size > 0) {
+                const tpVal = getEffectiveTp(d);
+                if (!tpVal || !activeFilters.tp.has(tpVal)) return false;
+            }
+
+            if (ignoreKey !== 'isl' && activeFilters.isl && activeFilters.isl.size > 0) {
+                if (!activeFilters.isl.has(getBucket(d.isl))) return false;
+            }
+
+            if (ignoreKey !== 'osl' && activeFilters.osl && activeFilters.osl.size > 0) {
+                if (!activeFilters.osl.has(getBucket(d.osl))) return false;
+            }
+
+            if (ignoreKey !== 'ratio' && activeFilters.ratio && activeFilters.ratio.size > 0) {
+                const r = getRatioType(d.isl, d.osl);
+                if (!activeFilters.ratio.has(r)) return false;
+            }
+
+            if (ignoreKey !== 'acc_count' && activeFilters.acc_count && activeFilters.acc_count.size > 0) {
+                const count = getAcceleratorCount(d);
+                if (!activeFilters.acc_count.has(count) && !activeFilters.acc_count.has(String(count)) && !activeFilters.acc_count.has(Number(count))) {
+                    return false;
+                }
+            }
+
+            if (ignoreKey !== 'modelServer' && activeFilters.modelServer && activeFilters.modelServer.size > 0) {
+                const ms = d.model_server || d.backend || d.metadata?.model_server || d.metadata?.backend;
+                if (!ms || !activeFilters.modelServer.has(ms)) return false;
+            }
+
+            if (ignoreKey !== 'useCase' && activeFilters.useCase && activeFilters.useCase.size > 0) {
+                if (!activeFilters.useCase.has(d.use_case)) return false;
+            }
+
+            if (ignoreKey !== 'servingStack' && activeFilters.servingStack && activeFilters.servingStack.size > 0) {
+                const ss = d.serving_stack || d.metadata?.serving_stack;
+                if (!ss || !activeFilters.servingStack.has(ss)) return false;
+            }
+
+            if (ignoreKey !== 'optimizations' && activeFilters.optimizations && activeFilters.optimizations.size > 0) {
+                let hasMet = false;
+                const isPD = d.architecture === 'disaggregated' || (d.pd_ratio && d.pd_ratio !== 'Aggregated' && d.pd_ratio !== 'N/A' && d.pd_ratio !== 'N/A:N/A');
+                if (activeFilters.optimizations.has("P/D Disaggregation") && isPD) hasMet = true;
+                if (activeFilters.optimizations.has("Approximate prefix aware routing")) {
+                    const ss = d.serving_stack || d.metadata?.serving_stack || '';
+                    if (ss.includes('llm-d') && d.source?.startsWith('giq:')) hasMet = true;
+                }
+                if (!hasMet) return false;
+            }
+
+            if (ignoreKey !== 'pdRatio' && activeFilters.pdRatio && activeFilters.pdRatio.size > 0) {
+                const ratio = d.pd_ratio || d.metadata?.pd_ratio || 'Aggregated';
+                if (!activeFilters.pdRatio.has(ratio)) return false;
+            }
+
+            if (ignoreKey !== 'components' && activeFilters.components && activeFilters.components.size > 0) {
+                const comps = d.components || d.metadata?.components;
+                if (!comps || !Array.isArray(comps) || comps.length === 0) return false;
+                const hasMatchingComp = comps.some(c => activeFilters.components.has(c));
+                if (!hasMatchingComp) return false;
+            }
+
+            return true;
+        };
+
+        const add = (category, key, modelId) => {
+            if (!tempCounts[category][key]) {
+                tempCounts[category][key] = new Set();
+            }
+            tempCounts[category][key].add(modelId);
+        };
+
+        baseData.forEach(d => {
+            const modelId = getBenchmarkKey(d);
+
+            if (d.model_name && check(d, 'models')) add('models', d.model_name, modelId);
+            if (d.hardware && check(d, 'hardware')) add('hardware', d.hardware, modelId);
+            if (d.machine_type && check(d, 'machines')) add('machines', d.machine_type, modelId);
+            if (d.precision && check(d, 'precisions')) add('precisions', d.precision, modelId);
+
+            const tp = getEffectiveTp(d);
+            if (tp && check(d, 'tp')) add('tp', tp, modelId);
+
+            const connName = getSourceTag(d);
+            if (connName && connName !== 'UNK' && check(d, 'connectionNames')) add('connectionNames', connName, modelId);
+
+            const origin = d.source_info?.origin || d.source;
+            if (origin && origin !== 'Unknown' && check(d, 'origins')) add('origins', origin, modelId);
+
+            const ms = d.model_server || d.backend || d.metadata?.model_server || d.metadata?.backend;
+            if (ms && ms !== 'Unknown' && check(d, 'modelServer')) add('modelServer', ms, modelId);
+
+            const ss = d.serving_stack || d.metadata?.serving_stack;
+            if (ss && ss !== 'Unknown' && check(d, 'servingStack')) add('servingStack', ss, modelId);
+
+            if (d.use_case && d.use_case !== 'Unknown' && check(d, 'useCase')) add('useCase', d.use_case, modelId);
+
+            if (d.isl > 0 && check(d, 'isl')) add('isl', getBucket(d.isl), modelId);
+            if (d.osl > 0 && check(d, 'osl')) add('osl', getBucket(d.osl), modelId);
+            if (d.isl > 0 && d.osl > 0 && check(d, 'ratio')) add('ratio', getRatioType(d.isl, d.osl), modelId);
+
+            const pd = d.pd_ratio || d.metadata?.pd_ratio || 'Aggregated';
+            if (check(d, 'pdRatio')) add('pdRatio', pd, modelId);
+
+            const comps = d.components || d.metadata?.components || [];
+            if (comps.length > 0 && check(d, 'components')) {
+                comps.forEach(c => add('components', c, modelId));
+            }
+
+            const accCount = getAcceleratorCount(d);
+            if (accCount && check(d, 'acc_count')) add('acc_count', accCount, modelId);
+        });
+
+        // Convert Sets of unique modelIds to numeric counts
+        const finalCounts = {
+            models: {}, hardware: {}, machines: {}, precisions: {}, tp: {}, isl: {}, osl: {}, ratio: {}, acc_count: {}, modelServer: {}, useCase: {}, servingStack: {}, optimizations: {}, origins: {}, connectionNames: {},
+            components: {}, pdRatio: {}
+        };
+
+        const categories = ['models', 'hardware', 'machines', 'precisions', 'tp', 'isl', 'osl', 'ratio', 'acc_count', 'modelServer', 'useCase', 'servingStack', 'optimizations', 'pdRatio', 'origins', 'connectionNames', 'components'];
+        categories.forEach(cat => {
+            Object.keys(tempCounts[cat]).forEach(key => {
+                finalCounts[cat][key] = tempCounts[cat][key].size;
+            });
+        });
+
+        return finalCounts;
+    }, [data, selectedSources, activeFilters]);
+
+    const toggleFilter = (category, value) => {
+        setActiveFilters(prev => {
+            const newSet = new Set(prev[category]);
+            if (value === '' || value === undefined) {
+                newSet.clear();
+            } else {
+                if (newSet.has(value)) newSet.delete(value);
+                else newSet.add(value);
+            }
+            return { ...prev, [category]: newSet };
+        });
+    };
+
+    const toggleBenchmark = (key) => {
+        const newSelected = new Set(selectedBenchmarks);
+        if (newSelected.has(key)) {
+            newSelected.delete(key);
+        } else {
+            newSelected.add(key);
+        }
+        setSelectedBenchmarks(newSelected);
+    };
+
+    const toggleModelExpansion = (key) => {
+        setExpandedModels(prev => {
+            const newExpanded = new Set(prev);
+            if (newExpanded.has(key)) {
+                newExpanded.delete(key);
+            } else {
+                newExpanded.add(key);
+            }
+            return newExpanded;
+        });
+    };
+
+
+    return (
+        <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col font-sans antialiased relative overflow-x-hidden pt-16">
+            {/* Toast Stack */}
+            <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2">
+                {toasts.map(t => (
+                    <div key={t.id} className={`px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4 ${t.type === 'error' ? 'bg-red-500/90 backdrop-blur' :
+                        t.type === 'success' ? 'bg-green-500/90 backdrop-blur' : 'bg-blue-600/90 backdrop-blur'
+                        }`}>
+                        <span>{t.message}</span>
+                        <button onClick={() => removeToast(t.id)} className="hover:bg-white/20 rounded-full p-1 opacity-75 hover:opacity-100">
+                            <X size={14} />
+                        </button>
+                    </div>
+                ))}
+            </div>
+
+            <header className="w-full h-16 border-b border-slate-800 flex justify-between items-center px-6 bg-slate-900 fixed top-0 left-0 right-0 z-[9999]">
+                <div className="flex items-center gap-4">
+                    {onNavigateBack && (
+                        <button onClick={onNavigateBack} className="p-1.5 rounded-full hover:bg-slate-800 text-slate-400 hover:text-white transition-colors">
+                            <ArrowLeft className="h-5 w-5" />
+                        </button>
+                    )}
+                    
+                    <div className="flex items-center gap-2.5 border-r border-slate-500 pr-4">
+                        <img src="https://llm-d.ai/img/llm-d-logotype-and-icon.png" alt="llm-d Logo" className="h-6 object-contain" />
+                        <span className="text-lg font-bold tracking-wide bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600">
+                            Prism
+                        </span>
+                    </div>
+
+                    <div className="flex items-center">
+                        <h1 className="text-lg font-bold text-white tracking-wide">Manage Benchmarks</h1>
+                    </div>
+                </div>
+
+                <div className="flex items-center space-x-4">
+                    {/* View Selected Button */}
+                    <button
+                        onClick={() => onNavigate('benchmark-browser')}
+                        className="px-4 py-2 text-sm font-semibold rounded-md text-white bg-blue-600 hover:bg-blue-500 transition-colors flex items-center shadow-lg border border-blue-500/20"
+                    >
+                        <Eye className="w-4 h-4 mr-2" /> View Selected ({selectedBenchmarks.size})
+                    </button>
+
+                    <button
+                        onClick={() => setShowDataPanel(!showDataPanel)}
+                        className={`px-4 py-2 text-sm font-medium rounded-md border transition-colors flex items-center ${showDataPanel ? 'bg-blue-500/20 text-blue-400 border-blue-500/30' : 'text-slate-300 bg-slate-800 hover:bg-slate-700 border-slate-700'}`}
+                    >
+                        <Database className="w-4 h-4 mr-2" /> Connections
+                    </button>
+
+                    <a 
+                        href="https://llm-d.ai/docs/community" 
+                        target="_blank" 
+                        rel="noreferrer"
+                        className="px-4 py-2 text-sm font-medium rounded-md text-slate-300 bg-slate-800 hover:bg-slate-700 transition-colors flex items-center border border-slate-700"
+                    >
+                        <MessageCircle className="w-4 h-4 mr-2" /> Contact us
+                    </a>
+                </div>
+            </header>
+
+            <main className="w-full px-8 py-6 pl-28 flex flex-col transition-colors duration-200">
+                <div className="space-y-4 mb-4 relative">
+                    <FilterPanel
+                        {...{
+                            showFilterPanel, filterOptions, activeFilters, facetCounts, toggleFilter,
+                            selectedModels: selectedBenchmarks, modelStats, filteredBySource, showSelectedOnly, setShowSelectedOnly,
+                            selectedBenchmarks, setSelectedBenchmarks, setActiveFilters, expandedModels,
+                            toggleBenchmark, toggleModelExpansion,
+                            baselineBenchmarkKey, setBaselineBenchmarkKey,
+                            UnifiedDataTable,
+                            hideShowSelectedOnly: true,
+                            renameClearToUnselectAll: true,
+                            brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run
+                        }}
+                    />
+                </div>
+            </main>
+
+            {/* Data Connections Panel */}
+            {showDataPanel && (
+                <div
+                    className="fixed inset-0 bg-black/50 z-[55] backdrop-blur-sm transition-opacity"
+                    onClick={() => setShowDataPanel(false)}
+                />
+            )}
+            <DataConnectionsPanel
+                {...dashboardData}
+                addToast={addToast}
+                showDataPanel={showDataPanel}
+                setShowDataPanel={setShowDataPanel}
+                INTEGRATIONS={INTEGRATIONS}
+                selectedModels={selectedBenchmarks}
+                activeFilters={activeFilters}
+                showSelectedOnly={showSelectedOnly}
+                state={dashboardState}
+            />
+        </div>
+    );
+}

--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -44,8 +44,8 @@ export const FilterPanel = ({
     const [groupBy, setGroupBy] = useState(() => {
         try {
             const saved = localStorage.getItem('prism_manage_group_by');
-            return saved || 'Origin';
-        } catch { return 'Origin'; }
+            return saved || 'Model';
+        } catch { return 'Model'; }
     });
     
     const [sortByField, setSortByField] = useState(() => {
@@ -73,6 +73,7 @@ export const FilterPanel = ({
         const defaults = {
             hardware: true,
             timestamp: true,
+            stage: true,
             nodes: false,
             islOsl: false,
             maxTput: true,
@@ -193,6 +194,7 @@ export const FilterPanel = ({
                                             <option value="Model">Model</option>
                                             <option value="Hardware">Hardware</option>
                                             <option value="Origin">Source Connections</option>
+                                            <option value="OriginFolder">Origin/Folder</option>
                                         </select>
                                     </div>
                                     <span className="text-xs text-slate-500 font-medium">Sort by:</span>
@@ -231,6 +233,7 @@ export const FilterPanel = ({
                                 {Object.entries({
                                     hardware: 'Hardware',
                                     timestamp: 'Timestamp',
+                                    stage: 'Stage',
                                     nodes: 'Nodes & Parallelism',
                                     islOsl: 'ISL/OSL',
                                     maxTput: 'Max TPUT',

--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -1,0 +1,478 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { useState, useEffect } from 'react';
+import { Filter, ChevronDown, ChevronUp, Check, ArrowDown01, ArrowDown10 } from 'lucide-react';
+import { MultiSelectDropdown } from '../common';
+import { USE_CASE_META, formatOriginLabel } from '../../utils/dashboardHelpers';
+
+export const FilterPanel = ({
+    showFilterPanel,
+    filterOptions,
+    activeFilters,
+    facetCounts,
+    toggleFilter,
+    selectedModels,
+    modelStats,
+    filteredBySource,
+    showSelectedOnly,
+    setShowSelectedOnly,
+    selectedBenchmarks,
+    setSelectedBenchmarks,
+    setActiveFilters,
+    expandedModels,
+    toggleBenchmark,
+    toggleModelExpansion,
+    baselineBenchmarkKey,
+    setBaselineBenchmarkKey,
+    UnifiedDataTable,
+    hideShowSelectedOnly,
+    renameClearToUnselectAll,
+    brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run
+}) => {
+    const [groupBy, setGroupBy] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_manage_group_by');
+            return saved || 'Origin';
+        } catch { return 'Origin'; }
+    });
+    
+    const [sortByField, setSortByField] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_manage_sort_by');
+            return saved || 'timestamp';
+        } catch { return 'timestamp'; }
+    });
+
+    const [sortDirection, setSortDirection] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_manage_sort_dir');
+            return saved || 'desc';
+        } catch { return 'desc'; }
+    });
+
+    const [isFiltersExpanded, setIsFiltersExpanded] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_manage_filters_expanded');
+            return saved !== null ? saved === 'true' : true;
+        } catch { return true; }
+    });
+
+    const [visibleSpecs, setVisibleSpecs] = useState(() => {
+        const defaults = {
+            hardware: true,
+            timestamp: true,
+            nodes: false,
+            islOsl: false,
+            maxTput: true,
+            minLat: true,
+            qps: false,
+            inputTput: false,
+            outputTput: false,
+            totalTput: false,
+            ntpot: false,
+            tpot: false,
+            itl: false,
+            ttft: false,
+            e2e: false,
+            costIn: false,
+            costOut: false,
+            inputLen: false,
+            outputLen: false
+        };
+        try {
+            const saved = localStorage.getItem('prism_manage_visible_specs');
+            if (saved) {
+                return { ...defaults, ...JSON.parse(saved) };
+            }
+        } catch (e) {
+            console.warn("Failed to load visible specs from local storage", e);
+        }
+        return defaults;
+    });
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_manage_group_by', groupBy);
+        } catch (e) { console.warn(e); }
+    }, [groupBy]);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_manage_sort_by', sortByField);
+        } catch (e) { console.warn(e); }
+    }, [sortByField]);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_manage_sort_dir', sortDirection);
+        } catch (e) { console.warn(e); }
+    }, [sortDirection]);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_manage_filters_expanded', isFiltersExpanded.toString());
+        } catch (e) { console.warn(e); }
+    }, [isFiltersExpanded]);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_manage_visible_specs', JSON.stringify(visibleSpecs));
+        } catch (e) { console.warn(e); }
+    }, [visibleSpecs]);
+
+    if (!showFilterPanel) return null;
+
+    return (
+        <div className="flex flex-col mb-4">
+            {/* Header & Controls */}
+            <div className="flex justify-end mb-2">
+        <button 
+            onClick={() => setIsFiltersExpanded(!isFiltersExpanded)}
+            className="flex items-center gap-1 text-xs text-blue-600 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 transition-colors font-medium cursor-pointer"
+        >
+            {isFiltersExpanded ? (
+                <><ChevronUp size={14} /> Hide Filters</>
+            ) : (
+                <><ChevronDown size={14} /> Show Filters</>
+            )}
+        </button>
+    </div>
+
+            {/* Filter Groups - Collapsible Layout */}
+            {isFiltersExpanded && (
+                <div className="flex flex-col gap-4 border-t border-slate-200 dark:border-slate-700/50 pt-3">
+                    {/* Origin filter & custom visible info options container */}
+                    <div className="flex flex-col gap-4 border-b border-slate-200 dark:border-slate-700/50 pb-4">
+                        <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
+                            <div className="w-full sm:w-64 flex-shrink-0 flex flex-col gap-3">
+                                <MultiSelectDropdown 
+                                    label="Connection / Source"
+                                    options={filterOptions.connectionNames || []}
+                                    selected={activeFilters.connectionNames || new Set()}
+                                    onChange={(val) => toggleFilter('connectionNames', val)}
+                                    counts={facetCounts.connectionNames || {}}
+                                />
+                                <MultiSelectDropdown 
+                                    label="Origin / Folder"
+                                    options={filterOptions.origins || []}
+                                    selected={activeFilters.origins}
+                                    onChange={(val) => toggleFilter('origins', val)}
+                                    counts={facetCounts.origins || {}}
+                                    formatLabel={formatOriginLabel}
+                                />
+                            </div>
+                        </div>
+
+                        {/* Visible Information Selection on its own dedicated line */}
+                        <div className="flex flex-col gap-2">
+                            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-slate-200 dark:border-slate-700/50 pb-2 mb-2">
+                                <span className="text-[10px] uppercase tracking-wider font-bold text-slate-400 dark:text-slate-500 select-none">Visible Specs & Detailed Performance Metrics:</span>
+                                
+                                <div className="flex items-center gap-2">
+                                    
+                                    <div className="flex items-center gap-2 mr-4 border-r border-slate-300 dark:border-slate-600 pr-4">
+                                        <span className="text-xs text-slate-500 font-medium">Group by:</span>
+                                        <select 
+                                            className="text-xs bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded px-2 py-1 outline-none focus:ring-1 focus:ring-blue-500 text-slate-700 dark:text-slate-300 font-semibold cursor-pointer"
+                                            value={groupBy}
+                                            onChange={(e) => setGroupBy(e.target.value)}
+                                        >
+                                            <option value="None">None</option>
+                                            <option value="Model">Model</option>
+                                            <option value="Hardware">Hardware</option>
+                                            <option value="Origin">Source Connections</option>
+                                        </select>
+                                    </div>
+                                    <span className="text-xs text-slate-500 font-medium">Sort by:</span>
+                                    <select 
+                                        className="text-xs bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded px-2 py-1 outline-none focus:ring-1 focus:ring-blue-500 text-slate-700 dark:text-slate-300 font-semibold cursor-pointer"
+                                        value={sortByField}
+                                        onChange={(e) => setSortByField(e.target.value)}
+                                    >
+                                        <option value="timestamp">Timestamp</option>
+                                        <option value="maxTput">Max Throughput</option>
+                                        <option value="minLat">Min Latency</option>
+                                        <option value="model">Model Name</option>
+                                        <option value="qps">QPS</option>
+                                        <option value="inputTput">Input Tok/s</option>
+                                        <option value="outputTput">Output Tok/s</option>
+                                        <option value="totalTput">Total Tok/s</option>
+                                        <option value="ntpot">NTPOT</option>
+                                        <option value="tpot">TPOT</option>
+                                        <option value="itl">ITL</option>
+                                        <option value="ttft">TTFT</option>
+                                        <option value="e2e">E2E Latency</option>
+                                        <option value="costIn">Cost/1M In</option>
+                                        <option value="costOut">Cost/1M Out</option>
+                                    </select>
+                                    
+                                    <button
+                                        onClick={() => setSortDirection(prev => prev === 'asc' ? 'desc' : 'asc')}
+                                        title={sortDirection === 'asc' ? 'Ascending' : 'Descending'}
+                                        className="p-1.5 text-slate-500 hover:text-slate-700 dark:text-slate-400 dark:hover:text-slate-200 bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 rounded border border-slate-200 dark:border-slate-700 transition-colors cursor-pointer flex items-center justify-center"
+                                    >
+                                        {sortDirection === 'asc' ? <ArrowDown01 size={14} /> : <ArrowDown10 size={14} />}
+                                    </button>
+                                </div>
+                            </div>
+                            <div className="flex flex-wrap items-center gap-2">
+                                {Object.entries({
+                                    hardware: 'Hardware',
+                                    timestamp: 'Timestamp',
+                                    nodes: 'Nodes & Parallelism',
+                                    islOsl: 'ISL/OSL',
+                                    maxTput: 'Max TPUT',
+                                    minLat: 'Min LAT',
+                                    qps: 'QPS',
+                                    inputTput: 'Input Tok/s',
+                                    outputTput: 'Output Tok/s',
+                                    totalTput: 'Total Tok/s',
+                                    ntpot: 'NTPOT (ms)',
+                                    tpot: 'TPOT (ms)',
+                                    itl: 'ITL (ms)',
+                                    ttft: 'TTFT (ms)',
+                                    e2e: 'E2E (s)',
+                                    costIn: 'Cost/1M In ($)',
+                                    costOut: 'Cost/1M Out ($)',
+                                    inputLen: 'Input Len',
+                                    outputLen: 'Output Len'
+                                }).map(([key, label]) => {
+                                    const isSelected = visibleSpecs[key];
+                                    return (
+                                        <button
+                                            key={key}
+                                            onClick={() => setVisibleSpecs(prev => ({ ...prev, [key]: !prev[key] }))}
+                                            className={`px-2.5 py-1 text-xs rounded transition-all flex items-center gap-1.5 font-medium border cursor-pointer select-none ${
+                                                isSelected 
+                                                    ? 'bg-blue-50 dark:bg-blue-950/40 text-blue-600 dark:text-blue-400 border-blue-200 dark:border-blue-900/50' 
+                                                    : 'bg-slate-50 dark:bg-slate-900/50 text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-800 hover:border-slate-300 dark:hover:border-slate-700'
+                                            }`}
+                                        >
+                                            <div className={`w-2.5 h-2.5 rounded-sm border flex items-center justify-center ${isSelected ? 'bg-blue-500 border-blue-500 text-white' : 'border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-800'}`}>
+                                                {isSelected && <Check size={8} strokeWidth={4} />}
+                                            </div>
+                                            {label}
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                    </div>
+                    
+                    <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+                
+                {/* Section 1: Application / Model Server */}
+                <div className="flex-1 min-w-[200px]">
+                    <h4 className="text-[10px] font-bold uppercase text-slate-400 mb-1 px-1">Application / Model Server</h4>
+                    <div className="flex flex-wrap gap-1.5">
+                        <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                            <MultiSelectDropdown 
+                                label="Models"
+                                options={filterOptions.models}
+                                selected={activeFilters.models}
+                                onChange={(val) => toggleFilter('models', val)}
+                                counts={facetCounts.models}
+                            />
+                        </div>
+                        <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                            <MultiSelectDropdown 
+                                label="Precisions"
+                                options={filterOptions.precisions}
+                                selected={activeFilters.precisions}
+                                onChange={(val) => toggleFilter('precisions', val)}
+                                counts={facetCounts.precisions}
+                            />
+                        </div>
+                        <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                             <MultiSelectDropdown 
+                                 label="Model Server"
+                                 options={filterOptions.modelServer}
+                                 selected={activeFilters.modelServer}
+                                 onChange={(val) => toggleFilter('modelServer', val)}
+                                 counts={facetCounts.modelServer}
+                             />
+                        </div>
+                        <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                            <MultiSelectDropdown 
+                                label="Tensor Parallelism (TP)"
+                                options={filterOptions.tp || []}
+                                selected={activeFilters.tp}
+                                onChange={(val) => toggleFilter('tp', val)}
+                                counts={facetCounts.tp}
+                            />
+                        </div>
+                    </div>
+                </div>
+                
+                {/* Section 2: Hardware Infrastructure */}
+                <div className="flex-1 min-w-[200px]">
+                    <h4 className="text-[10px] font-bold uppercase text-slate-400 mb-1 px-1">Hardware Infrastructure</h4>
+                    <div className="flex flex-wrap gap-1.5">
+                        <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                            <MultiSelectDropdown 
+                                label="Machine Type"
+                                options={filterOptions.machines}
+                                selected={activeFilters.machines}
+                                onChange={(val) => toggleFilter('machines', val)}
+                                counts={facetCounts.machines}
+                            />
+                        </div>
+                        <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                            <MultiSelectDropdown 
+                                label="Accelerators"
+                                options={filterOptions.hardware}
+                                selected={activeFilters.hardware}
+                                onChange={(val) => toggleFilter('hardware', val)}
+                                counts={facetCounts.hardware}
+                            />
+                        </div>
+                        <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                            <MultiSelectDropdown 
+                                label="Accelerator Count"
+                                options={filterOptions.acc_count}
+                                selected={activeFilters.acc_count}
+                                onChange={(val) => toggleFilter('acc_count', val)}
+                                counts={facetCounts.acc_count}
+                            />
+                        </div>
+                    </div>
+                </div>
+
+                {/* Section 3: Orchestration */}
+                <div className="flex-1 min-w-[200px]">
+                      <h4 className="text-[10px] font-bold uppercase text-slate-400 mb-1 px-1">Orchestration / Serving Framework</h4>
+                      <div className="flex flex-wrap gap-1.5">
+                         <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                             <MultiSelectDropdown 
+                                 label="Serving Stack"
+                                 options={filterOptions.servingStack || []}
+                                 selected={activeFilters.servingStack}
+                                 onChange={(val) => toggleFilter('servingStack', val)}
+                                 counts={facetCounts.servingStack || {}}
+                             />
+                         </div>
+                         <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                             <MultiSelectDropdown 
+                                 label="Optimizations"
+                                 options={[
+                                     "Atomic / Gang Scheduling",
+                                     "Topology Aware Scheduling",
+                                     "P/D Disaggregation",
+                                     "Horizontal Pod Autoscaling",
+                                     "Body based routing",
+                                     "Approximate prefix aware routing",
+                                     "Precise prefix aware routing"
+                                 ]}
+                                 selected={activeFilters.optimizations}
+                                 onChange={(val) => toggleFilter('optimizations', val)}
+                                 counts={facetCounts.optimizations}
+                             />
+                         </div>
+                         <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                              <MultiSelectDropdown 
+                                 label="Components"
+                                 options={["Inference Gateway", "Inference Scheduler", "LeaderWorkerSet"]}
+                                 selected={activeFilters.components}
+                                 onChange={(val) => toggleFilter('components', val)}
+                                 counts={facetCounts.components}
+                             />
+                         </div>
+                         <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                             <MultiSelectDropdown 
+                                 label="P/D Node Ratio"
+                                 options={filterOptions.pdRatio}
+                                 selected={activeFilters.pdRatio}
+                                 onChange={(val) => toggleFilter('pdRatio', val)}
+                                 counts={facetCounts.pdRatio}
+                             />
+                         </div>
+                      </div>
+                </div>
+
+                {/* Section 4: Benchmark Load */}
+                <div className="flex-1 min-w-[200px]">
+                     <h4 className="text-[10px] font-bold uppercase text-slate-400 mb-1 px-1">Benchmark Load</h4>
+                     <div className="flex flex-wrap gap-1.5">
+                         <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                             <MultiSelectDropdown 
+                                 label="Input (ISL)"
+                                 options={filterOptions.isl}
+                                 selected={activeFilters.isl}
+                                 onChange={(val) => toggleFilter('isl', val)}
+                                 counts={facetCounts.isl}
+                             />
+                         </div>
+                         <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                             <MultiSelectDropdown 
+                                 label="Output (OSL)"
+                                 options={filterOptions.osl}
+                                 selected={activeFilters.osl}
+                                 onChange={(val) => toggleFilter('osl', val)}
+                                 counts={facetCounts.osl}
+                             />
+                         </div>
+                         <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                             <MultiSelectDropdown 
+                                 label="Workload Type"
+                                 options={filterOptions.ratio}
+                                 selected={activeFilters.ratio}
+                                 onChange={(val) => toggleFilter('ratio', val)}
+                                 counts={facetCounts.ratio}
+                             />
+                         </div>
+                         <div className="flex-1 min-w-[130px] sm:min-w-[150px]">
+                             <MultiSelectDropdown 
+                                 label="Use Case"
+                                 options={filterOptions.useCase}
+                                 selected={activeFilters.useCase}
+                                 onChange={(val) => toggleFilter('useCase', val)}
+                                 counts={facetCounts.useCase}
+                                 formatLabel={(opt) => {
+                                     const meta = USE_CASE_META[opt];
+                                     return meta ? `${opt} ${meta}` : opt;
+                                 }}
+                             />
+                         </div>
+                      </div>
+                 </div>
+              </div>
+            </div>
+            )}
+            
+            {/* Spacer */}
+            <div className="h-4" />
+
+             <UnifiedDataTable
+                groupBy={groupBy}
+                sortByField={sortByField}
+                sortDirection={sortDirection}
+                visibleSpecs={visibleSpecs}
+                modelStats={modelStats} selectedModels={selectedModels} filteredBySource={filteredBySource}
+                showSelectedOnly={showSelectedOnly} setShowSelectedOnly={setShowSelectedOnly}
+                selectedBenchmarks={selectedBenchmarks} setSelectedBenchmarks={setSelectedBenchmarks}
+                setActiveFilters={setActiveFilters} expandedModels={expandedModels}
+                toggleBenchmark={toggleBenchmark} toggleModelExpansion={toggleModelExpansion}
+                baselineBenchmarkKey={baselineBenchmarkKey}
+                setBaselineBenchmarkKey={setBaselineBenchmarkKey}
+                hideShowSelectedOnly={hideShowSelectedOnly}
+                renameClearToUnselectAll={renameClearToUnselectAll}
+                brv02Runs={brv02Runs}
+                brv02CustomLabels={brv02CustomLabels}
+                setBrv02CustomLabels={setBrv02CustomLabels}
+                removeBrv02Run={removeBrv02Run}
+            />
+        </div>
+    );
+};

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -14,7 +14,7 @@
 
 import React, { useState } from 'react';
 import { RotateCcw, ChevronDown, ChevronUp, Star, CheckSquare, Square, Check, Pencil, Trash2 } from 'lucide-react';
-import { getEffectiveTp, getBucket, getSourceTag, getSourceType, getSourceTypeStyle } from '../../utils/dashboardHelpers';
+import { getEffectiveTp, getBucket, getSourceTag, getSourceType, getSourceTypeStyle, formatOriginLabel } from '../../utils/dashboardHelpers';
 
 export const UnifiedDataTable = (props) => {
     const [editingRunId, setEditingRunId] = useState(null);
@@ -49,12 +49,13 @@ export const UnifiedDataTable = (props) => {
         hideShowSelectedOnly = false,
         renameClearToUnselectAll = false,
         brv02Runs = [], brv02CustomLabels = {}, setBrv02CustomLabels, removeBrv02Run,
-        groupBy = 'Origin',
+        groupBy = 'Model',
         sortByField = 'timestamp',
         sortDirection = 'desc',
         visibleSpecs = {
             hardware: true,
             timestamp: true,
+            stage: true,
             nodes: false,
             islOsl: false,
             maxTput: true,
@@ -265,11 +266,38 @@ export const UnifiedDataTable = (props) => {
                 valB = getPeakRunMetric(b, sortByField);
             }
             
+            let primaryResult = 0;
             if (typeof valA === 'string' && typeof valB === 'string') {
-                return sortDirection === 'asc' ? valA.localeCompare(valB) : valB.localeCompare(valA);
+                primaryResult = sortDirection === 'asc' ? valA.localeCompare(valB) : valB.localeCompare(valA);
+            } else {
+                primaryResult = sortDirection === 'asc' ? valA - valB : valB - valA;
+            }
+
+            if (primaryResult !== 0 && !isNaN(primaryResult)) {
+                return primaryResult;
+            }
+
+            // Fallback tie-breaker: Origin/Folder first, then Filename
+            const firstA = a.data?.[0];
+            const firstB = b.data?.[0];
+            
+            const originA = firstA?.source_info?.origin || firstA?.source || '';
+            const originB = firstB?.source_info?.origin || firstB?.source || '';
+            
+            const originCmp = originA.localeCompare(originB);
+            if (originCmp !== 0) {
+                return originCmp;
             }
             
-            return sortDirection === 'asc' ? valA - valB : valB - valA;
+            const fileA = firstA?.source_info?.file_identifier || firstA?.filename || '';
+            const fileB = firstB?.source_info?.file_identifier || firstB?.filename || '';
+            
+            const fileCmp = fileA.localeCompare(fileB);
+            if (fileCmp !== 0) {
+                return fileCmp;
+            }
+
+            return (a.benchmarkKey || '').localeCompare(b.benchmarkKey || '');
         });
     }, [filteredStats, sortByField, sortDirection]);
 
@@ -285,6 +313,10 @@ export const UnifiedDataTable = (props) => {
                 if (groupBy === 'Origin') {
                     const origin = stat.data?.[0]?.source_info?.origin || stat.data?.[0]?.source;
                     key = origin ? getSourceTag(stat.data[0]) : 'Unknown Origin';
+                }
+                if (groupBy === 'OriginFolder') {
+                    const origin = stat.data?.[0]?.source_info?.origin || stat.data?.[0]?.source;
+                    key = origin ? formatOriginLabel(origin) : 'Unknown Origin/Folder';
                 }
                 if (!grouped[key]) grouped[key] = [];
                 grouped[key].push(stat);
@@ -536,6 +568,18 @@ export const UnifiedDataTable = (props) => {
                                                                  }
                                                              }
 
+                                                             if (visibleSpecs.stage) {
+                                                                 const stageVal = benchmarkData[0]?.workload?.stage;
+                                                                 if (stageVal !== undefined && stageVal !== null && stageVal !== '') {
+                                                                     specs.push(
+                                                                         <span key="stage" className="inline-flex items-center gap-1">
+                                                                             <span className="text-slate-400 dark:text-slate-500 font-normal">Stage:</span>
+                                                                             <span className="font-semibold text-slate-700 dark:text-slate-300">{stageVal}</span>
+                                                                         </span>
+                                                                     );
+                                                                 }
+                                                             }
+
                                                              if (visibleSpecs.hardware) {
                                                                 specs.push(
                                                                     <span key="hardware" className="inline-flex items-center gap-1">
@@ -711,39 +755,39 @@ export const UnifiedDataTable = (props) => {
                                                                 );
                                                             }
 
-                                                            return (
-                                                                <div className="flex-1 flex flex-col min-w-0">
-                                                                    {/* Line 1: Model Title on left, Source Tag & Date on right */}
-                                                                    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 w-full">
-                                                                        <div className="flex items-center gap-2 min-w-0 flex-1">
-                                                                            {editingRunId === runId && isBrv02 ? (
-                                                                                <div className="flex-1 flex flex-col gap-0.5 min-w-0" onClick={e => e.stopPropagation()}>
-                                                                                    <input
-                                                                                        autoFocus
-                                                                                        value={editingValue}
-                                                                                        onChange={e => setEditingValue(e.target.value)}
-                                                                                        onBlur={commitEdit}
-                                                                                        onKeyDown={e => {
-                                                                                            if (e.key === 'Enter') commitEdit();
-                                                                                            if (e.key === 'Escape') cancelEdit();
-                                                                                        }}
-                                                                                        className="w-full text-sm font-medium bg-white dark:bg-slate-800 border border-cyan-400 rounded px-1.5 py-0.5 text-slate-800 dark:text-slate-200 focus:outline-none"
-                                                                                    />
-                                                                                </div>
-                                                                            ) : (
-                                                                                <div className="flex items-center gap-1 min-w-0">
-                                                                                    <span className="font-bold text-sm sm:text-base text-slate-800 dark:text-slate-100 truncate">
-                                                                                        {isBrv02 && brv02CustomLabels && brv02CustomLabels[runId] 
-                                                                                            ? brv02CustomLabels[runId] 
-                                                                                            : (stat.model_name || stat.model || meta.model_name)}
-                                                                                    </span>
-                                                                                    {isBrv02 && (
-                                                                                        <button
-                                                                                            onClick={(e) => {
-                                                                                                e.stopPropagation();
-                                                                                                setEditingRunId(runId);
-                                                                                                setEditingValue(brv02CustomLabels[runId] || (stat.model_name || stat.model || meta.model_name));
-                                                                                            }}
+                                                             return (
+                                                                 <div className="flex-1 flex flex-col min-w-0">
+                                                                     {/* Line 1: Model Title on left, Source Tag & Date on right */}
+                                                                     <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 w-full">
+                                                                         <div className="flex items-center gap-2 min-w-0 flex-1">
+                                                                             {editingRunId === runId && isBrv02 ? (
+                                                                                 <div className="flex-1 flex flex-col gap-0.5 min-w-0" onClick={e => e.stopPropagation()}>
+                                                                                     <input
+                                                                                         autoFocus
+                                                                                         value={editingValue}
+                                                                                         onChange={e => setEditingValue(e.target.value)}
+                                                                                         onBlur={commitEdit}
+                                                                                         onKeyDown={e => {
+                                                                                             if (e.key === 'Enter') commitEdit();
+                                                                                             if (e.key === 'Escape') cancelEdit();
+                                                                                         }}
+                                                                                         className="w-full text-sm font-medium bg-white dark:bg-slate-800 border border-cyan-400 rounded px-1.5 py-0.5 text-slate-800 dark:text-slate-200 focus:outline-none"
+                                                                                     />
+                                                                                 </div>
+                                                                             ) : (
+                                                                                 <div className="flex items-center gap-1 min-w-0">
+                                                                                     <span className="font-bold text-sm sm:text-base text-slate-800 dark:text-slate-100 truncate">
+                                                                                         {isBrv02 && brv02CustomLabels && brv02CustomLabels[runId] 
+                                                                                             ? brv02CustomLabels[runId] 
+                                                                                             : (stat.model_name || stat.model || meta.model_name)}
+                                                                                     </span>
+                                                                                     {isBrv02 && (
+                                                                                         <button
+                                                                                             onClick={(e) => {
+                                                                                                 e.stopPropagation();
+                                                                                                 setEditingRunId(runId);
+                                                                                                 setEditingValue(brv02CustomLabels[runId] || (stat.model_name || stat.model || meta.model_name));
+                                                                                             }}
                                                                                             title="Rename run"
                                                                                             className="p-1 text-slate-300 dark:text-slate-600 hover:text-cyan-400 transition-colors flex-shrink-0"
                                                                                         >

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -1,0 +1,924 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React, { useState } from 'react';
+import { RotateCcw, ChevronDown, ChevronUp, Star, CheckSquare, Square, Check, Pencil, Trash2 } from 'lucide-react';
+import { getEffectiveTp, getBucket, getSourceTag, getSourceType, getSourceTypeStyle } from '../../utils/dashboardHelpers';
+
+export const UnifiedDataTable = (props) => {
+    const [editingRunId, setEditingRunId] = useState(null);
+    const [editingValue, setEditingValue] = useState('');
+
+    const commitEdit = () => {
+        if (editingRunId && setBrv02CustomLabels) {
+            const trimmed = editingValue.trim();
+            if (trimmed) {
+                setBrv02CustomLabels(prev => ({ ...prev, [editingRunId]: trimmed }));
+            }
+        }
+        setEditingRunId(null);
+    };
+
+    const cancelEdit = () => {
+        setEditingRunId(null);
+    };
+
+    const [isDraggingSelection, setIsDraggingSelection] = useState(false);
+    const dragStartPagePos = React.useRef({ x: 0, y: 0 });
+    const lastPointerPos = React.useRef({ x: 0, y: 0 });
+    const [dragBox, setDragBox] = useState(null);
+    const dragActionSelect = React.useRef(true);
+    const initialSelection = React.useRef(new Set());
+
+    const {
+        modelStats, selectedModels, filteredBySource, showSelectedOnly: propShowSelectedOnly, setShowSelectedOnly,
+        selectedBenchmarks, setSelectedBenchmarks, setActiveFilters, expandedModels,
+        toggleBenchmark, toggleModelExpansion,
+        baselineBenchmarkKey, setBaselineBenchmarkKey,
+        hideShowSelectedOnly = false,
+        renameClearToUnselectAll = false,
+        brv02Runs = [], brv02CustomLabels = {}, setBrv02CustomLabels, removeBrv02Run,
+        groupBy = 'Origin',
+        sortByField = 'timestamp',
+        sortDirection = 'desc',
+        visibleSpecs = {
+            hardware: true,
+            timestamp: true,
+            nodes: false,
+            islOsl: false,
+            maxTput: true,
+            minLat: true,
+            qps: false,
+            inputTput: false,
+            outputTput: false,
+            totalTput: false,
+            ntpot: false,
+            tpot: false,
+            itl: false,
+            ttft: false,
+            e2e: false,
+            costIn: false,
+            costOut: false,
+            inputLen: false,
+            outputLen: false
+        }
+    } = props;
+
+    const hasNonLocalSelected = React.useMemo(() => {
+        if (!selectedBenchmarks || selectedBenchmarks.size === 0) return false;
+        return Array.from(selectedBenchmarks).some(key => {
+            const stat = modelStats.find(s => s.benchmarkKey === key);
+            if (!stat) return false;
+            const sourceStr = stat.data?.[0]?.source || '';
+            return !sourceStr.startsWith('brv02:');
+        });
+    }, [selectedBenchmarks, modelStats]);
+
+    const handleDeleteSelected = () => {
+        if (!removeBrv02Run) return;
+        selectedBenchmarks.forEach(key => {
+            const stat = modelStats.find(s => s.benchmarkKey === key);
+            if (stat) {
+                const benchmarkData = stat.data || [];
+                const sourceStr = benchmarkData[0]?.source || '';
+                const isBrv02 = sourceStr.startsWith('brv02:');
+                const runId = isBrv02 ? sourceStr.replace('brv02:', '') : null;
+                if (isBrv02 && runId) {
+                    removeBrv02Run(runId);
+                }
+            }
+        });
+        setSelectedBenchmarks(new Set());
+    };
+
+    React.useEffect(() => {
+        if (!isDraggingSelection) return;
+
+        const updateDragSelection = () => {
+            const vStartX = dragStartPagePos.current.x - window.scrollX;
+            const vStartY = dragStartPagePos.current.y - window.scrollY;
+            const vCurrentX = lastPointerPos.current.x;
+            const vCurrentY = lastPointerPos.current.y;
+
+            setDragBox({
+                startX: vStartX,
+                startY: vStartY,
+                currentX: vCurrentX,
+                currentY: vCurrentY
+            });
+
+            const minX = Math.min(vStartX, vCurrentX);
+            const maxX = Math.max(vStartX, vCurrentX);
+            const minY = Math.min(vStartY, vCurrentY);
+            const maxY = Math.max(vStartY, vCurrentY);
+
+            const checkboxes = document.querySelectorAll('.benchmark-checkbox-area');
+            const newSelected = new Set(initialSelection.current);
+
+            checkboxes.forEach(cb => {
+                const rect = cb.getBoundingClientRect();
+                // Check if the checkbox overlaps in 2D with the drag range
+                if (rect.bottom >= minY && rect.top <= maxY && rect.right >= minX && rect.left <= maxX) {
+                    const key = cb.getAttribute('data-benchmark-key');
+                    if (key) {
+                        if (dragActionSelect.current) {
+                            newSelected.add(key);
+                        } else {
+                            newSelected.delete(key);
+                        }
+                    }
+                }
+            });
+
+            setSelectedBenchmarks(newSelected);
+        };
+
+        const handlePointerMove = (e) => {
+            lastPointerPos.current = { x: e.clientX, y: e.clientY };
+            updateDragSelection();
+        };
+
+        const handleScroll = () => {
+            updateDragSelection();
+        };
+
+        const handlePointerUp = () => {
+            setIsDraggingSelection(false);
+            setDragBox(null);
+        };
+
+        window.addEventListener('pointermove', handlePointerMove);
+        window.addEventListener('pointerup', handlePointerUp);
+        window.addEventListener('pointercancel', handlePointerUp);
+        window.addEventListener('scroll', handleScroll, { passive: true });
+
+        return () => {
+            window.removeEventListener('pointermove', handlePointerMove);
+            window.removeEventListener('pointerup', handlePointerUp);
+            window.removeEventListener('pointercancel', handlePointerUp);
+            window.removeEventListener('scroll', handleScroll);
+        };
+    }, [isDraggingSelection, setSelectedBenchmarks]);
+
+    const handleCheckboxPointerDown = (e, key, isCurrentlySelected) => {
+        // Only trigger on left mouse button or touch
+        if (e.pointerType === 'mouse' && e.button !== 0) return;
+        
+        e.preventDefault();
+        e.stopPropagation();
+        
+        dragStartPagePos.current = { x: e.clientX + window.scrollX, y: e.clientY + window.scrollY };
+        lastPointerPos.current = { x: e.clientX, y: e.clientY };
+        setDragBox({
+            startX: e.clientX,
+            startY: e.clientY,
+            currentX: e.clientX,
+            currentY: e.clientY
+        });
+
+        const willSelect = !isCurrentlySelected;
+        dragActionSelect.current = willSelect;
+        
+        // Take a snapshot of the selection BEFORE this click so that the
+        // pointermove loop can cleanly apply additions/deletions onto it.
+        initialSelection.current = new Set(selectedBenchmarks);
+        
+        setIsDraggingSelection(true);
+        
+        // Immediately toggle the one we pressed on
+        setSelectedBenchmarks(prev => {
+            const newSelected = new Set(prev);
+            if (willSelect) newSelected.add(key);
+            else newSelected.delete(key);
+            return newSelected;
+        });
+    };
+
+
+
+    const showSelectedOnly = hideShowSelectedOnly ? false : propShowSelectedOnly;
+
+    const toggleBaseline = (key) => {
+        if (!setBaselineBenchmarkKey) return;
+        setBaselineBenchmarkKey(prev => (prev === key ? null : key));
+    };
+
+    const clearFilters = () => {
+        setActiveFilters({
+            models: new Set(), hardware: new Set(), machines: new Set(), precisions: new Set(),
+            tp: new Set(), isl: new Set(), osl: new Set(), ratio: new Set(),
+            acc_count: new Set(), modelServer: new Set(), useCase: new Set(),
+            servingStack: new Set(), optimizations: new Set(), components: new Set(),
+            pdRatio: new Set(), origins: new Set(), connectionNames: new Set()
+        });
+        setShowSelectedOnly(false);
+    };
+
+    const filteredStats = React.useMemo(() => {
+        return modelStats.filter(stat => !showSelectedOnly || selectedBenchmarks.has(stat.benchmarkKey));
+    }, [modelStats, showSelectedOnly, selectedBenchmarks]);
+
+    const sortedStats = React.useMemo(() => {
+        return [...filteredStats].sort((a, b) => {
+            let valA, valB;
+            
+            if (sortByField === 'timestamp') {
+                valA = a.timestamp || 0;
+                valB = b.timestamp || 0;
+            } else if (sortByField === 'maxTput') {
+                valA = a.maxTput || 0;
+                valB = b.maxTput || 0;
+            } else if (sortByField === 'minLat') {
+                valA = a.minLat || (sortDirection === 'asc' ? Infinity : -Infinity);
+                valB = b.minLat || (sortDirection === 'asc' ? Infinity : -Infinity);
+            } else if (sortByField === 'model') {
+                valA = a.model || '';
+                valB = b.model || '';
+            } else {
+                const getPeakRunMetric = (stat, field) => {
+                    const peakRun = stat.data?.reduce((prev, curr) => (curr?.throughput || 0) > (prev?.throughput || 0) ? curr : prev, stat.data[0]) || {};
+                    if (field === 'qps') return peakRun.metrics?.request_rate || peakRun.qps || 0;
+                    if (field === 'inputTput') return peakRun.metrics?.input_tput || 0;
+                    if (field === 'outputTput') return peakRun.metrics?.output_tput || peakRun.throughput || 0;
+                    if (field === 'totalTput') return peakRun.metrics?.total_tput || 0;
+                    if (field === 'ntpot') return peakRun.metrics?.ntpot || peakRun.ntpot || 0;
+                    if (field === 'tpot') return peakRun.metrics?.tpot || peakRun.time_per_output_token || 0;
+                    if (field === 'itl') return peakRun.metrics?.itl || peakRun.itl || 0;
+                    if (field === 'ttft') return peakRun.metrics?.ttft?.mean || peakRun.ttft?.mean || 0;
+                    if (field === 'e2e') return peakRun.metrics?.e2e_latency || peakRun.latency?.mean || 0;
+                    if (field === 'costIn') return peakRun.metrics?.cost?.explicit_input || 0;
+                    if (field === 'costOut') return peakRun.metrics?.cost?.explicit_output || 0;
+                    return 0;
+                };
+                valA = getPeakRunMetric(a, sortByField);
+                valB = getPeakRunMetric(b, sortByField);
+            }
+            
+            if (typeof valA === 'string' && typeof valB === 'string') {
+                return sortDirection === 'asc' ? valA.localeCompare(valB) : valB.localeCompare(valA);
+            }
+            
+            return sortDirection === 'asc' ? valA - valB : valB - valA;
+        });
+    }, [filteredStats, sortByField, sortDirection]);
+
+    const needsExpansion = sortedStats.length > 4;
+
+    const groupedStats = React.useMemo(() => {
+        const grouped = {};
+        if (groupBy !== 'None') {
+            sortedStats.forEach(stat => {
+                let key = 'Other';
+                if (groupBy === 'Model') key = stat.model_name || stat.model || 'Unknown Model';
+                if (groupBy === 'Hardware') key = stat.hardware || 'Unknown Hardware';
+                if (groupBy === 'Origin') {
+                    const origin = stat.data?.[0]?.source_info?.origin || stat.data?.[0]?.source;
+                    key = origin ? getSourceTag(stat.data[0]) : 'Unknown Origin';
+                }
+                if (!grouped[key]) grouped[key] = [];
+                grouped[key].push(stat);
+            });
+        } else {
+            grouped['All'] = sortedStats;
+        }
+        return grouped;
+    }, [sortedStats, groupBy]);
+
+    const selectAllVisible = () => {
+        const allVisible = new Set(sortedStats.map(s => s.benchmarkKey));
+        setSelectedBenchmarks(allVisible);
+    };
+
+    const invertSelected = () => {
+        const inverted = new Set(sortedStats.map(s => s.benchmarkKey).filter(k => !selectedBenchmarks.has(k)));
+        setSelectedBenchmarks(inverted);
+    };
+
+    const clearSelected = () => {
+        setSelectedBenchmarks(new Set());
+    };
+
+    const toggleGroup = (groupStats, isAllSelected) => {
+        const newSelected = new Set(selectedBenchmarks);
+        if (isAllSelected) {
+            groupStats.forEach(s => newSelected.delete(s.benchmarkKey));
+        } else {
+            groupStats.forEach(s => newSelected.add(s.benchmarkKey));
+        }
+        setSelectedBenchmarks(newSelected);
+    };
+
+    return (
+        <div className="flex flex-col gap-3">
+            {/* Action Bar */}
+            <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 px-1 border-b border-slate-200 dark:border-slate-700/50 pb-3">
+                <div className="flex items-center gap-4">
+                    <div className="flex flex-col">
+                        <span className="text-sm font-medium text-slate-700 dark:text-slate-300">
+                            {modelStats.length} matching benchmarks
+                        </span>
+                        <span className="text-xs text-slate-500">
+                            {selectedBenchmarks.size} selected
+                        </span>
+                    </div>
+                    
+                    {!hideShowSelectedOnly && (
+                        <>
+                            <div className="h-8 w-px bg-slate-300 dark:bg-slate-700" />
+                            <div className="flex items-center gap-2">
+                                <span className="text-xs text-slate-600 dark:text-slate-400 font-medium">Show selected only</span>
+                                <button 
+                                    onClick={() => setShowSelectedOnly(!showSelectedOnly)}
+                                    className={`w-9 h-5 rounded-full relative transition-colors shadow-inner ${showSelectedOnly ? 'bg-blue-500' : 'bg-slate-300 dark:bg-slate-600'}`}
+                                >
+                                    <div className={`absolute top-0.5 left-0.5 w-4 h-4 rounded-full bg-white shadow-sm transition-transform ${showSelectedOnly ? 'translate-x-4' : 'translate-x-0'}`} />
+                                </button>
+                            </div>
+                        </>
+                    )}
+                </div>
+
+                <div className="flex items-center gap-2">
+                    {selectedBenchmarks.size === 0 ? (
+                        <>
+                            <button
+                                onClick={selectAllVisible}
+                                className="px-3 py-1.5 text-xs font-medium bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 rounded hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
+                            >
+                                Select All Visible
+                            </button>
+                            <button
+                                onClick={clearFilters}
+                                className="px-3 py-1.5 text-xs font-medium bg-slate-100 dark:bg-slate-800 border border-transparent text-slate-600 dark:text-slate-400 rounded hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors flex items-center gap-1"
+                            >
+                                <RotateCcw size={12} /> Clear Filters
+                            </button>
+                        </>
+                    ) : (
+                        <>
+                            <button
+                                onClick={invertSelected}
+                                className="px-3 py-1.5 text-xs font-medium bg-white dark:bg-slate-800 border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 rounded hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors"
+                            >
+                                Invert Selected
+                            </button>
+                            <button
+                                onClick={clearSelected}
+                                className="px-3 py-1.5 text-xs font-medium bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/30 text-red-600 dark:text-red-400 rounded hover:bg-red-100 dark:hover:bg-red-900/40 transition-colors"
+                            >
+                                {renameClearToUnselectAll ? "Unselect All" : "Clear Selected"}
+                            </button>
+                            <div className="relative group flex items-center">
+                                <button
+                                    onClick={handleDeleteSelected}
+                                    disabled={hasNonLocalSelected}
+                                    className={`px-3 py-1.5 text-xs font-medium rounded transition-colors ${
+                                        hasNonLocalSelected
+                                            ? 'bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500 border border-slate-200 dark:border-slate-700/50 cursor-not-allowed opacity-50'
+                                            : 'bg-red-600 hover:bg-red-500 text-white shadow-sm border border-transparent'
+                                    }`}
+                                >
+                                    Delete Selected
+                                </button>
+                                {hasNonLocalSelected && (
+                                    <div className="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-3 py-1.5 bg-slate-800 border border-slate-700/80 text-white text-xs font-medium rounded-lg invisible group-hover:visible shadow-xl z-[99999] whitespace-nowrap flex items-center gap-2">
+                                        Non-local data sources are read-only.
+                                    </div>
+                                )}
+                            </div>
+                        </>
+                    )}
+                </div>
+            </div>
+
+            {/* Stacked Cards List Container */}
+            <div className="relative">
+                <div className="flex flex-col gap-4 pr-1">
+                    {modelStats.length === 0 ? (
+                    <div className="flex flex-col items-center justify-center py-12 text-slate-400 bg-slate-50 dark:bg-slate-900/50 rounded-lg border border-dashed border-slate-300 dark:border-slate-700">
+                        <span className="mb-3">No benchmarks match your current filters.</span>
+                        <button 
+                            onClick={clearFilters}
+                            className="text-blue-500 hover:text-blue-400 hover:underline text-sm flex items-center gap-1 font-medium"
+                        >
+                            <RotateCcw size={14} /> Clear all filters
+                        </button>
+                    </div>
+                ) : (
+                    Object.entries(groupedStats).map(([groupKey, stats]) => {
+                        const isAllSelected = stats.every(s => selectedBenchmarks.has(s.benchmarkKey));
+                        return (
+                        <div key={groupKey} className="flex flex-col gap-2">
+                            {groupBy !== 'None' && (
+                                <div className="sticky top-0 z-10 bg-slate-100/90 dark:bg-slate-800/90 backdrop-blur py-1.5 px-3 rounded text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider border-y border-slate-200 dark:border-slate-700/50 flex items-center gap-3">
+                                    <div 
+                                        onClick={(e) => {
+                                            e.stopPropagation();
+                                            toggleGroup(stats, isAllSelected);
+                                        }}
+                                        className="w-5 h-5 flex-shrink-0 flex items-center justify-center cursor-pointer transition-colors"
+                                    >
+                                        <div className={`w-4 h-4 rounded-full flex items-center justify-center border transition-all ${
+                                            isAllSelected ? 'bg-blue-500 border-blue-500 text-white' : 'bg-white dark:bg-slate-800 border-slate-300 dark:border-slate-600'
+                                        }`}>
+                                            {isAllSelected && <Check size={10} strokeWidth={3} />}
+                                        </div>
+                                    </div>
+                                    {groupKey}
+                                </div>
+                            )}
+                            
+                            <div className="flex flex-col gap-2">
+                                {stats.map(stat => {
+                                    const isSelected = selectedBenchmarks.has(stat.benchmarkKey);
+                                    const isExpanded = expandedModels.has(stat.benchmarkKey || stat.model);
+                                    const isBaseline = stat.benchmarkKey === baselineBenchmarkKey;
+                                    
+                                    const benchmarkData = stat.data || [];
+                                    const meta = benchmarkData[0]?.metadata || {};
+                                    const sourceStr = benchmarkData[0]?.source || '';
+                                    const isBrv02 = sourceStr.startsWith('brv02:');
+                                    const runId = isBrv02 ? sourceStr.replace('brv02:', '') : null;
+                                    const tp = getEffectiveTp(benchmarkData[0]) || '-';
+                                    
+                                    const uniqueIsl = [...new Set(benchmarkData.map(d => getBucket(d.isl || d.workload?.input_tokens)))];
+                                    const uniqueOsl = [...new Set(benchmarkData.map(d => getBucket(d.osl || d.workload?.output_tokens)))];
+                                    
+                                    const isl = uniqueIsl.length === 1 ? uniqueIsl[0] : (uniqueIsl.length > 1 ? 'Var' : '-');
+                                    const osl = uniqueOsl.length === 1 ? uniqueOsl[0] : (uniqueOsl.length > 1 ? 'Var' : '-');
+
+                                    return (
+                                        <div 
+                                            key={stat.benchmarkKey || stat.model}
+                                            className={`flex flex-col bg-white dark:bg-slate-900 border rounded-lg overflow-hidden transition-all shadow-sm ${
+                                                isSelected 
+                                                    ? 'border-blue-400 dark:border-blue-600 ring-1 ring-blue-400 dark:ring-blue-600/50' 
+                                                    : 'border-slate-200 dark:border-slate-700 hover:border-blue-300 dark:hover:border-blue-700'
+                                            } ${isBaseline ? 'ring-2 ring-cyan-400/50' : ''}`}
+                                        >
+                                            {/* Card Main Row (Header) */}
+                                            <div className="flex items-stretch min-h-[60px]">
+                                                {/* Left Checkbox Area (Dedicated Click Target) */}
+                                                <div 
+                                                    onPointerDown={(e) => handleCheckboxPointerDown(e, stat.benchmarkKey, isSelected)}
+                                                    className={`benchmark-checkbox-area w-12 flex-shrink-0 flex items-center justify-center cursor-pointer border-r transition-colors select-none ${
+                                                        isSelected 
+                                                            ? 'bg-blue-50 dark:bg-blue-900/20 border-blue-200 dark:border-blue-800' 
+                                                            : 'bg-slate-50 dark:bg-slate-800/50 border-slate-100 dark:border-slate-800 hover:bg-slate-100 dark:hover:bg-slate-700/50'
+                                                    }`}
+                                                    data-benchmark-key={stat.benchmarkKey}
+                                                    style={{ touchAction: 'none' }}
+                                                >
+                                                    <div className={`w-5 h-5 rounded flex items-center justify-center border transition-all ${
+                                                        isSelected ? 'bg-blue-500 border-blue-500 text-white' : 'bg-white dark:bg-slate-800 border-slate-300 dark:border-slate-600'
+                                                    }`}>
+                                                        {isSelected && <Check size={14} strokeWidth={3} />}
+                                                    </div>
+                                                </div>
+
+                                                {/* Card Content Area (Expand Toggle) */}
+                                                <div 
+                                                    onClick={() => toggleModelExpansion(stat.benchmarkKey || stat.model)}
+                                                    className="flex-1 flex items-center justify-between p-3 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors gap-3"
+                                                >
+                                                    {/* Left side info block */}
+                                                    <div className="flex-1 flex flex-wrap sm:flex-nowrap items-center gap-4 min-w-0">
+                                                        {/* Specs list container */}
+                                                        {(() => {
+                                                            let nodesAndParallelismText = '';
+                                                            if (meta.prefill_node_count > 0 || meta.decode_node_count > 0) {
+                                                                const totalNodes = (meta.prefill_node_count || 0) + (meta.decode_node_count || 0);
+                                                                const config = meta.configuration || '';
+                                                                const pTpMatch = config.match(/(\d+)P-TP(\d+)/i);
+                                                                const dTpMatch = config.match(/(\d+)D-TP(\d+)/i);
+                                                                const pTp = pTpMatch ? pTpMatch[2] : '?';
+                                                                const dTp = dTpMatch ? dTpMatch[2] : '?';
+                                                                nodesAndParallelismText = `${totalNodes} nodes (P:${meta.prefill_node_count}-TP${pTp} | D:${meta.decode_node_count}-TP${dTp})`;
+                                                            } else {
+                                                                const totalNodes = stat.node_count || stat.accelerator_count || 1;
+                                                                const displayTp = tp !== '-' ? tp : (getEffectiveTp(stat) || '');
+                                                                nodesAndParallelismText = `${totalNodes} node${totalNodes > 1 ? 's' : ''}${displayTp && displayTp !== '-' ? ` (${displayTp})` : ''}`;
+                                                            }
+
+                                                            const peakRun = benchmarkData.reduce((prev, curr) => {
+                                                                const prevVal = prev?.metrics?.output_tput || prev?.throughput || 0;
+                                                                const currVal = curr?.metrics?.output_tput || curr?.throughput || 0;
+                                                                return currVal > prevVal ? curr : prev;
+                                                            }, benchmarkData[0] || {});
+
+                                                             const specs = [];
+
+                                                             if (visibleSpecs.timestamp) {
+                                                                 const timestampVal = benchmarkData[0]?.timestamp;
+                                                                 if (timestampVal) {
+                                                                     const d = new Date(timestampVal);
+                                                                     if (!isNaN(d.getTime())) {
+                                                                         specs.push(
+                                                                             <span key="timestamp" className="inline-flex items-center gap-1">
+                                                                                 <span className="text-slate-400 dark:text-slate-500 font-normal">Date:</span>
+                                                                                 <span className="font-semibold text-slate-700 dark:text-slate-300">
+                                                                                     {d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' })}
+                                                                                 </span>
+                                                                             </span>
+                                                                         );
+                                                                     }
+                                                                 }
+                                                             }
+
+                                                             if (visibleSpecs.hardware) {
+                                                                specs.push(
+                                                                    <span key="hardware" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Hardware:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{stat.accelerator_count}x {stat.hardware}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.nodes) {
+                                                                specs.push(
+                                                                    <span key="nodes" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Nodes:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{nodesAndParallelismText}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.islOsl) {
+                                                                specs.push(
+                                                                    <span key="islOsl" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">I/O Load:</span>
+                                                                        <span className="font-mono font-semibold text-slate-700 dark:text-slate-300">{isl}/{osl}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.maxTput) {
+                                                                specs.push(
+                                                                    <span key="maxTput" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Max Tput:</span>
+                                                                        <span className="font-bold text-green-600 dark:text-green-400">{stat.maxTput.toFixed(0)} <span className="text-[10px] font-normal opacity-70">tok/s</span></span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.minLat) {
+                                                                specs.push(
+                                                                    <span key="minLat" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Min Lat:</span>
+                                                                        <span className="font-semibold text-amber-600 dark:text-amber-400">{stat.minLat ? `${stat.minLat.toFixed(0)} ms` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.qps) {
+                                                                const qpsVal = peakRun.metrics?.request_rate || peakRun.qps;
+                                                                specs.push(
+                                                                    <span key="qps" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">QPS:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{qpsVal != null ? qpsVal.toFixed(2) : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.inputTput) {
+                                                                const inVal = peakRun.metrics?.input_tput;
+                                                                specs.push(
+                                                                    <span key="inputTput" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Input Tput:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{inVal != null ? `${inVal.toFixed(0)} tok/s` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.outputTput) {
+                                                                const outVal = peakRun.metrics?.output_tput || peakRun.throughput;
+                                                                specs.push(
+                                                                    <span key="outputTput" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Output Tput:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{outVal != null ? `${outVal.toFixed(0)} tok/s` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.totalTput) {
+                                                                const totVal = peakRun.metrics?.total_tput;
+                                                                specs.push(
+                                                                    <span key="totalTput" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Total Tput:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{totVal != null ? `${totVal.toFixed(0)} tok/s` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.ntpot) {
+                                                                const ntpotVal = peakRun.metrics?.ntpot || peakRun.ntpot;
+                                                                specs.push(
+                                                                    <span key="ntpot" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">NTPOT:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{ntpotVal != null ? `${ntpotVal.toFixed(2)} ms` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.tpot) {
+                                                                const tpotVal = peakRun.metrics?.tpot || peakRun.time_per_output_token;
+                                                                specs.push(
+                                                                    <span key="tpot" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">TPOT:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{tpotVal != null ? `${tpotVal.toFixed(2)} ms` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.itl) {
+                                                                const itlVal = peakRun.metrics?.itl || peakRun.itl;
+                                                                specs.push(
+                                                                    <span key="itl" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">ITL:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{itlVal != null ? `${itlVal.toFixed(2)} ms` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.ttft) {
+                                                                const ttftVal = peakRun.metrics?.ttft?.mean || peakRun.ttft?.mean;
+                                                                specs.push(
+                                                                    <span key="ttft" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">TTFT:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{ttftVal != null ? `${ttftVal.toFixed(2)} ms` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.e2e) {
+                                                                const e2eVal = (peakRun.metrics?.e2e_latency || peakRun.latency?.mean);
+                                                                specs.push(
+                                                                    <span key="e2e" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">E2E Latency:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{e2eVal != null ? `${(e2eVal / 1000).toFixed(2)} s` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.costIn) {
+                                                                const costInVal = peakRun.metrics?.cost?.explicit_input;
+                                                                specs.push(
+                                                                    <span key="costIn" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Cost/1M In:</span>
+                                                                        <span className="font-semibold text-slate-500">{costInVal > 0 ? `$${costInVal.toFixed(4)}` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.costOut) {
+                                                                const costOutVal = peakRun.metrics?.cost?.explicit_output;
+                                                                specs.push(
+                                                                    <span key="costOut" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Cost/1M Out:</span>
+                                                                        <span className="font-semibold text-slate-500">{costOutVal > 0 ? `$${costOutVal.toFixed(4)}` : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.inputLen) {
+                                                                const inLenVal = peakRun.isl || peakRun.workload?.input_tokens;
+                                                                specs.push(
+                                                                    <span key="inputLen" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Input Len:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{inLenVal != null ? inLenVal.toFixed(0) : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            if (visibleSpecs.outputLen) {
+                                                                const outLenVal = peakRun.osl || peakRun.workload?.output_tokens;
+                                                                specs.push(
+                                                                    <span key="outputLen" className="inline-flex items-center gap-1">
+                                                                        <span className="text-slate-400 dark:text-slate-500 font-normal">Output Len:</span>
+                                                                        <span className="font-semibold text-slate-700 dark:text-slate-300">{outLenVal != null ? outLenVal.toFixed(0) : '-'}</span>
+                                                                    </span>
+                                                                );
+                                                            }
+
+                                                            return (
+                                                                <div className="flex-1 flex flex-col min-w-0">
+                                                                    {/* Line 1: Model Title on left, Source Tag & Date on right */}
+                                                                    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-1 w-full">
+                                                                        <div className="flex items-center gap-2 min-w-0 flex-1">
+                                                                            {editingRunId === runId && isBrv02 ? (
+                                                                                <div className="flex-1 flex flex-col gap-0.5 min-w-0" onClick={e => e.stopPropagation()}>
+                                                                                    <input
+                                                                                        autoFocus
+                                                                                        value={editingValue}
+                                                                                        onChange={e => setEditingValue(e.target.value)}
+                                                                                        onBlur={commitEdit}
+                                                                                        onKeyDown={e => {
+                                                                                            if (e.key === 'Enter') commitEdit();
+                                                                                            if (e.key === 'Escape') cancelEdit();
+                                                                                        }}
+                                                                                        className="w-full text-sm font-medium bg-white dark:bg-slate-800 border border-cyan-400 rounded px-1.5 py-0.5 text-slate-800 dark:text-slate-200 focus:outline-none"
+                                                                                    />
+                                                                                </div>
+                                                                            ) : (
+                                                                                <div className="flex items-center gap-1 min-w-0">
+                                                                                    <span className="font-bold text-sm sm:text-base text-slate-800 dark:text-slate-100 truncate">
+                                                                                        {isBrv02 && brv02CustomLabels && brv02CustomLabels[runId] 
+                                                                                            ? brv02CustomLabels[runId] 
+                                                                                            : (stat.model_name || stat.model || meta.model_name)}
+                                                                                    </span>
+                                                                                    {isBrv02 && (
+                                                                                        <button
+                                                                                            onClick={(e) => {
+                                                                                                e.stopPropagation();
+                                                                                                setEditingRunId(runId);
+                                                                                                setEditingValue(brv02CustomLabels[runId] || (stat.model_name || stat.model || meta.model_name));
+                                                                                            }}
+                                                                                            title="Rename run"
+                                                                                            className="p-1 text-slate-300 dark:text-slate-600 hover:text-cyan-400 transition-colors flex-shrink-0"
+                                                                                        >
+                                                                                            <Pencil size={12} />
+                                                                                        </button>
+                                                                                    )}
+                                                                                </div>
+                                                                            )}
+                                                                            <button
+                                                                                onClick={(e) => {
+                                                                                    e.stopPropagation();
+                                                                                    toggleBaseline(stat.benchmarkKey);
+                                                                                }}
+                                                                                title={isBaseline ? 'Clear baseline' : 'Set as baseline'}
+                                                                                className={`p-1 rounded-full transition-colors flex-shrink-0 ${
+                                                                                    isBaseline
+                                                                                        ? 'text-cyan-500 bg-cyan-50 dark:bg-cyan-900/20'
+                                                                                        : 'text-slate-300 dark:text-slate-600 hover:text-cyan-500 hover:bg-slate-100 dark:hover:bg-slate-700'
+                                                                                }`}
+                                                                            >
+                                                                                <Star size={16} fill={isBaseline ? 'currentColor' : 'none'} />
+                                                                            </button>
+                                                                            {isBrv02 && (
+                                                                                <button
+                                                                                    onClick={(e) => {
+                                                                                        e.stopPropagation();
+                                                                                        if (removeBrv02Run) {
+                                                                                            removeBrv02Run(runId);
+                                                                                        }
+                                                                                    }}
+                                                                                    title="Delete run"
+                                                                                    className="p-1 rounded text-slate-300 hover:text-red-500 dark:text-slate-600 dark:hover:text-red-400 transition-colors flex-shrink-0"
+                                                                                >
+                                                                                    <Trash2 size={14} />
+                                                                                </button>
+                                                                            )}
+                                                                        </div>
+                                                                        <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 flex-shrink-0">
+                                                                             <span className="text-[10px] sm:text-xs bg-slate-100 dark:bg-slate-800/80 px-1.5 py-0.5 rounded border border-slate-200 dark:border-slate-700/80 text-slate-500 dark:text-slate-400 font-semibold whitespace-nowrap">
+                                                                                 {getSourceTag(benchmarkData[0])}
+                                                                             </span>
+                                                                             {(() => {
+                                                                                 const type = getSourceType(benchmarkData[0]);
+                                                                                 const style = getSourceTypeStyle(type);
+                                                                                 return (
+                                                                                     <span className={`text-[10px] sm:text-xs font-semibold px-1.5 py-0.5 rounded border whitespace-nowrap ${style.bg} ${style.text} ${style.border}`}>
+                                                                                         {type}
+                                                                                     </span>
+                                                                                 );
+                                                                             })()}
+                                                                        </div>
+                                                                    </div>
+
+                                                                    {/* Line 2: Dedicated to just selected visible stats */}
+                                                                    {specs.length > 0 && (
+                                                                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 mt-1.5 text-xs text-slate-500 dark:text-slate-400 font-medium">
+                                                                            {specs.map((spec, sIdx) => {
+                                                                                const showDot = sIdx > 0;
+                                                                                return (
+                                                                                    <React.Fragment key={spec.key}>
+                                                                                        {showDot && <span className="text-slate-300 dark:text-slate-700 select-none font-bold">·</span>}
+                                                                                        {spec}
+                                                                                    </React.Fragment>
+                                                                                );
+                                                                            })}
+                                                                        </div>
+                                                                    )}
+                                                                </div>
+                                                            );
+                                                        })()}
+                                                    </div>
+
+                                                    {/* Right side expand icon */}
+                                                    <div className="flex-shrink-0 text-slate-400 flex items-center justify-center w-6 h-6 ml-2">
+                                                        {isExpanded ? <ChevronUp size={20} /> : <ChevronDown size={20} />}
+                                                    </div>
+                                                </div>
+                                            </div>
+
+                                            {/* Expanded Table Details */}
+                                            {isExpanded && (
+                                                <div className="border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/30 p-4">
+                                                     <div className="mb-3 px-2 text-[10px] sm:text-xs text-slate-500 font-mono flex flex-wrap gap-x-4 gap-y-1 items-center bg-white dark:bg-slate-800 py-2 px-3 rounded border border-slate-200 dark:border-slate-700 shadow-sm">
+                                                         {(() => {
+                                                             const displayRunId = (benchmarkData[0]?.run_id !== undefined && benchmarkData[0]?.run_id !== null && benchmarkData[0]?.run_id !== '')
+                                                                 ? benchmarkData[0].run_id 
+                                                                 : benchmarkData[0]?.id;
+                                                             if (displayRunId === undefined || displayRunId === null || displayRunId === '') return null;
+                                                             return (
+                                                                 <span className="flex items-center gap-1">
+                                                                     <b className="text-slate-700 dark:text-slate-300">Run ID:</b> 
+                                                                     <span className="select-all opacity-75">{displayRunId}</span>
+                                                                 </span>
+                                                             );
+                                                         })()}
+                                                         {benchmarkData[0]?.source_info?.file_identifier && (
+                                                            <span className="flex items-center gap-1 ml-auto">
+                                                                <b className="text-slate-700 dark:text-slate-300">File:</b> 
+                                                                <span>{benchmarkData[0].source_info.file_identifier.split('/').pop()}</span>
+                                                            </span>
+                                                        )}
+                                                    </div>
+
+                                                    <div className="overflow-x-auto rounded border border-slate-200 dark:border-slate-700">
+                                                        <table className="w-full text-left text-slate-600 dark:text-slate-300 text-xs bg-white dark:bg-slate-800">
+                                                            <thead className="bg-slate-100 dark:bg-slate-700/50 text-slate-700 dark:text-slate-100 uppercase text-[10px] font-medium border-b border-slate-200 dark:border-slate-700">
+                                                                <tr>
+                                                                    <th className="px-4 py-2">QPS</th>
+                                                                    <th className="px-2 py-2">Input Tok/s</th>
+                                                                    <th className="px-2 py-2">Output Tok/s</th>
+                                                                    <th className="px-2 py-2">Total Tok/s</th>
+                                                                    <th className="px-2 py-2">NTPOT (ms)</th>
+                                                                    <th className="px-2 py-2">TPOT (ms)</th>
+                                                                    <th className="px-2 py-2">ITL (ms)</th>
+                                                                    <th className="px-2 py-2">TTFT (ms)</th>
+                                                                    <th className="px-2 py-2">E2E (s)</th>
+                                                                    <th className="px-2 py-2">Cost/1M In ($)</th>
+                                                                    <th className="px-2 py-2">Cost/1M Out ($)</th>
+                                                                    <th className="px-2 py-2">Input Len</th>
+                                                                    <th className="px-2 py-2">Output Len</th>
+                                                                </tr>
+                                                            </thead>
+                                                            <tbody className="divide-y divide-slate-100 dark:divide-slate-700/50">
+                                                                {benchmarkData.map((d, index) => (
+                                                                    <tr key={index} className="hover:bg-slate-50 dark:hover:bg-slate-700/30">
+                                                                        <td className="px-4 py-2 font-mono">{d.metrics?.request_rate?.toFixed(2) || d.qps?.toFixed(2) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono">{d.metrics?.input_tput?.toFixed(0) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono">{d.metrics?.output_tput?.toFixed(0) || d.throughput?.toFixed(0) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono font-medium">{d.metrics?.total_tput?.toFixed(0) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.ntpot?.toFixed(2) || d.ntpot?.toFixed(2) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.tpot?.toFixed(2) || d.time_per_output_token?.toFixed(2) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.itl?.toFixed(2) || d.itl?.toFixed(2) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.ttft?.mean?.toFixed(2) || d.ttft?.mean?.toFixed(2) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono text-[10px]">{((d.metrics?.e2e_latency || d.latency?.mean) / 1000)?.toFixed(2) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono text-[10px] text-slate-500">
+                                                                            {d.metrics?.cost?.explicit_input > 0 ? `$${d.metrics.cost.explicit_input.toFixed(4)}` : '-'}
+                                                                        </td>
+                                                                        <td className="px-2 py-2 font-mono text-[10px] text-slate-500">
+                                                                            {d.metrics?.cost?.explicit_output > 0 ? `$${d.metrics.cost.explicit_output.toFixed(4)}` : '-'}
+                                                                        </td>
+                                                                        <td className="px-2 py-2 font-mono text-[10px]">{d.isl?.toFixed(0) || d.workload?.input_tokens?.toFixed(0) || '-'}</td>
+                                                                        <td className="px-2 py-2 font-mono text-[10px]">{d.osl?.toFixed(0) || d.workload?.output_tokens?.toFixed(0) || '-'}</td>
+                                                                    </tr>
+                                                                ))}
+                                                            </tbody>
+                                                        </table>
+                                                    </div>
+                                                </div>
+                                            )}
+                                        </div>
+                                    );
+                                })}
+                            </div>
+                        </div>
+                        );
+                    })
+                )}
+                </div>
+            </div>
+            {dragBox && (
+                <div
+                    style={{
+                        position: 'fixed',
+                        left: Math.min(dragBox.startX, dragBox.currentX),
+                        top: Math.min(dragBox.startY, dragBox.currentY),
+                        width: Math.abs(dragBox.currentX - dragBox.startX),
+                        height: Math.abs(dragBox.currentY - dragBox.startY),
+                        pointerEvents: 'none',
+                        zIndex: 9999,
+                        backgroundColor: 'rgba(59, 130, 246, 0.1)',
+                        border: '1px solid rgba(59, 130, 246, 0.4)',
+                        borderRadius: '2px',
+                    }}
+                />
+            )}
+        </div>
+    );
+};

--- a/src/config/defaultState.js
+++ b/src/config/defaultState.js
@@ -17,11 +17,8 @@ export const defaultState = {
     tputType: "output",
     costMode: "spot",
     latType: "e2e",
-    selectedModels: new Set([
-        "*::*::qwen3-32b::H100::*::*::Aggregated::*",
-        "*::*::qwen3-32b::TPU-V6E::*::*::Aggregated::*"
-    ]),
-    modelsFilter: new Set(["qwen3-32b"]),
+    selectedModels: new Set([]),
+    modelsFilter: new Set([]),
     hwFilter: new Set([]),
     precFilter: new Set([]),
     tpFilter: new Set([]),

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -37,9 +37,109 @@ export const useDashboardData = (initialState, dashboardState) => {
     const [lpgLoading, setLpgLoading] = useState(false);
     const [lpgError, setLpgError] = useState(null);
     const [lpgPasteText, setLpgPasteText] = useState("");
-    const [brv02Runs, setBrv02Runs] = useState([]);
+    const [brv02Runs, setBrv02Runs] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_brv02_runs');
+            return saved ? JSON.parse(saved) : [];
+        } catch { return []; }
+    });
     const [brv02Error, setBrv02Error] = useState(null);
-    const [brv02CustomLabels, setBrv02CustomLabels] = useState({});
+    const [brv02Loading, setBrv02Loading] = useState(false);
+    const [brv02CustomLabels, setBrv02CustomLabels] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_brv02_custom_labels');
+            return saved ? JSON.parse(saved) : {};
+        } catch { return {}; }
+    });
+    const [brv02BaselineRunId, setBrv02BaselineRunId] = useState(() => {
+        try {
+            return localStorage.getItem('prism_brv02_baseline_run_id') || null;
+        } catch { return null; }
+    });
+    const [brv02SelectedStages, setBrv02SelectedStages] = useState(() => {
+        try {
+            const saved = localStorage.getItem('prism_brv02_selected_stages');
+            return saved ? JSON.parse(saved) : {};
+        } catch { return {}; }
+    });
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_brv02_runs', JSON.stringify(brv02Runs));
+        } catch (e) {
+            console.error("Failed to persist brv02 runs to LocalStorage:", e);
+        }
+    }, [brv02Runs]);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_brv02_custom_labels', JSON.stringify(brv02CustomLabels));
+        } catch (e) {
+            console.error("Failed to persist brv02 custom labels to LocalStorage:", e);
+        }
+    }, [brv02CustomLabels]);
+
+    useEffect(() => {
+        try {
+            if (brv02BaselineRunId) {
+                localStorage.setItem('prism_brv02_baseline_run_id', brv02BaselineRunId);
+            } else {
+                localStorage.removeItem('prism_brv02_baseline_run_id');
+            }
+        } catch (e) {
+            console.error("Failed to persist brv02 baseline run ID to LocalStorage:", e);
+        }
+    }, [brv02BaselineRunId]);
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_brv02_selected_stages', JSON.stringify(brv02SelectedStages));
+        } catch (e) {
+            console.error("Failed to persist brv02 selected stages to LocalStorage:", e);
+        }
+    }, [brv02SelectedStages]);
+
+    useEffect(() => {
+        // Automatically sync all benchmark stage runs into the main scatter plot data array
+        const brv02Entries = brv02Runs.flatMap(run => run.stages.map(stageToEntry));
+        const runSourceKeys = brv02Runs.map(r => `brv02:${r.runId}`);
+
+        setData(prev => {
+            const nonBrv02Data = prev.filter(d => !d.source?.startsWith('brv02:'));
+            const startId = nonBrv02Data.length;
+            const entriesWithIds = brv02Entries.map((e, i) => ({ ...e, id: startId + i }));
+            return [...nonBrv02Data, ...entriesWithIds];
+        });
+
+        if (runSourceKeys.length > 0) {
+            setAvailableSources(prev => {
+                const next = new Set(prev);
+                runSourceKeys.forEach(k => next.add(k));
+                return next;
+            });
+
+            setSelectedSources(prev => {
+                const next = new Set(prev);
+                runSourceKeys.forEach(k => next.add(k));
+                return next;
+            });
+        } else {
+            setAvailableSources(prev => {
+                const next = new Set(prev);
+                Array.from(next).forEach(k => {
+                    if (k.startsWith('brv02:')) next.delete(k);
+                });
+                return next;
+            });
+            setSelectedSources(prev => {
+                const next = new Set(prev);
+                Array.from(next).forEach(k => {
+                    if (k.startsWith('brv02:')) next.delete(k);
+                });
+                return next;
+            });
+        }
+    }, [brv02Runs]);
     const [driveLoading, setDriveLoading] = useState(false);
     const [driveStatus, setDriveStatus] = useState("");
     const [driveProgress, setDriveProgress] = useState(0);
@@ -989,121 +1089,21 @@ export const useDashboardData = (initialState, dashboardState) => {
                 } else if (newD.metadata?.configuration && newD.metadata.configuration !== 'Unknown') {
                     // Use hardware config (e.g. from standalone/modelservice parser)
                     suffix = ` [${newD.metadata.configuration}]`;
-                } else if (newD.configuration && newD.configuration !== 'Unknown') {
-                    suffix = ` [${newD.configuration}]`;
                 }
-
                 if (suffix) {
-                    newD.model += suffix;
-                    console.log(`[fetchArchivedData] Appended config suffix to model: ${newD.model}`);
+                    newD.model = newD.model + suffix;
+                    newD.model_name = newD.model_name + suffix;
+                    newD.metadata.model_name = newD.metadata.model_name + suffix;
                 }
-
-                newD.model_name = normalizeModelName(newD.metadata.model_name || newD.model_name || 'Unknown'); // Critical for filter dropdowns
-                newD.hardware = normalizeHardware(newD.metadata.hardware || newD.hardware || 'Unknown');
-                newD.accelerator_count = newD.metadata.accelerator_count || newD.accelerator_count || 1;
-                newD.metadata.tensor_parallelism = newD.metadata.tensor_parallelism || 8;
-                newD.tensor_parallelism = newD.metadata.tensor_parallelism;
-                newD.tp = newD.tensor_parallelism; // Sync for helpers
-
-                newD.backend = newD.metadata.backend || 'Unknown';
-                // Map variant to configuration for specialized grouping in Dashboard.jsx
-                if (newD.metadata.variant) {
-                    newD.configuration = newD.metadata.variant;
-                }
-
-                // Associate all results store benchmarks with llm-d serving stack
-                newD.serving_stack = 'llm-d';
-                newD.metadata.serving_stack = 'llm-d';
 
                 return newD;
             });
         } catch (e) {
-            console.warn("Failed to load archived drive data", e);
+            console.error("Failed to load archived data", e);
             return [];
         }
-    };
+    }
 
-    // --- Extracted Block ---
-    const restoreSampleData = async () => {
-        setGcsLoading(true);
-        try {
-            const localEntries = await fetchLocalData();
-
-            if (!localEntries || localEntries.length === 0) {
-                setGcsLoading(false);
-                return false;
-            }
-
-            // Add to data
-            setData(prev => {
-                const next = [...prev, ...localEntries].map((d, i) => ({ ...d, id: i }));
-                return next;
-            });
-
-            // Update Sources
-            setAvailableSources(prev => new Set([...prev, 'local']));
-            setSelectedSources(prev => new Set([...prev, 'local'])); // Auto-select
-            setShowSampleData(true);
-
-            // Re-populate models for local data
-            const localModels = new Set(localEntries.map(d => d.model).filter(m => m !== 'Unknown'));
-            setSelectedBenchmarks(prev => {
-                const next = new Set(prev);
-                localModels.forEach(m => next.add(m));
-                return next;
-            });
-
-            setGcsLoading(false);
-            return true;
-        } catch (e) {
-            setGcsError(`Failed to restore sample data: ${e.message}`);
-            setGcsLoading(false);
-            return false;
-        }
-    };
-
-    const removeSampleData = () => {
-        // Remove 'local' source entries from data
-        setData(prev => prev.filter(d => d.source !== 'local'));
-
-        // Remove 'local' from selected and available sources
-        setSelectedSources(prev => {
-            const next = new Set(prev);
-            next.delete('local');
-            return next;
-        });
-        setAvailableSources(prev => {
-            const next = new Set(prev);
-            next.delete('local');
-            return next;
-        });
-
-        setShowSampleData(false);
-    };
-
-    const removeLLMDData = () => {
-        // Remove 'llmd_drive' (live syncs) and 'llm-d-results:google_drive' (archive) from data
-        setData(prev => prev.filter(d => d.source !== 'llmd_drive' && d.source !== 'llm-d-results:google_drive'));
-
-        // Remove from selected and available sources
-        setSelectedSources(prev => {
-            const next = new Set(prev);
-            next.delete('llmd_drive');
-            next.delete('llm-d-results:google_drive');
-            return next;
-        });
-        setAvailableSources(prev => {
-            const next = new Set(prev);
-            next.delete('llmd_drive');
-            next.delete('llm-d-results:google_drive');
-            return next;
-        });
-
-        // Also clean up any lingering local data if needed, but the main two cover the standard flows.
-        setEnableLLMDResults(false);
-    };
-
-    // --- Extracted Block ---
     const loadAllData = async (fetchedConfig = null) => {
         console.log("[useDashboardData] loadAllData START", { initialState });
         setLoading(true);
@@ -1316,211 +1316,59 @@ export const useDashboardData = (initialState, dashboardState) => {
                     validSources.add('quality_scores');
                 }
 
-                setAvailableSources(validSources);
-
-                if (initialState.sources && initialState.sources.size > 0 && !initialState.sources.has('local')) {
-                    const allowed = new Set();
-                    validSources.forEach(vs => {
-                        if (initialState.sources.has(vs)) {
-                            allowed.add(vs);
-                        } else if (vs.startsWith('giq') && initialState.sources.has('giq')) {
-                            allowed.add(vs);
-                        } else if (vs === 'llm-d-results:google_drive' || vs === 'quality_scores') {
-                            allowed.add(vs);
-                        }
-                    });
-                    setSelectedSources(prevSources => new Set([...prevSources, ...allowed]));
-                } else {
-                    setSelectedSources(prevSources => new Set([...prevSources, ...validSources]));
+                if (enableLLMDResults) {
+                    validSources.add('llmd_drive');
+                    validSources.add('llm-d-results:google_drive');
                 }
 
-                return prev; // We don't modify data here
+                setAvailableSources(prev => new Set([...prev, ...validSources]));
+                return prev;
             });
 
-            // Trigger auto-selection if current state is empty AND no initial defaults provided
-            const hasInitialModels = initialState.selectedModels && initialState.selectedModels.size > 0;
-            if (selectedBenchmarks.size === 0 && !hasInitialModels && dataWithIds.length > 0) {
-                const initialSelection = new Set();
-                const sourcesInNext = new Set(dataWithIds.map(d => d.source || 'local'));
-
-                sourcesInNext.forEach(src => {
-                    const sourceEntries = dataWithIds.filter(d => (d.source || 'local') === src);
-                    const sorted = sourceEntries.sort((a, b) => {
-                        if (!a.timestamp) return 1;
-                        if (!b.timestamp) return -1;
-                        return new Date(b.timestamp) - new Date(a.timestamp);
-                    });
-                    if (sorted.length > 0) initialSelection.add(getBenchmarkKey(sorted[0]));
-                });
-                setSelectedBenchmarks(initialSelection);
-            }
-
-            // Update max latency (using xAxisMax state)
-            const latencies = dataWithIds.map(d => d.latency?.mean).filter(l => l > 0);
-            if (latencies.length > 0) {
-                // Only update if it seems like a default (Infinity) or user hasn't set a specific low value
-                if (xAxisMax === Infinity) {
-                    setXAxisMax(Math.max(...latencies));
-                }
-            }
-
             if (failedSources.length > 0) {
-                setGcsError(`Failed to load data from: ${failedSources.join(', ')}`);
+                setGcsError(`Connection issue with: ${failedSources.join(', ')}`);
             }
-
-        } catch (err) {
-            console.error("Global Load Error:", err);
-            setGcsError(`Application Error: ${err.message}.`);
+        } catch (e) {
+            console.error("loadAllData Error:", e);
+            setGcsError(`Load failed: ${e.message}`);
         } finally {
             setLoading(false);
             setGcsLoading(false);
         }
     };
 
-    // --- Extracted Block ---
-    const handleLpgGcsScan = async (bucketUri) => {
-        const cleanUri = bucketUri.replace(/^gs:\/\//, '').replace(/\/$/, '');
-        const firstSlashIndex = cleanUri.indexOf('/');
-
-        let bucketName = cleanUri;
-        let prefix = '';
-        if (firstSlashIndex !== -1) {
-            bucketName = cleanUri.substring(0, firstSlashIndex);
-            prefix = cleanUri.substring(firstSlashIndex + 1);
-        }
-
-        let usingProxy = false;
-        let allItems = [];
-        let nextPageToken = null;
-
-        // Build base URL with optional prefix
-        let url = `https://storage.googleapis.com/storage/v1/b/${bucketName}/o`;
-        let proxyUrl = `/api/gcs/storage/v1/b/${bucketName}/o`;
-
-        const params = new URLSearchParams();
-        if (prefix) {
-            params.append('prefix', prefix.endsWith('/') ? prefix : prefix + '/');
-        }
-
+    const handleLpgGcsScan = async (bucketUrl) => {
         try {
-            do {
-                let fetchUrl = url;
-                let fetchProxyUrl = proxyUrl;
-
-                const currentParams = new URLSearchParams(params);
-                if (nextPageToken) {
-                    currentParams.append('pageToken', nextPageToken);
-                }
-
-                const queryStr = currentParams.toString();
-                if (queryStr) {
-                    fetchUrl += `?${queryStr}`;
-                    fetchProxyUrl += `?${queryStr}`;
-                }
-
-                let response = await fetch(fetchUrl);
-
-                if (response.status === 401 || response.status === 403) {
-                    response = await fetch(fetchProxyUrl);
-                    if (response.ok) {
-                        usingProxy = true;
-                    }
-                }
-
-                if (response.status === 404) {
-                    throw new Error(`Bucket '${bucketName}' not found or does not exist.`);
-                } else if (!response.ok) {
-                    throw new Error(`Failed to access bucket: HTTP ${response.status}`);
-                }
-
-                const json = await response.json();
-                if (json.items) {
-                    allItems = allItems.concat(json.items);
-                }
-
-                nextPageToken = json.nextPageToken;
-            } while (nextPageToken);
-        } catch (error) {
-            throw error;
+            console.log(`[useDashboardData] GCS Scanning ${bucketUrl}...`);
+            const cleanUrl = bucketUrl.replace(/^gs:\/\//, '').replace(/\/$/, '');
+            const response = await fetch(`/api/gcs/scan?bucket=${cleanUrl}`);
+            if (response.ok) {
+                const results = await response.json();
+                return results;
+            } else {
+                const errorText = await response.text();
+                throw new Error(errorText || `HTTP ${response.status}`);
+            }
+        } catch (e) {
+            console.error("GCS Scan Failed:", e);
+            throw e;
         }
-
-        if (allItems.length === 0) throw new Error('No files found in bucket or folder.');
-
-        const prefixDir = prefix ? (prefix.endsWith('/') ? prefix : prefix + '/') : '';
-
-        // Determine if the prefix itself is a leaf node benchmark
-        // A leaf node contains the actual metric files we want to parse.
-        const isLeafNode = prefixDir !== '' && allItems.some(item => {
-            const relName = item.name.substring(prefixDir.length);
-            return relName.endsWith('lifecycle_metrics.json') ||
-                relName.endsWith('manifest.yaml') ||
-                relName === 'metadata.json' ||
-                relName === 'params.json' ||
-                relName.startsWith('output/') ||
-                relName.startsWith('logs/') ||
-                relName.startsWith('results/') ||
-                (relName.indexOf('/') === -1 && relName.endsWith('.json'));
-        });
-
-        // Group files by relative top-level folder
-        const folders = {};
-
-        if (isLeafNode) {
-            const singleFolderName = prefix.split('/').filter(Boolean).pop() || prefixDir;
-            folders[singleFolderName] = allItems;
-        } else {
-            allItems.forEach(item => {
-                let relativeName = item.name;
-                if (prefixDir && relativeName.startsWith(prefixDir)) {
-                    relativeName = relativeName.substring(prefixDir.length);
-                }
-
-                const parts = relativeName.split('/');
-
-                let folder;
-                if (parts.length > 1) {
-                    folder = parts[0];
-                } else {
-                    folder = prefix ? prefix.split('/').filter(Boolean).pop() : 'root';
-                }
-
-                if (!folders[folder]) folders[folder] = [];
-                folders[folder].push(item);
-            });
-        }
-
-        let folderNames = Object.keys(folders);
-        if (folderNames.length === 0) throw new Error('No files found.');
-
-        // Sort folders by most recent 'updated' timestamp of any file inside them
-        folderNames = folderNames.sort((a, b) => {
-            const latestA = Math.max(...folders[a].map(f => new Date(f.updated || 0).getTime()));
-            const latestB = Math.max(...folders[b].map(f => new Date(f.updated || 0).getTime()));
-            return latestB - latestA; // descending
-        });
-
-        return { folders, folderNames, cleanBucketName: bucketName, usingProxy };
     };
 
-    const handleLpgGcsLoad = async (bucketUri, foldersToLoad, foldersMap, usingProxy) => {
-        console.log("handleLpgGcsLoad CALLED with:", bucketUri);
-        if (!bucketUri) return;
+    const handleLpgGcsLoad = async (bucketUrl, folderNames, folders, usingProxy) => {
         setLpgLoading(true);
         setLpgError(null);
-
-        const cleanUri = bucketUri.replace(/^gs:\/\//, '').replace(/\/$/, '');
-        const firstSlashIndex = cleanUri.indexOf('/');
-        const cleanBucketName = firstSlashIndex !== -1 ? cleanUri.substring(0, firstSlashIndex) : cleanUri;
-        let allNewEntries = [];
         let folderCount = 0;
+        let allNewEntries = [];
 
         try {
-            console.log("handleLpgGcsLoad STARTING TRY BLOCK for:", cleanBucketName);
+            const cleanBucketName = bucketUrl.replace(/^gs:\/\//, '').replace(/\/$/, '');
+            const cleanUri = bucketUrl.replace(/\/$/, '');
 
-            await Promise.all(foldersToLoad.map(async (folder) => {
+            // Process folders in parallel
+            await Promise.all(folderNames.map(async (folder) => {
                 try {
-                    const files = foldersMap[folder];
-
+                    const files = folders[folder];
                     // Relaxed search: find manifest and metrics ANYWHERE within this logical leaf node folder
                     // i.e., "config/manifest.yaml" or "stage_4_lifecycle_metrics.json"
                     const manifestFile = files.find(f => f.name.endsWith('manifest.yaml'));
@@ -1642,7 +1490,6 @@ export const useDashboardData = (initialState, dashboardState) => {
         setLpgLoading(true);
         setLpgError(null);
         let allNewEntries = [];
-        let errors = 0;
         const newSourceKeys = [];
 
         try {
@@ -1667,8 +1514,6 @@ export const useDashboardData = (initialState, dashboardState) => {
                         };
                     });
                     allNewEntries.push(...entries);
-                } else {
-                    errors++;
                 }
             }
 
@@ -1689,7 +1534,7 @@ export const useDashboardData = (initialState, dashboardState) => {
                     return newSet;
                 });
                 setAvailableSources(prev => {
-                    const newSet = new Set(prev);
+                    const newSet = newSet(prev);
                     newSourceKeys.forEach(k => newSet.add(k));
                     return newSet;
                 });
@@ -1712,79 +1557,165 @@ export const useDashboardData = (initialState, dashboardState) => {
     // Benchmark Report v0.2 handlers
     // -------------------------------------------------------------------------
 
-    const handleBrv02Upload = async (event) => {
-        const files = event.target.files;
+    const handleBrv02Upload = async (eventOrFiles) => {
+        let files;
+        let isEvent = false;
+        if (eventOrFiles && eventOrFiles.target && eventOrFiles.target.files) {
+            files = Array.from(eventOrFiles.target.files);
+            isEvent = true;
+        } else if (Array.isArray(eventOrFiles)) {
+            files = eventOrFiles;
+        } else if (eventOrFiles) {
+            files = Array.from(eventOrFiles);
+        }
+
         if (!files || files.length === 0) return;
+        
+        setBrv02Loading(true);
         setBrv02Error(null);
 
-        const newStages = [];
-        let skipped = 0;
-        for (let i = 0; i < files.length; i++) {
-            const file = files[i];
-            const text = await file.text();
-            const record = parseReportV02(text, file.name);
-            if (record) {
-                newStages.push(record);
-            } else {
-                skipped++;
+        try {
+            const v02Pattern = /^benchmark_report_v0\.2.*\.ya?ml$/i;
+            const matchingFiles = [];
+
+            for (let i = 0; i < files.length; i++) {
+                const file = files[i];
+                if (v02Pattern.test(file.name)) {
+                    matchingFiles.push(file);
+                }
             }
+
+            if (matchingFiles.length === 0) {
+                setBrv02Error("No valid benchmark_report_v0.2 files found. Make sure the files start with version: '0.2' and match the 'benchmark_report_v0.2' filename prefix.");
+                if (isEvent && eventOrFiles.target) {
+                    eventOrFiles.target.value = '';
+                }
+                return;
+            }
+
+            const trulyNewStages = [];
+            for (let i = 0; i < matchingFiles.length; i++) {
+                const file = matchingFiles[i];
+                const text = await file.text();
+                const identifier = file.webkitRelativePath || file.relativePath || file.name;
+                const record = await parseReportV02(text, identifier);
+                if (record) {
+                    const isDupInBatch = trulyNewStages.some(s => s.filename === record.filename);
+                    const isDupInExisting = brv02Runs.some(run => 
+                        run.stages.some(existingStage => existingStage.filename === record.filename)
+                    );
+                    if (!isDupInBatch && !isDupInExisting) {
+                        trulyNewStages.push(record);
+                    }
+                }
+            }
+
+            if (trulyNewStages.length === 0) {
+                setBrv02Error('All selected files have already been uploaded.');
+                if (isEvent && eventOrFiles.target) {
+                    eventOrFiles.target.value = '';
+                }
+                return;
+            }
+
+            // Update comparison panel state
+            setBrv02Runs(prev => {
+                const allStages = [...prev.flatMap(run => run.stages), ...trulyNewStages];
+                return groupStagesIntoRuns(allStages);
+            });
+
+            if (isEvent && eventOrFiles.target) {
+                eventOrFiles.target.value = '';
+            }
+        } catch (e) {
+            console.error("Failed to upload local report files:", e);
+            setBrv02Error("Failed to upload report files. Make sure they are valid YAML files.");
+        } finally {
+            setBrv02Loading(false);
         }
+    };
 
-        if (newStages.length === 0) {
-            setBrv02Error('No valid benchmark_report_v0.2 files found. Make sure the files start with version: \'0.2\'.');
-            event.target.value = '';
-            return;
+    const restoreSampleData = async () => {
+        setGcsLoading(true);
+        try {
+            const localEntries = await fetchLocalData();
+
+            if (!localEntries || localEntries.length === 0) {
+                setGcsLoading(false);
+                return false;
+            }
+
+            // Add to data
+            setData(prev => {
+                const next = [...prev, ...localEntries].map((d, i) => ({ ...d, id: i }));
+                return next;
+            });
+
+            // Update Sources
+            setAvailableSources(prev => new Set([...prev, 'local']));
+            setSelectedSources(prev => new Set([...prev, 'local'])); // Auto-select
+            setShowSampleData(true);
+
+            // Re-populate models for local data
+            const localModels = new Set(localEntries.map(d => d.model).filter(m => m !== 'Unknown'));
+            setSelectedBenchmarks(prev => {
+                const next = new Set(prev);
+                localModels.forEach(m => next.add(m));
+                return next;
+            });
+
+            setGcsLoading(false);
+            return true;
+        } catch (e) {
+            setGcsError(`Failed to restore sample data: ${e.message}`);
+            setGcsLoading(false);
+            return false;
         }
+    };
 
-        // Deduplicate against existing stages by filename before updating state
-        const existingFilenames = new Set(
-            brv02Runs.flatMap(run => run.stages.map(s => s.filename))
-        );
-        const trulyNewStages = newStages.filter(s => !existingFilenames.has(s.filename));
+    const removeSampleData = () => {
+        // Remove 'local' source entries from data
+        setData(prev => prev.filter(d => d.source !== 'local'));
 
-        if (trulyNewStages.length === 0 && newStages.length > 0) {
-            setBrv02Error('All selected files have already been uploaded.');
-            event.target.value = '';
-            return;
-        }
-
-        // Update comparison panel state
-        setBrv02Runs(prev => {
-            const allStages = [...prev.flatMap(run => run.stages), ...trulyNewStages];
-            return groupStagesIntoRuns(allStages);
-        });
-
-        // Also push entries into the main data array so they appear in the
-        // scatter chart alongside all other data sources.
-        const newEntries = trulyNewStages.map(stageToEntry);
-        const newSourceKeys = [...new Set(newEntries.map(e => e.source))];
-        const startId = data.length;
-        const entriesWithIds = newEntries.map((e, i) => ({ ...e, id: startId + i }));
-
-        setData(prev => [...prev, ...entriesWithIds]);
+        // Remove 'local' from selected and available sources
         setSelectedSources(prev => {
             const next = new Set(prev);
-            newSourceKeys.forEach(k => next.add(k));
+            next.delete('local');
             return next;
         });
         setAvailableSources(prev => {
             const next = new Set(prev);
-            newSourceKeys.forEach(k => next.add(k));
+            next.delete('local');
             return next;
         });
 
-        if (skipped > 0) {
-            setBrv02Error(`${skipped} file(s) skipped — not valid v0.2 benchmark reports.`);
-        }
-        event.target.value = '';
+        setShowSampleData(false);
+    };
+
+    const removeLLMDData = () => {
+        // Remove 'llmd_drive' (live syncs) and 'llm-d-results:google_drive' (archive) from data
+        setData(prev => prev.filter(d => d.source !== 'llmd_drive' && d.source !== 'llm-d-results:google_drive'));
+
+        // Remove from selected and available sources
+        setSelectedSources(prev => {
+            const next = new Set(prev);
+            next.delete('llmd_drive');
+            next.delete('llm-d-results:google_drive');
+            return next;
+        });
+        setAvailableSources(prev => {
+            const next = new Set(prev);
+            next.delete('llmd_drive');
+            next.delete('llm-d-results:google_drive');
+            return next;
+        });
+
+        // Also clean up any lingering local data if needed, but the main two cover the standard flows.
+        setEnableLLMDResults(false);
     };
 
     const removeBrv02Run = (runId) => {
-        const sourceKey = `brv02:${runId}`;
         setBrv02Runs(prev => prev.filter(r => r.runId !== runId));
-        setData(prev => prev.filter(d => d.source !== sourceKey));
-        setSelectedSources(prev => { const next = new Set(prev); next.delete(sourceKey); return next; });
-        setAvailableSources(prev => { const next = new Set(prev); next.delete(sourceKey); return next; });
     };
 
     return {
@@ -1829,7 +1760,9 @@ export const useDashboardData = (initialState, dashboardState) => {
         expandedIntegration, setExpandedIntegration,
         awsBucketConfigs, setAwsBucketConfigs,
         fetchAWSBucketData, handleAddAWSBucket, removeAWSBucket,
-        brv02Runs, brv02Error, setBrv02Error, handleBrv02Upload, removeBrv02Run,
-        brv02CustomLabels, setBrv02CustomLabels
+        brv02Runs, brv02Error, setBrv02Error, brv02Loading, handleBrv02Upload, removeBrv02Run,
+        brv02CustomLabels, setBrv02CustomLabels,
+        brv02BaselineRunId, setBrv02BaselineRunId,
+        brv02SelectedStages, setBrv02SelectedStages
     };
 };

--- a/src/hooks/useDashboardState.js
+++ b/src/hooks/useDashboardState.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import { defaultState } from '../config/defaultState';
 
 export const getSharedState = () => {
@@ -84,7 +84,22 @@ export const useDashboardState = () => {
     // Chart configs
     const [xAxisMax, setXAxisMax] = useState(initialState.xAxisMax);
     const [showPerChip, setShowPerChip] = useState(initialState.showPerChip);
-    const [showSelectedOnly, setShowSelectedOnly] = useState(initialState.showSelectedOnly);
+    const [showSelectedOnly, setShowSelectedOnly] = useState(() => {
+        if (initialState.showSelectedOnly !== undefined && initialState.showSelectedOnly !== defaultState.showSelectedOnly) {
+            return initialState.showSelectedOnly;
+        }
+        try {
+            const saved = localStorage.getItem('prism_show_selected_only');
+            return saved !== null ? saved === 'true' : initialState.showSelectedOnly;
+        } catch { return initialState.showSelectedOnly; }
+    });
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_show_selected_only', showSelectedOnly.toString());
+        } catch (e) { console.warn(e); }
+    }, [showSelectedOnly]);
+
     const [showPareto, setShowPareto] = useState(initialState.showPareto);
     const [showLabels, setShowLabels] = useState(initialState.showLabels);
     const [showDataLabels, setShowDataLabels] = useState(initialState.showDataLabels);
@@ -100,7 +115,27 @@ export const useDashboardState = () => {
     const [qualityInspectOpen, setQualityInspectOpen] = useState(false);
 
     // Benchmark selection
-    const [selectedBenchmarks, setSelectedBenchmarks] = useState(initialState.selectedModels);
+    const [selectedBenchmarks, setSelectedBenchmarks] = useState(() => {
+        if (initialState.selectedModels && initialState.selectedModels.size > 0) return initialState.selectedModels;
+        try {
+            const saved = localStorage.getItem('prism_selected_benchmarks');
+            if (saved) {
+                return new Set(JSON.parse(saved));
+            }
+        } catch (e) {
+            console.warn("Failed to load selected benchmarks from local storage", e);
+        }
+        return initialState.selectedModels || new Set();
+    });
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_selected_benchmarks', JSON.stringify(Array.from(selectedBenchmarks)));
+        } catch (e) {
+            console.warn("Failed to save selected benchmarks to local storage", e);
+        }
+    }, [selectedBenchmarks]);
+
     // Baseline key — when set, the matching benchmark is highlighted on the
     // scatter chart and other points show a %diff badge in the tooltip.
     const [baselineBenchmarkKey, setBaselineBenchmarkKey] = useState(() => {
@@ -110,6 +145,16 @@ export const useDashboardState = () => {
             return saved || null;
         } catch { return null; }
     });
+
+    useEffect(() => {
+        try {
+            if (baselineBenchmarkKey) {
+                localStorage.setItem('baselineBenchmarkKey', baselineBenchmarkKey);
+            } else {
+                localStorage.removeItem('baselineBenchmarkKey');
+            }
+        } catch { /* ignore */ }
+    }, [baselineBenchmarkKey]);
 
     // Derive initial modelsFilter from selectedModels if modelsFilter is empty
     const deriveInitialModelsFilter = () => {
@@ -136,24 +181,60 @@ export const useDashboardState = () => {
     };
 
     // Active Filters
-    const [activeFilters, setActiveFilters] = useState({
-        models: deriveInitialModelsFilter(),
-        hardware: initialState.hwFilter || new Set(),
-        machines: initialState.machFilter || new Set(),
-        tp: initialState.tpFilter || new Set(),
-        precisions: initialState.precFilter || new Set(),
-        isl: initialState.islFilter || new Set(),
-        osl: initialState.oslFilter || new Set(),
-        ratio: initialState.ratioFilter || new Set(),
-        modelServer: initialState.msFilter || new Set(),
-        servingStack: initialState.ssFilter || new Set(),
-        components: initialState.compFilter || new Set(),
-        origins: initialState.originFilter || new Set(),
-        pdRatio: initialState.pdRatioFilter || new Set(),
-        acc_count: initialState.accFilter || new Set(),
-        useCase: initialState.ucFilter || new Set(),
-        optimizations: initialState.optFilter || new Set()
+    const [activeFilters, setActiveFilters] = useState(() => {
+        const defaultFilters = {
+            models: deriveInitialModelsFilter(),
+            hardware: initialState.hwFilter || new Set(),
+            machines: initialState.machFilter || new Set(),
+            tp: initialState.tpFilter || new Set(),
+            precisions: initialState.precFilter || new Set(),
+            isl: initialState.islFilter || new Set(),
+            osl: initialState.oslFilter || new Set(),
+            ratio: initialState.ratioFilter || new Set(),
+            modelServer: initialState.msFilter || new Set(),
+            servingStack: initialState.ssFilter || new Set(),
+            components: initialState.compFilter || new Set(),
+            origins: initialState.originFilter || new Set(),
+            connectionNames: new Set(),
+            pdRatio: initialState.pdRatioFilter || new Set(),
+            acc_count: initialState.accFilter || new Set(),
+            useCase: initialState.ucFilter || new Set(),
+            optimizations: initialState.optFilter || new Set()
+        };
+        
+        // If there are no initial state filters (e.g. from URL), try loading from local storage
+        if (!initialState.hwFilter && !initialState.machFilter && !initialState.tpFilter) {
+            try {
+                const savedStr = localStorage.getItem('prism_active_filters');
+                if (savedStr) {
+                    const saved = JSON.parse(savedStr);
+                    const loadedFilters = { ...defaultFilters };
+                    for (const key of Object.keys(saved)) {
+                        if (Array.isArray(saved[key])) {
+                            loadedFilters[key] = new Set(saved[key]);
+                        }
+                    }
+                    return loadedFilters;
+                }
+            } catch (e) {
+                console.warn("Failed to load active filters from local storage", e);
+            }
+        }
+        
+        return defaultFilters;
     });
+
+    useEffect(() => {
+        try {
+            const filtersToSave = {};
+            for (const key of Object.keys(activeFilters)) {
+                filtersToSave[key] = Array.from(activeFilters[key]);
+            }
+            localStorage.setItem('prism_active_filters', JSON.stringify(filtersToSave));
+        } catch (e) {
+            console.warn("Failed to save active filters to local storage", e);
+        }
+    }, [activeFilters]);
 
     const generateShareUrl = useCallback((
         bucketConfigs,

--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -54,12 +54,27 @@ const pct = (val) => {
 // Stage grouping (multiple files → one run) requires the directory name as
 // context, which will be available once the directory-picker upload path is
 // implemented.
-const deriveRunId = (doc) => doc.run?.uid || crypto.randomUUID();
+const deriveRunId = (doc, filename) => {
+    const uid = doc.run?.uid || crypto.randomUUID();
+    if (!filename || !filename.includes('/')) return uid;
+    
+    const parts = filename.split('/');
+    parts.pop(); // Remove the file name itself
+    const dirPrefix = parts.join('_');
+    
+    return `${dirPrefix}_${uid}`;
+};
 
 // Derive a human-readable label from scenario context so the user can tell
 // runs apart without seeing raw UUIDs or uninformative filenames.
 const deriveRunLabel = (doc, filename) => {
     if (doc.run?.description) return doc.run.description;
+
+    if (filename && filename.includes('/')) {
+        const pathParts = filename.split('/');
+        pathParts.pop(); // Remove the file name itself
+        return pathParts.join('/');
+    }
 
     // Build label from scenario: model · hardware · QPS · stage
     const stack = doc.scenario?.stack || [];
@@ -82,9 +97,9 @@ const deriveRunLabel = (doc, filename) => {
     if (parts.length > 0) return parts.join(' · ');
 
     // Last resort: filename stripped of the common prefix
-    return filename
-        .replace(/^benchmark_report_v0\.2,_/, '')
-        .replace(/\.yaml$/, '');
+    return (filename || "upload")
+        .replace(/^benchmark_report_v0\.2[,_]*/i, "")
+        .replace(/\.ya?ml$/i, "");
 };
 
 // ---------------------------------------------------------------------------
@@ -139,17 +154,43 @@ const deriveRunLabel = (doc, filename) => {
  *   } | null,
  * }
  */
+const extractComponents = (stack) => {
+    const components = [];
+    if (!Array.isArray(stack)) return components;
+    for (const c of stack) {
+        const label = String(c.metadata?.label || '');
+        const tool = String(c.standardized?.tool || '');
+        const kind = String(c.standardized?.kind || '');
+        
+        const isGateway = label.toLowerCase().includes('gateway') || tool.toLowerCase().includes('gateway') || kind.toLowerCase().includes('gateway');
+        const isScheduler = label.toLowerCase().includes('scheduler') || tool.toLowerCase().includes('scheduler') || kind.toLowerCase().includes('scheduler');
+        const isLws = label.toLowerCase().includes('lws') || label.toLowerCase().includes('leaderworkerset') || tool.toLowerCase().includes('lws') || tool.toLowerCase().includes('leaderworkerset');
+        
+        if (isGateway && !components.includes("Inference Gateway")) {
+            components.push("Inference Gateway");
+        }
+        if (isScheduler && !components.includes("Inference Scheduler")) {
+            components.push("Inference Scheduler");
+        }
+        if (isLws && !components.includes("LeaderWorkerSet")) {
+            components.push("LeaderWorkerSet");
+        }
+    }
+    return components;
+};
+
 export function parseReportV02(yamlText, filename) {
     let doc;
     try {
         doc = yaml.load(yamlText);
-    } catch (_) {
+    } catch {
         return null;
     }
     if (!doc || doc.version !== '0.2') return null;
 
     // --- Scenario ---
     const stack = doc.scenario?.stack || [];
+    const components = extractComponents(stack);
     const primaryComponent = (
         stack.find(c => c.standardized?.role === 'aggregate') ||
         stack.find(c => c.standardized?.role === 'decode') ||
@@ -243,7 +284,7 @@ export function parseReportV02(yamlText, filename) {
     }
 
     return {
-        runId: deriveRunId(doc),
+        runId: deriveRunId(doc, filename),
         runLabel: deriveRunLabel(doc, filename),
         filename,
         runUid: doc.run?.uid || null,
@@ -253,6 +294,7 @@ export function parseReportV02(yamlText, filename) {
         scenario,
         performance,
         observability,
+        components,
     };
 }
 
@@ -275,21 +317,37 @@ export function groupStagesIntoRuns(stageRecords) {
         if (!map.has(record.runId)) {
             map.set(record.runId, {
                 runId: record.runId,
-                runLabel: record.runLabel,
+                runLabel: record.runLabel || record.runId || "Unknown Run",
                 stages: [],
             });
         }
         map.get(record.runId).stages.push(record);
     }
+    
     // Sort stages within each run
-    for (const run of map.values()) {
+    const runsList = Array.from(map.values());
+    for (const run of runsList) {
         run.stages.sort((a, b) => {
             if (a.stageIndex === null) return 1;
             if (b.stageIndex === null) return -1;
             return a.stageIndex - b.stageIndex;
         });
     }
-    return Array.from(map.values());
+
+    // Since we're grouping stages by runId (which is the directory name)
+    // we no longer want to automatically append numeric suffixes. 
+    // They are unique inherently by their runId.
+    for (const run of runsList) {
+        let uniqueLabel = run.runLabel || run.runId || "Unknown Run";
+        run.runLabel = uniqueLabel;
+        
+        // Propagate unique runLabel to all stage records of this run
+        for (const stage of run.stages) {
+            stage.runLabel = uniqueLabel;
+        }
+    }
+
+    return runsList;
 }
 
 /**
@@ -301,7 +359,7 @@ export function groupStagesIntoRuns(stageRecords) {
  * user removes a run from the comparison panel.
  */
 export function stageToEntry(stage) {
-    const { scenario, performance, runId, runLabel, timestamp } = stage;
+    const { scenario, performance, runId, timestamp, components } = stage;
 
     const modelName  = normalizeModelName(scenario.model);
     const hardware   = normalizeHardware(scenario.hardware);
@@ -320,6 +378,7 @@ export function stageToEntry(stage) {
 
     return createEntry({
         // Top-level fields read directly by Dashboard / filter logic
+        run_id: stage.runId,
         model: modelName,
         model_name: modelName,
         hardware: hardware,
@@ -331,11 +390,12 @@ export function stageToEntry(stage) {
         throughput,
         latency,
         ttft,
+        components: components || [],
 
         source: `brv02:${runId}`,
         source_info: {
             type: 'benchmark_report_v02',
-            origin: 'local-upload',
+            origin: 'brv02:' + (stage.runLabel || runId || 'local-upload'),
             file_identifier: stage.filename,
             experiment_id: stage.runEid,
         },
@@ -351,6 +411,7 @@ export function stageToEntry(stage) {
             timestamp: ts,
             tp: scenario.tp || 1,
             architecture: scenario.role || 'aggregate',
+            components: components || [],
         },
 
         workload: {

--- a/src/utils/dashboardHelpers.jsx
+++ b/src/utils/dashboardHelpers.jsx
@@ -282,6 +282,65 @@ export const getSourceTag = (d) => {
     return s.split(':')[0].toUpperCase();
 };
 
+export const getSourceType = (d) => {
+    if (!d) return 'Built-in';
+    const s = typeof d === 'string' ? d : d.source;
+    if (!s) return 'Built-in';
+    
+    if (s === 'local') return 'Built-in';
+    if (s.startsWith('giq:')) return 'Cloud';
+    if (s.startsWith('gcs:') || s.startsWith('aws:')) return 'Cloud';
+    if (s.startsWith('lpg:') || s === 'infperf' || s === 'inference-perf') return 'Local';
+    if (s.startsWith('brv02:')) return 'Local';
+    if (s === 'llm-d-results:google_drive' || s === 'llmd_drive') return 'Built-in';
+    if (s === 'quality_scores') return 'Built-in';
+    
+    return 'Built-in';
+};
+
+export const getIntegrationSourceType = (id) => {
+    switch (id) {
+        case 'google_giq':
+            return 'Cloud';
+        case 'llmd_results':
+            return 'Built-in';
+        case 'lpg_lifecycle':
+            return 'Local';
+        case 'local_sample':
+            return 'Built-in';
+        case 'quality_scores':
+            return 'Built-in';
+        case 'benchmark_report_v02':
+            return 'Local';
+        default:
+            return 'Built-in';
+    }
+};
+
+export const getSourceTypeStyle = (type) => {
+    switch (type) {
+        case 'Local':
+            return {
+                bg: 'bg-amber-100 dark:bg-amber-950/40',
+                text: 'text-amber-800 dark:text-amber-400',
+                border: 'border-amber-200 dark:border-amber-900/30'
+            };
+        case 'Cloud':
+            return {
+                bg: 'bg-cyan-100 dark:bg-cyan-950/40',
+                text: 'text-cyan-800 dark:text-cyan-400',
+                border: 'border-cyan-200 dark:border-cyan-900/30'
+            };
+        case 'Built-in':
+        default:
+            return {
+                bg: 'bg-emerald-100 dark:bg-emerald-950/40',
+                text: 'text-emerald-800 dark:text-emerald-400',
+                border: 'border-emerald-200 dark:border-emerald-900/30'
+            };
+    }
+};
+
 export const formatOriginLabel = (origin) => {
     if (!origin) return 'Unknown Origin';
     if (origin === 'local_disk') return 'LOCAL: local_disk';
@@ -290,6 +349,7 @@ export const formatOriginLabel = (origin) => {
     if (origin.startsWith('infperf:')) return origin; 
     if (origin === 'llm-d-results:google_drive' || origin === 'llmd_drive') return 'llm-d Results Store';
     if (origin.startsWith('gcs:')) return `GCS: ${origin.substring(4)}`;
+    if (origin.startsWith('brv02:')) return `BRV0.2: ${origin.substring(6)}`;
 
     if (origin.startsWith('giq:')) return `GIQ: ${origin.substring(4)}`;
     if (origin === 'quality_scores') return 'Quality: Leaderboards';


### PR DESCRIPTION
This PR introduces a dedicated **Manage Benchmarks** view that completely decouples data connection setups and local file ingestion from the core visualization dashboard.

The intention is to allow for benchmark uploading within this same page, enabling a seamless "upload, view then contribute" UX flow.

## Key Changes

### Dedicated "Manage Benchmarks" View & Left Navigation

To prevent interface clutter and keep the primary results dashboard focused strictly on performance comparison, we decoupled functionalities from the existing Benchmark Explorer page and the Connections sidebar into its own view.

The added "Manage Benchmarks" page is meant to be a clean workspace housing all benchmark browsing tools, GCS/AWS/GIQ data connections, and the selection list. Benchmark selections made on the Manage Benchmarks page seamlessly carry over to the classic dashboard view.

<img width="800" src="https://github.com/user-attachments/assets/353009bb-3b71-40cd-9352-af03757c7a39" />

### Improved Benchmarks Table

The benchmarks table also received major usability enhancements compared to the previous one in Browse Benchmarks:

- **Drag-to-Select:** Users can click, hold, and drag across checkboxes to quickly select or deselect multiple contiguous benchmarks.

<div align="center"><img height="300" src="https://github.com/user-attachments/assets/a644e536-5803-402c-ace5-34351dfa76be" /></div>

- **Inline Run Management:** Moved Delete, Baseline, and Rename controls for custom uploaded runs directly inline as row actions inside the unified table rather than being in the Connections sidebar.

<div align="center"><img width="600" src="https://github.com/user-attachments/assets/e9124260-1ae8-4e75-b690-fb873b05be9e" /></div>

- **Bulk Local Run Deletes:** Added a "Delete Selected" button that clears multiple local benchmarks at once. When non-local (read-only) sources are selected, the button gracefully disables on hover with a descriptive tooltip.

<div align="center"><img width="300" src="https://github.com/user-attachments/assets/f99bd557-9043-4685-8055-cefb10e5eb68" /></div>

### Streamlined Directory Dropping for BRV2.0

Users can drag-and-drop entire folders or select full directories produced by `llm-d-benchmark` via a native picker. Subdirectories are recursively parsed to batch-ingest benchmark files in one step.

<div align="center"><img height="400" src="https://github.com/user-attachments/assets/c1d19567-f433-4deb-a6d5-a80a560d4e8f" /></div>

Benchmark runs originating from the same folder are grouped appropriately:

<div align="center">
<img width="400" src="https://github.com/user-attachments/assets/ce5fa299-a42b-42f2-bde3-208d72bcfbc2" />
<img width="400" src="https://github.com/user-attachments/assets/e245a524-9f6e-4ff9-a474-f6613517a219" />
</div>

### Integration Source Type Categorization

To make the origins of various benchmarks immediately clear to users, we introduced explicit source classifications:

- **Source Categories:** All integrations and runs are now explicitly categorized into **Local**, **Cloud**, or **Built-in** sources.
- **Color-Coded Status Pills:** Custom visual badges have been added to the connection targets and the benchmark rows (gold for Local, cyan for Cloud, and green for Built-in) to delineate origins at a glance.

<div align="center">
<img height="250" src="https://github.com/user-attachments/assets/15c56881-7252-4084-bf26-9faf92402427" />
</div>

In the future, Local runs are expected to be the primary way benchmarks are uploaded and managed.

### Session and State Persistence

Uploaded benchmarks, search filters, baseline run selections, selected benchmarks list, and visibility filters now persist seamlessly across page reloads.