### PR TITLE
Fix model name grouping and sorting

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -38,6 +38,12 @@ import DataInspector from './DataInspector';
 import { useDashboardState } from '../hooks/useDashboardState';
 import { useDashboardData } from '../hooks/useDashboardData';
 import { INTEGRATIONS, getBucket, getRatioType, getEffectiveTp, sortBuckets, findParetoPoint, getNodesAndType, getBenchmarkKey } from '../utils/dashboardHelpers';
+
+const getCleanModelName = (name) => {
+    if (!name) return '';
+    return name.replace(/\s*\[.*?\]/g, '').replace(/\s*\(.*?\)/g, '').trim();
+};
+
 const USE_CASE_META = {
     "Advanced Customer Support": "(~9k/256)",
     "Chatbot (ShareGPT)": "(~128/128)",
@@ -361,7 +367,7 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
             const source = d.source || 'local';
             if (!selectedSources.has(source)) return false;
 
-            if (activeFilters.models.size > 0 && !activeFilters.models.has(d.model_name)) return false;
+            if (activeFilters.models.size > 0 && !activeFilters.models.has(getCleanModelName(d.model_name))) return false;
             if (activeFilters.hardware.size > 0 && !activeFilters.hardware.has(d.hardware)) return false;
             if (activeFilters.precisions.size > 0 && !activeFilters.precisions.has(d.precision)) return false;
             if (activeFilters.isl.size > 0 && !activeFilters.isl.has(getBucket(d.isl))) return false;
@@ -855,9 +861,24 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
             pdRatio: {}
         };
 
+        const canonicalModelMap = {};
+        baseData.forEach(d => {
+            if (d.model_name) {
+                const clean = getCleanModelName(d.model_name);
+                const cleanLower = clean.toLowerCase();
+                if (!canonicalModelMap[cleanLower]) {
+                    canonicalModelMap[cleanLower] = clean;
+                }
+            }
+        });
+
         // Helper to check if item satisfies all active filters EXCEPT the ignored category
         const check = (d, ignoreKey) => {
-            if (ignoreKey !== 'models' && activeFilters.models.size > 0 && !activeFilters.models.has(d.model_name)) return false;
+            if (ignoreKey !== 'models' && activeFilters.models.size > 0) {
+                const modelNameLower = getCleanModelName(d.model_name).toLowerCase();
+                const hasMatch = [...activeFilters.models].some(m => m.toLowerCase() === modelNameLower);
+                if (!hasMatch) return false;
+            }
             if (ignoreKey !== 'hardware' && activeFilters.hardware.size > 0 && !activeFilters.hardware.has(d.hardware)) return false;
             if (ignoreKey !== 'machines' && activeFilters.machines.size > 0 && !activeFilters.machines.has(d.machine_type)) return false;
             if (ignoreKey !== 'precisions' && activeFilters.precisions.size > 0 && !activeFilters.precisions.has(d.precision)) return false;
@@ -927,7 +948,11 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
         baseData.forEach(d => {
             const modelId = getBenchmarkKey(d); // Unique identifier for the benchmark config
 
-            if (check(d, 'models')) add('models', d.model_name, modelId);
+            if (check(d, 'models')) {
+                const cleanLower = getCleanModelName(d.model_name).toLowerCase();
+                const canonicalName = canonicalModelMap[cleanLower] || getCleanModelName(d.model_name);
+                add('models', canonicalName, modelId);
+            }
 
             if (check(d, 'hardware')) add('hardware', d.hardware, modelId);
 
@@ -1006,7 +1031,7 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
         console.log("[Dashboard] recalculating filteredBySource. baseData length:", baseData.length, "activeFilters:", activeFilters);
         const filtered = baseData.filter(d => {
             // Check modal filters
-            if (activeFilters.models.size > 0 && !activeFilters.models.has(d.model_name)) return false;
+            if (activeFilters.models.size > 0 && !activeFilters.models.has(getCleanModelName(d.model_name))) return false;
             if (activeFilters.hardware.size > 0 && !activeFilters.hardware.has(d.hardware)) return false;
             if (activeFilters.machines.size > 0 && !activeFilters.machines.has(d.machine_type)) return false;
             if (activeFilters.precisions.size > 0 && !activeFilters.precisions.has(d.precision)) return false;
@@ -1112,8 +1137,16 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
             origins: new Set()
         };
 
+        const seenModelsLower = new Set();
         baseData.forEach(d => {
-            if (d.model_name) options.models.add(d.model_name);
+            if (d.model_name) {
+                const clean = getCleanModelName(d.model_name);
+                const cleanLower = clean.toLowerCase();
+                if (!seenModelsLower.has(cleanLower)) {
+                    seenModelsLower.add(cleanLower);
+                    options.models.add(clean);
+                }
+            }
             if (d.hardware && d.hardware !== 'Unknown') {
                 options.hardware.add(d.hardware);
                 options.acc_count.add(getAcceleratorCount(d));

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1213,7 +1213,7 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
                 const parse = s => String(s).split(':').map(Number);
                 const [pa, da] = parse(a);
                 const [pb, db] = parse(b);
-                if (isNaN(pa) || isNaN(pb)) return String(a).localeCompare(String(b));
+                if (isNaN(pa) || isNaN(pb)) return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: 'base' });
                 if (pa !== pb) return pa - pb;
                 return da - db;
             }),

--- a/src/components/ManageBenchmarks.jsx
+++ b/src/components/ManageBenchmarks.jsx
@@ -308,7 +308,7 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
                 const parse = s => String(s).split(':').map(Number);
                 const [pa, da] = parse(a);
                 const [pb, db] = parse(b);
-                if (isNaN(pa) || isNaN(pb)) return String(a).localeCompare(String(b));
+                if (isNaN(pa) || isNaN(pb)) return String(a).localeCompare(String(b), undefined, { numeric: true, sensitivity: 'base' });
                 if (pa !== pb) return pa - pb;
                 return da - db;
             }),

--- a/src/components/ManageBenchmarks.jsx
+++ b/src/components/ManageBenchmarks.jsx
@@ -19,6 +19,11 @@ import { UnifiedDataTable } from './ManageBenchmarks/UnifiedDataTable';
 import DataConnectionsPanel from './DataConnectionsPanel';
 import { INTEGRATIONS, getSourceTag, getBenchmarkKey, getBucket, getRatioType, getAcceleratorCount, getEffectiveTp, sortBuckets } from '../utils/dashboardHelpers';
 
+const getCleanModelName = (name) => {
+    if (!name) return '';
+    return name.replace(/\s*\[.*?\]/g, '').replace(/\s*\(.*?\)/g, '').trim();
+};
+
 export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboardState, dashboardData }) {
     const {
         showFilterPanel,
@@ -67,8 +72,9 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
 
             // Apply Model filter
             if (activeFilters.models && activeFilters.models.size > 0) {
-                const modelName = d.model_name || d.model;
-                if (!activeFilters.models.has(modelName)) return false;
+                const modelNameLower = getCleanModelName(d.model_name || d.model).toLowerCase();
+                const hasMatch = [...activeFilters.models].some(m => m.toLowerCase() === modelNameLower);
+                if (!hasMatch) return false;
             }
 
             // Apply Hardware filter
@@ -233,8 +239,17 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
 
         const baseData = data.filter(d => selectedSources.has(d.source || 'local'));
 
+        const seenModelsLower = new Set();
         baseData.forEach(d => {
-            if (d.model_name) options.models.add(d.model_name);
+            const modelVal = d.model_name || d.model;
+            if (modelVal) {
+                const clean = getCleanModelName(modelVal);
+                const cleanLower = clean.toLowerCase();
+                if (!seenModelsLower.has(cleanLower)) {
+                    seenModelsLower.add(cleanLower);
+                    options.models.add(clean);
+                }
+            }
             if (d.hardware && d.hardware !== 'Unknown') {
                 options.hardware.add(d.hardware);
                 options.acc_count.add(getAcceleratorCount(d));
@@ -327,6 +342,13 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
 
         const baseData = data.filter(d => selectedSources.has(d.source || 'local'));
 
+        const canonicalModelMap = {};
+        if (filterOptions && filterOptions.models) {
+            filterOptions.models.forEach(m => {
+                canonicalModelMap[m.toLowerCase()] = m;
+            });
+        }
+
         // Helper to check if item satisfies all active filters EXCEPT the ignored category
         const check = (d, ignoreKey) => {
             if (ignoreKey !== 'connectionNames' && activeFilters.connectionNames && activeFilters.connectionNames.size > 0) {
@@ -340,8 +362,9 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
             }
 
             if (ignoreKey !== 'models' && activeFilters.models && activeFilters.models.size > 0) {
-                const modelName = d.model_name || d.model;
-                if (!activeFilters.models.has(modelName)) return false;
+                const modelNameLower = getCleanModelName(d.model_name || d.model).toLowerCase();
+                const hasMatch = [...activeFilters.models].some(m => m.toLowerCase() === modelNameLower);
+                if (!hasMatch) return false;
             }
 
             if (ignoreKey !== 'hardware' && activeFilters.hardware && activeFilters.hardware.size > 0) {
@@ -431,7 +454,12 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
         baseData.forEach(d => {
             const modelId = getBenchmarkKey(d);
 
-            if (d.model_name && check(d, 'models')) add('models', d.model_name, modelId);
+            const mVal = d.model_name || d.model;
+            if (mVal && check(d, 'models')) {
+                const cleanLower = getCleanModelName(mVal).toLowerCase();
+                const canonicalName = canonicalModelMap[cleanLower] || getCleanModelName(mVal);
+                add('models', canonicalName, modelId);
+            }
             if (d.hardware && check(d, 'hardware')) add('hardware', d.hardware, modelId);
             if (d.machine_type && check(d, 'machines')) add('machines', d.machine_type, modelId);
             if (d.precision && check(d, 'precisions')) add('precisions', d.precision, modelId);
@@ -483,7 +511,7 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
         });
 
         return finalCounts;
-    }, [data, selectedSources, activeFilters]);
+    }, [data, selectedSources, activeFilters, filterOptions]);
 
     const toggleFilter = (category, value) => {
         setActiveFilters(prev => {

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -273,7 +273,9 @@ export const UnifiedDataTable = (props) => {
             
             let primaryResult = 0;
             if (typeof valA === 'string' && typeof valB === 'string') {
-                primaryResult = sortDirection === 'asc' ? valA.localeCompare(valB) : valB.localeCompare(valA);
+                primaryResult = sortDirection === 'asc' 
+                    ? valA.localeCompare(valB, undefined, { numeric: true, sensitivity: 'base' }) 
+                    : valB.localeCompare(valA, undefined, { numeric: true, sensitivity: 'base' });
             } else {
                 primaryResult = sortDirection === 'asc' ? valA - valB : valB - valA;
             }
@@ -289,7 +291,7 @@ export const UnifiedDataTable = (props) => {
             const originA = firstA?.source_info?.origin || firstA?.source || '';
             const originB = firstB?.source_info?.origin || firstB?.source || '';
             
-            const originCmp = originA.localeCompare(originB);
+            const originCmp = originA.localeCompare(originB, undefined, { numeric: true, sensitivity: 'base' });
             if (originCmp !== 0) {
                 return originCmp;
             }
@@ -297,12 +299,12 @@ export const UnifiedDataTable = (props) => {
             const fileA = firstA?.source_info?.file_identifier || firstA?.filename || '';
             const fileB = firstB?.source_info?.file_identifier || firstB?.filename || '';
             
-            const fileCmp = fileA.localeCompare(fileB);
+            const fileCmp = fileA.localeCompare(fileB, undefined, { numeric: true, sensitivity: 'base' });
             if (fileCmp !== 0) {
                 return fileCmp;
             }
 
-            return (a.benchmarkKey || '').localeCompare(b.benchmarkKey || '');
+            return (a.benchmarkKey || '').localeCompare(b.benchmarkKey || '', undefined, { numeric: true, sensitivity: 'base' });
         });
     }, [filteredStats, sortByField, sortDirection]);
 

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -16,6 +16,11 @@ import React, { useState } from 'react';
 import { RotateCcw, ChevronDown, ChevronUp, Star, CheckSquare, Square, Check, Pencil, Trash2 } from 'lucide-react';
 import { getEffectiveTp, getBucket, getSourceTag, getSourceType, getSourceTypeStyle, formatOriginLabel } from '../../utils/dashboardHelpers';
 
+const getCleanModelName = (name) => {
+    if (!name) return '';
+    return name.replace(/\s*\[.*?\]/g, '').replace(/\s*\(.*?\)/g, '').trim();
+};
+
 export const UnifiedDataTable = (props) => {
     const [editingRunId, setEditingRunId] = useState(null);
     const [editingValue, setEditingValue] = useState('');
@@ -306,9 +311,26 @@ export const UnifiedDataTable = (props) => {
     const groupedStats = React.useMemo(() => {
         const grouped = {};
         if (groupBy !== 'None') {
+            // Build a mapping of lowercase clean model names to their first seen nicely-cased clean name
+            const canonicalCasing = {};
+            sortedStats.forEach(stat => {
+                if (groupBy === 'Model') {
+                    const rawName = stat.model_name || stat.model || 'Unknown Model';
+                    const clean = getCleanModelName(rawName);
+                    const cleanLower = clean.toLowerCase();
+                    if (!canonicalCasing[cleanLower]) {
+                        canonicalCasing[cleanLower] = clean;
+                    }
+                }
+            });
+
             sortedStats.forEach(stat => {
                 let key = 'Other';
-                if (groupBy === 'Model') key = stat.model_name || stat.model || 'Unknown Model';
+                if (groupBy === 'Model') {
+                    const rawName = stat.model_name || stat.model || 'Unknown Model';
+                    const clean = getCleanModelName(rawName);
+                    key = canonicalCasing[clean.toLowerCase()] || clean;
+                }
                 if (groupBy === 'Hardware') key = stat.hardware || 'Unknown Hardware';
                 if (groupBy === 'Origin') {
                     const origin = stat.data?.[0]?.source_info?.origin || stat.data?.[0]?.source;


### PR DESCRIPTION
## What does this PR do?

This PR addresses two key issues in the benchmark dashboard and management components:

1. **Model Name Normalization & Case-Insensitive Grouping**: Introduces a helper to normalize model names by stripping parenthesized suffixes (e.g., `(...)`) and bracketed suffixes (e.g., `[...]`). It also establishes a canonical model casing map to ensure case-insensitive model grouping and matching across filters, options, and tables.

2. **Natural / Numeric Sorting**: Upgrades string sorting for sequence lengths, facets, run IDs, and stats across `Dashboard`, `ManageBenchmarks`, and `UnifiedDataTable` by switching from basic lexicographical sorting to natural numeric-aware sorting using `localeCompare` with `{ numeric: true, sensitivity: 'base' }`.

## Why is this change needed?

- **Fragmented Model Facets/Filters**: Following recent merges, the logic parsing model names from benchmarks did not normalize them. This resulted in duplicate model options in filters (differing only by bracket/parenthesised metadata or casing).

- **Incorrect Sorting of Numeric Sequences**: String fields containing numbers (such as sequence lengths, e.g., `"128:128"` vs `"1024:128"`) were being sorted lexicographically. This caused larger values to incorrectly appear before smaller ones under default sorting logic.

## How was this tested?

- [x] Manual testing performed on the dashboard UI.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)


## Related Issues

Issue was introduced in https://github.com/llm-d/llm-d-prism/pull/67.
