### PR TITLE
refactor: rename Agentic Workloads to Agentic Serving

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -107,7 +107,7 @@ function App() {
         <main ref={mainRef} className="flex-1 overflow-y-auto flex flex-col relative w-full h-screen">
           {currentView === 'home' && <PrismHome onNavigate={handleNavigate} />}
           {currentView === 'inference-scheduling' && <Milestone1Dashboard onNavigateBack={() => handleNavigate('home')} onNavigate={handleNavigate} onToggleMobileNav={() => setIsMobileNavOpen(!isMobileNavOpen)} />}
-          {currentView === 'agentic-workloads' && <AgenticWorkloadsDashboard onNavigateBack={() => handleNavigate('home')} onNavigate={handleNavigate} onToggleMobileNav={() => setIsMobileNavOpen(!isMobileNavOpen)} />}
+          {currentView === 'agentic-serving' && <AgenticWorkloadsDashboard onNavigateBack={() => handleNavigate('home')} onNavigate={handleNavigate} onToggleMobileNav={() => setIsMobileNavOpen(!isMobileNavOpen)} />}
           {currentView === 'benchmark-browser' && <Dashboard onNavigateBack={() => handleNavigate('home')} />}
           {currentView === 'schema-explorer' && <SchemaExplorer onNavigateBack={() => handleNavigate('home')} />}
           {currentView === 'workload-catalog' && <WorkloadCatalog onNavigateBack={() => handleNavigate('home')} />}

--- a/src/components/AgenticWorkloadsDashboard.jsx
+++ b/src/components/AgenticWorkloadsDashboard.jsx
@@ -350,7 +350,7 @@ export default function AgenticWorkloadsDashboard({ onNavigateBack, onNavigate, 
         return (
             <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col items-center justify-center pt-16 md:pl-24 w-full font-sans">
                 <Loader className="animate-spin text-cyan-500" size={40} />
-                <div className="text-lg font-semibold text-slate-200 mt-4">Loading Agentic Workloads Data...</div>
+                <div className="text-lg font-semibold text-slate-200 mt-4">Loading Agentic Serving Data...</div>
                 <p className="text-xs text-slate-500 mt-2">Scanning GCS benchmark results</p>
             </div>
         );
@@ -522,7 +522,7 @@ export default function AgenticWorkloadsDashboard({ onNavigateBack, onNavigate, 
                         </span>
                     </div>
                     <div className="flex items-center">
-                        <h1 className="text-sm sm:text-lg font-bold text-white tracking-wide truncate">Agentic workloads</h1>
+                        <h1 className="text-sm sm:text-lg font-bold text-white tracking-wide truncate">Agentic serving</h1>
                         <span className="ml-3 px-2 py-0.5 rounded text-xs font-semibold bg-emerald-500/20 text-emerald-400 border border-emerald-500/30 hidden sm:inline">
                             Guided path
                         </span>

--- a/src/components/LeftNavigation.jsx
+++ b/src/components/LeftNavigation.jsx
@@ -34,7 +34,7 @@ const MENU_GROUPS = [
     {
         title: "Workload hub",
         items: [
-            { id: 'agentic-workloads', label: 'Agentic workloads', icon: Compass, view: 'agentic-workloads' }
+            { id: 'agentic-serving', label: 'Agentic serving', icon: Compass, view: 'agentic-serving' }
         ]
     },
     {

--- a/src/components/PrismHome.jsx
+++ b/src/components/PrismHome.jsx
@@ -210,11 +210,11 @@ const PrismHome = ({ onNavigate }) => {
                     <div className="w-full max-w-[46%] mx-auto">
                         {/* Path 5: Agentic Workloads (M2 Path) */}
                         <div 
-                            onClick={() => onNavigate('agentic-workloads')}
+                            onClick={() => onNavigate('agentic-serving')}
                             className="group relative bg-slate-900/80 backdrop-blur-xl shadow-lg hover:shadow-2xl rounded-xl p-5 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(34,211,238,0.15)] transition-all duration-300 cursor-pointer flex flex-col h-full overflow-hidden border border-slate-800/50 hover:border-cyan-500/30"
                         >
                             <h3 className="text-base font-bold mb-2 text-white group-hover:text-cyan-400 transition-colors leading-tight">
-                                Agentic workloads
+                                Agentic serving
                             </h3>
                             <div className="flex flex-wrap gap-1.5 mb-3">
                                 <span className="text-[9px] px-1.5 py-0.5 bg-cyan-500/10 text-cyan-400 rounded-full font-medium border border-cyan-500/20 whitespace-nowrap">Multi-turn</span>
@@ -456,7 +456,7 @@ const PrismHome = ({ onNavigate }) => {
                                      Test harness
                                      <Link className="h-3 w-3 text-cyan-400 group-hover:scale-110 transition-transform" />
                                  </h4>
-                                 <p className="text-sm text-slate-400">Stress distributed systems with agentic workloads.</p>
+                                 <p className="text-sm text-slate-400">Stress distributed systems with agentic serving workloads.</p>
                              </a>
 
                              {/* Real World Workload Catalog */}


### PR DESCRIPTION
Update all user-facing labels from "Agentic workloads" to "Agentic serving" across the dashboard header, left navigation, and home page card.

