### PR TITLE
Regressions updates

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -335,6 +335,12 @@ const parseServerRegressionReport = (content, filePath, metadataContent, jsonCon
                             hardware = 'TPU v6e';
                         } else if (accel === 'tpu-v7' || accel.includes('v7') || accel.includes('tpu7')) {
                             hardware = 'TPU v7';
+                        } else if (accel.includes('h100')) {
+                            hardware = 'H100';
+                        } else if (accel.includes('a100')) {
+                            hardware = 'A100';
+                        } else if (accel.includes('l4')) {
+                            hardware = 'L4';
                         } else if (accel === 'gpu') {
                             hardware = 'GPU';
                         } else {

--- a/server/server.js
+++ b/server/server.js
@@ -255,7 +255,7 @@ app.all('/api/gcs/*', async (req, res) => {
 
 const generateUUID = () => crypto.randomUUID();
 
-const parseServerRegressionReport = (content, filePath, metadataContent, jsonContent) => {
+const parseServerRegressionReport = (content, filePath, metadataContent, jsonContent, planConfigContent) => {
     try {
         const doc = yaml.load(content);
         if (!doc) return null;
@@ -315,9 +315,10 @@ const parseServerRegressionReport = (content, filePath, metadataContent, jsonCon
         let githubRunId = null;
         let githubRepository = null;
         let hardware = 'Unknown';
+        let metaDoc = null;
         if (metadataContent) {
             try {
-                const metaDoc = yaml.load(metadataContent);
+                metaDoc = yaml.load(metadataContent);
                 if (metaDoc) {
                     if (metaDoc.model) {
                         model = metaDoc.model;
@@ -357,6 +358,58 @@ const parseServerRegressionReport = (content, filePath, metadataContent, jsonCon
                 }
             } catch (e) {
                 // Ignore
+            }
+        }
+
+        // Fallback to plan config.yaml if accelerator is still Unknown or generic TPU/GPU
+        if ((hardware === 'Unknown' || hardware === 'TPU' || hardware === 'GPU') && planConfigContent) {
+            console.log(`[Regressions API] Entering fallback block for run ${runId}. Current hardware: ${hardware}`);
+            try {
+                const planDoc = yaml.load(planConfigContent);
+                const accBackend = planDoc?.kustomize?.acceleratorBackend;
+                console.log(`[Regressions API] accBackend for ${runId}: ${accBackend}`);
+                let inferredHw = null;
+                if (accBackend) {
+                    const match = accBackend.match(/^(tpu-v\d+|h100|a100|l4)/i);
+                    if (match) {
+                        const accel = match[1].toLowerCase();
+                        if (accel.includes('v6')) inferredHw = 'TPU v6e';
+                        else if (accel.includes('v7')) inferredHw = 'TPU v7';
+                        else if (accel.includes('v5')) inferredHw = 'TPU v5e';
+                        else if (accel.includes('h100')) inferredHw = 'H100';
+                        else if (accel.includes('a100')) inferredHw = 'A100';
+                        else if (accel.includes('l4')) inferredHw = 'L4';
+                    }
+                }
+
+                if (!inferredHw) {
+                    const stdType = planDoc?.standalone?.acceleratorType?.labelValue || planDoc?.prefill?.acceleratorType?.labelValue;
+                    if (stdType) {
+                        const match = stdType.match(/(h100|a100|l4|tpu-v\d+)/i);
+                        if (match) {
+                            const accel = match[1].toLowerCase();
+                            if (accel.includes('v6')) inferredHw = 'TPU v6e';
+                            else if (accel.includes('v7')) inferredHw = 'TPU v7';
+                            else if (accel.includes('v5')) inferredHw = 'TPU v5e';
+                            else if (accel.includes('h100')) inferredHw = 'H100';
+                            else if (accel.includes('a100')) inferredHw = 'A100';
+                            else if (accel.includes('l4')) inferredHw = 'L4';
+                        }
+                    }
+                }
+
+                console.log(`[Regressions API] inferredHw for ${runId}: ${inferredHw}`);
+                if (inferredHw) {
+                    const isTpuNs = String(metaDoc?.namespace || '').toLowerCase().includes('tpu');
+                    const isGpuNs = String(metaDoc?.namespace || '').toLowerCase().includes('gpu') || String(metaDoc?.namespace || '').toLowerCase().includes('nvidia');
+                    const isInferredTpu = inferredHw.startsWith('TPU');
+                    if ((isTpuNs && isInferredTpu) || (isGpuNs && !isInferredTpu) || (!isTpuNs && !isGpuNs)) {
+                        hardware = inferredHw;
+                        console.log(`[Regressions API] hardware resolved to: ${hardware}`);
+                    }
+                }
+            } catch (e) {
+                console.error(`[Regressions API] Error in fallback parsing for ${runId}:`, e);
             }
         }
 
@@ -500,14 +553,22 @@ app.get('/api/regressions', async (req, res) => {
                 const jsonFilename = filename.replace('benchmark_report_v0.2,_', '').replace('.yaml', '');
                 const jsonPath = parentPath + '/' + jsonFilename;
 
+                const parts = item.name.split('/');
+                let configPath = '';
+                if (parts.length >= 6) {
+                    configPath = parts.slice(0, 6).join('/') + '/plan/' + parts[1] + '/config.yaml';
+                }
+
                 const reportUrl = `https://storage.googleapis.com/storage/v1/b/llm-d-benchmarks/o/${encodeURIComponent(item.name)}?alt=media`;
                 const metadataUrl = `https://storage.googleapis.com/storage/v1/b/llm-d-benchmarks/o/${encodeURIComponent(metadataPath)}?alt=media`;
                 const jsonUrl = `https://storage.googleapis.com/storage/v1/b/llm-d-benchmarks/o/${encodeURIComponent(jsonPath)}?alt=media`;
+                const configUrl = configPath ? `https://storage.googleapis.com/storage/v1/b/llm-d-benchmarks/o/${encodeURIComponent(configPath)}?alt=media` : '';
 
-                const [reportRes, metadataRes, jsonRes] = await Promise.all([
+                const [reportRes, metadataRes, jsonRes, configRes] = await Promise.all([
                     fetch(reportUrl, { headers: { 'Authorization': `Bearer ${accessToken}` } }),
                     fetch(metadataUrl, { headers: { 'Authorization': `Bearer ${accessToken}` } }).catch(() => null),
-                    fetch(jsonUrl, { headers: { 'Authorization': `Bearer ${accessToken}` } }).catch(() => null)
+                    fetch(jsonUrl, { headers: { 'Authorization': `Bearer ${accessToken}` } }).catch(() => null),
+                    configUrl ? fetch(configUrl, { headers: { 'Authorization': `Bearer ${accessToken}` } }).catch(() => null) : null
                 ]);
 
                 if (!reportRes.ok) return;
@@ -527,7 +588,16 @@ app.get('/api/regressions', async (req, res) => {
                     }
                 }
 
-                const parsed = parseServerRegressionReport(content, item.name, metadataContent, jsonContent);
+                let planConfigContent = null;
+                if (configRes) {
+                    if (configRes.ok) {
+                        planConfigContent = await configRes.text();
+                    } else {
+                        console.warn(`[Regressions API] Failed to fetch configUrl: ${configUrl} status: ${configRes.status}`);
+                    }
+                }
+
+                const parsed = parseServerRegressionReport(content, item.name, metadataContent, jsonContent, planConfigContent);
                 if (parsed) reports.push(parsed);
             } catch (e) {
                 console.warn(`Failed to parse file ${item.name}:`, e);

--- a/server/server.js
+++ b/server/server.js
@@ -313,6 +313,8 @@ const parseServerRegressionReport = (content, filePath, metadataContent, jsonCon
 
         let model = 'Unknown';
         let githubRunId = null;
+        let githubRepository = null;
+        let hardware = 'Unknown';
         if (metadataContent) {
             try {
                 const metaDoc = yaml.load(metadataContent);
@@ -322,6 +324,29 @@ const parseServerRegressionReport = (content, filePath, metadataContent, jsonCon
                     }
                     if (metaDoc.github_run_id) {
                         githubRunId = String(metaDoc.github_run_id);
+                    }
+                    if (metaDoc.github_repository) {
+                        githubRepository = String(metaDoc.github_repository);
+                    }
+                    let accel = metaDoc.accelerator || null;
+                    if (accel) {
+                        accel = String(accel).toLowerCase();
+                        if (accel === 'tpu-v6' || accel.includes('v6')) {
+                            hardware = 'TPU v6e';
+                        } else if (accel === 'tpu-v7' || accel.includes('v7') || accel.includes('tpu7')) {
+                            hardware = 'TPU v7';
+                        } else if (accel === 'gpu') {
+                            hardware = 'GPU';
+                        } else {
+                            hardware = metaDoc.accelerator;
+                        }
+                    } else if (metaDoc.namespace) {
+                        const ns = String(metaDoc.namespace).toLowerCase();
+                        if (ns.includes('tpu')) {
+                            hardware = 'TPU';
+                        } else if (ns.includes('gpu')) {
+                            hardware = 'GPU';
+                        }
                     }
                 }
             } catch (e) {
@@ -357,7 +382,9 @@ const parseServerRegressionReport = (content, filePath, metadataContent, jsonCon
             model,
             model_name: model,
             github_run_id: githubRunId,
-            precision,
+            github_repository: githubRepository,
+            hardware: hardware,
+            precision: precision,
             serving_engine,
             stage,
             duration: durationSeconds,

--- a/src/components/RegressionsAnalysisDashboard.jsx
+++ b/src/components/RegressionsAnalysisDashboard.jsx
@@ -181,6 +181,8 @@ export default function RegressionsAnalysisDashboard({ onNavigateBack, onToggleM
                             model: modelName,
                             suite: d.suite || 'gke/standalone',
                             github_run_id: d.github_run_id || null,
+                            github_repository: d.github_repository || null,
+                            hardware: d.hardware || 'Unknown',
                             // Parse actual percentiles from GCS
                             ttft_p50: d.ttft?.p50 || 0,
                             ttft_p90: d.ttft?.p90 || d.tpot?.p90 || 0,
@@ -274,15 +276,34 @@ export default function RegressionsAnalysisDashboard({ onNavigateBack, onToggleM
             .filter(s => s.includes('optimized-baseline'));
         if (uniqueSuites.length === 0) {
             return [
-                { id: 'optimized-baseline/gke/kustomize', title: 'Optimized Baseline Gke Kustomize', sig: 'SIG-Serving', desc: 'Baseline optimization regressions tracking' }
+                { 
+                    id: 'optimized-baseline/gke/kustomize', 
+                    title: 'Optimized Baseline', 
+                    infraTag: 'GKE',
+                    methodTag: 'Kustomize',
+                    sig: 'SIG Router', 
+                    desc: 'Baseline optimization regressions tracking' 
+                }
             ];
         }
         return uniqueSuites.map(s => {
-            const title = s.split('/').map(part => part.charAt(0).toUpperCase() + part.slice(1)).join(' ');
+            const parts = s.split('/');
+            const scenarioName = parts[0] ? parts[0].split('-').map(word => word.charAt(0).toUpperCase() + word.slice(1)).join(' ') : 'Unknown Scenario';
+            const infra = parts[1] ? parts[1].toUpperCase() : null;
+            const method = parts[2] ? parts[2].charAt(0).toUpperCase() + parts[2].slice(1) : null;
+            
+            const pathKey = parts[0];
+            const meta = WELL_LIT_PATH_METADATA[pathKey] || {
+                sig: 'SIG Router',
+                owners: '@gke-runner',
+                infra: 'GKE Cluster'
+            };
             return {
                 id: s,
-                title: title,
-                sig: s.includes('multi') ? 'SIG-Scale' : 'SIG-Serving',
+                title: scenarioName,
+                infraTag: infra,
+                methodTag: method,
+                sig: meta.sig,
                 desc: `Telemetry suite for benchmark scenario: ${s}`
             };
         });
@@ -508,29 +529,24 @@ export default function RegressionsAnalysisDashboard({ onNavigateBack, onToggleM
                                     >
                                         <div 
                                             onClick={() => setSelectedRunMenu(run.id)}
-                                            className="cursor-pointer flex flex-col gap-0.5 w-full"
+                                            className="cursor-pointer flex flex-col gap-1 w-full"
                                         >
-                                            <div className="flex items-center justify-between w-full gap-2">
-                                                <span className="font-bold text-xs font-sans truncate">{run.title}</span>
-                                                <span className="text-[9px] font-mono bg-slate-900 text-slate-400 px-1.5 py-0.5 rounded border border-slate-800 shrink-0">{run.sig}</span>
+                                            <span className="font-bold text-xs font-sans text-slate-100 truncate">{run.title}</span>
+                                            <div className="flex flex-wrap items-center gap-1.5 mt-0.5">
+                                                {run.infraTag && (
+                                                    <span className="px-1.5 py-0.5 text-[8px] font-extrabold rounded-sm uppercase tracking-wide border bg-slate-950 text-cyan-400 border-cyan-950/50 shrink-0">
+                                                        {run.infraTag}
+                                                    </span>
+                                                )}
+                                                {run.methodTag && (
+                                                    <span className="px-1.5 py-0.5 text-[8px] font-extrabold rounded-sm uppercase tracking-wide border bg-slate-950 text-slate-400 border-slate-800 shrink-0">
+                                                        {run.methodTag}
+                                                    </span>
+                                                )}
+                                                <span className="text-[8px] font-mono bg-slate-900 text-slate-400 px-1.5 py-0.5 rounded border border-slate-800 shrink-0">
+                                                    {run.sig}
+                                                </span>
                                             </div>
-                                            <span className="text-[10px] text-slate-400 leading-snug line-clamp-2 font-sans">{run.desc}</span>
-                                            {isSelected && (
-                                                <div className="flex items-center justify-start gap-3 text-[8px] text-slate-400 pt-0.5">
-                                                    <div className="flex items-center gap-0.5" title="Regression Detected">
-                                                        <AlertTriangle className="w-2.5 h-2.5 text-red-500" />
-                                                        <span>Regression</span>
-                                                    </div>
-                                                    <div className="flex items-center gap-0.5" title="Regression Resolved">
-                                                        <CheckCircle className="w-2.5 h-2.5 text-emerald-500" />
-                                                        <span>Fixed</span>
-                                                    </div>
-                                                    <div className="flex items-center gap-0.5" title="Stable Performance">
-                                                        <Shield className="w-2.5 h-2.5 text-blue-500" />
-                                                        <span>Stable</span>
-                                                    </div>
-                                                </div>
-                                            )}
                                         </div>
 
                                         {isSelected && (
@@ -555,29 +571,33 @@ export default function RegressionsAnalysisDashboard({ onNavigateBack, onToggleM
                                                                 }`}>
                                                                     {isRunSelected && '✓'}
                                                                 </div>
-                                                                {runPoint.status === 'regression' ? (
-                                                                    <AlertTriangle className="w-3 h-3 text-red-500 shrink-0" />
-                                                                ) : runPoint.status === 'fixed' ? (
-                                                                    <CheckCircle className="w-3 h-3 text-emerald-500 shrink-0" />
-                                                                ) : (
-                                                                    <Shield className="w-3 h-3 text-blue-500 shrink-0" />
-                                                                )}
-                                                                <span className="font-mono font-bold text-slate-200">{formatBuildId(runPoint.build)}</span>
-                                                            </div>
-                                                            <div className="flex items-center gap-2">
-                                                                <a 
-                                                                    href={runPoint.github_run_id 
-                                                                        ? `https://github.com/llm-d/llm-d/actions/runs/${runPoint.github_run_id}` 
-                                                                        : `https://github.com/llm-d/llm-d/actions/runs/${runPoint.build.replace('b', '')}`
-                                                                    }
-                                                                    target="_blank" 
-                                                                    rel="noopener noreferrer"
-                                                                    onClick={(e) => e.stopPropagation()} // Prevent selecting run when clicking link
-                                                                    className="text-cyan-400 hover:text-cyan-300 flex items-center gap-0.5 font-semibold"
-                                                                >
-                                                                    <span>View</span>
-                                                                    <ExternalLink className="w-2.5 h-2.5" />
-                                                                </a>
+                                                                <div className="flex flex-col flex-1 min-w-0">
+                                                                    <a 
+                                                                        href={runPoint.github_run_id 
+                                                                            ? `https://github.com/${runPoint.github_repository || 'llm-d/llm-d'}/actions/runs/${runPoint.github_run_id}` 
+                                                                            : `https://github.com/llm-d/llm-d/actions/runs/${runPoint.build.replace('b', '')}`
+                                                                        }
+                                                                        target="_blank" 
+                                                                        rel="noopener noreferrer"
+                                                                        onClick={(e) => e.stopPropagation()} // Prevent selecting run when clicking link
+                                                                        className="font-mono font-bold text-slate-200 hover:text-cyan-400 hover:underline flex items-center gap-1.5 transition-colors w-fit"
+                                                                        title="View GitHub Action Run"
+                                                                    >
+                                                                        <span>{formatBuildId(runPoint.build)}</span>
+                                                                        <ExternalLink className="w-2.5 h-2.5 opacity-60 shrink-0" />
+                                                                    </a>
+                                                                    {runPoint.hardware && runPoint.hardware !== 'Unknown' && (
+                                                                        <div className="flex items-center gap-1.5 mt-0.5">
+                                                                            <span className={`px-1 py-0.5 text-[8px] font-extrabold rounded-sm uppercase tracking-wide border ${
+                                                                                runPoint.hardware.startsWith('TPU') 
+                                                                                    ? 'bg-purple-950/60 text-purple-300 border-purple-800/40' 
+                                                                                    : 'bg-emerald-950/60 text-emerald-300 border-emerald-800/40'
+                                                                            }`}>
+                                                                                {runPoint.hardware}
+                                                                            </span>
+                                                                        </div>
+                                                                    )}
+                                                                </div>
                                                             </div>
                                                         </div>
                                                     );


### PR DESCRIPTION

This PR improves the regressions view by extracting specific GPU/TPU accelerator model names instead of displaying generic labels (like "GPU" or "TPU") and styles configuration parameters as tags in the "Defined Test Runs" layout. Additionally, it introduces a robust server-side fallback to resolve the accelerator hardware name when it is missing from a run's `run_metadata.yaml`.

<img width="758" height="1016" alt="image" src="https://github.com/user-attachments/assets/51d4816a-72af-404e-ac26-301b833e2819" />

## Key Changes

### 1. Granular Accelerator Names & Normalized Display
* Refined how accelerator models are parsed in the regressions dashboard. Specific models (e.g. `NVIDIA-H100-80GB-HBM3`) are now normalized to clean user-facing tags like **`H100`**, **`A100`**, and **`L4`**.
* TPU versions are cleaned up and normalized to display consistently (e.g. **`TPU v6e`** or **`TPU v7`**).

### 2. Cleaned Up Defined Test Runs Layout
* Moved configuration parameters (like `GKE` and `Kustomize`) out of the test scenario titles and styled them as visual tags, matching the layout pattern used for accelerator models.

### 3. Server-Side Hardware Resolution Fallback
* Identified that some nightly benchmark runs (e.g. TPU kustomize runs) fail to write the `accelerator` field to their GCS `run_metadata.yaml` file, causing them to fall back to the generic namespace tag `"TPU"`.
* Added a backend fallback in [server/server.js](file:///usr/local/google/home/jkramberger/jetski/llm-d-prism/server/server.js#L358-L410) to fetch the run's plan **`config.yaml`** from GCS when `run_metadata.yaml` lacks the accelerator key. 
* Resolves the correct hardware model (`TPU v6e`) from the plan's `kustomize.acceleratorBackend` or standalone configuration blocks, ensuring complete hardware visibility across all historical nightly runs.

## Verification & Testing
* Tested locally on port `3005` with a live GCS regressions cache reload.
* Verified that the most recent nightly run (`runner-20260605-171510-309`) now correctly resolves the hardware type to **`TPU v6e`** (instead of the previous fallback `"TPU"`).

## How was this tested?

<!-- Describe how you verified the changes work correctly -->
- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->
