### PR TITLE
Fix/workload catalog url share

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,8 +208,8 @@ The project uses a standard `.npmrc` to enforce the public npm registry (`https:
 
 - **Running Locally:** Run `npm run dev`.
 - **Parsing Logic:** Data ingestion logic resides in `src/utils/dataParser.js` and files specific to the data source.
-  - **Hardware Metadata:** The parser extracts `accelerator` (e.g., `tpu7x`) and `machine_type` from `manifest.yaml` when available in GCS/S3 sources.
-  - **Source Identification:** Benchmarks are tagged with standardized IDs: `infperf` (inference-perf), `Quality` (MQ), `llm-d` (DRIVE), and `brv02:<run-uid>` (local Benchmark Report v0.2 uploads).
+  - **Hardware Metadata:** The parser extracts `accelerator` (e.g., `tpu7x`) and configuration details (tensor parallel size, backend) from `manifest.yaml` when available in GCS/S3 sources.
+  - **Source Identification:** Benchmarks are tagged with standardized IDs: `infperf` (inference-perf), `quality_scores` (Model Quality), `llm-d-results:google_drive` / `llmd_drive` (DRIVE), and `brv02:<run-uid>` (local Benchmark Report v0.2 uploads).
 - **Local Benchmark Comparison:** Users can upload `benchmark_report_v0.2,_*.yaml` files produced by [llm-d-benchmark](https://github.com/llm-d/llm-d-benchmark) directly in the browser via the **Connections → Local Benchmark Comparison** panel. Uploaded runs appear in both the main scatter chart and a dedicated full-width comparison view (bar charts + metric table with % diffs). Parser: `src/utils/benchmarkReportV02Parser.js`. UI: `src/components/DataConnections/BenchmarkReportPanel.jsx` and `src/components/BenchmarkComparisonDashboard.jsx`. State lives in `useDashboardData` under the `brv02*` prefix.
 - **Visuals:** Prioritize intuitive and interactive aesthetics. Use dark mode, glassmorphism, and smooth transitions.
 - **Data handling:**

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -54,6 +54,15 @@ const USE_CASE_META = {
     "Text Summarization": "(~1k/128)"
 };
 
+const formatContactUrl = (url) => {
+    if (!url) return 'https://llm-d.ai/community';
+    if (url.includes('@') && !url.startsWith('mailto:') && !url.startsWith('http')) {
+        return `mailto:${url}`;
+    }
+    return url;
+};
+
+
 
 
 
@@ -1729,7 +1738,7 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
                     <div className="flex items-center gap-2.5 border-r border-slate-500 pr-4">
                         <img src="https://llm-d.ai/img/llm-d-logotype-and-icon.png" alt="llm-d Logo" className="h-6 object-contain" />
                         <span className="text-lg font-bold tracking-wide bg-clip-text text-transparent bg-gradient-to-r from-cyan-400 via-blue-500 to-purple-600">
-                            Prism
+                            Prism{siteName ? ` - ${siteName}` : ''}
                         </span>
                     </div>
 
@@ -1750,7 +1759,7 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
                     </button>
 
                     <a 
-                        href="https://llm-d.ai/community" 
+                        href={formatContactUrl(contactUrl)} 
                         target="_blank" 
                         rel="noreferrer"
                         className="px-4 py-2 text-sm font-medium rounded-md text-slate-300 bg-slate-800 hover:bg-slate-700 transition-colors flex items-center border border-slate-700"

--- a/src/components/WorkloadCatalog.jsx
+++ b/src/components/WorkloadCatalog.jsx
@@ -1,7 +1,53 @@
-import React from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { ArrowLeft, MessageCircle, Share2 } from 'lucide-react';
 
 const WorkloadCatalog = ({ onNavigateBack }) => {
+    const [copied, setCopied] = useState(false);
+
+    // Compute the initial iframe source on mount only to prevent reloading the iframe on parent re-renders.
+    const iframeSrc = useMemo(() => {
+        const queryParams = new URLSearchParams(window.location.search);
+        const workload = queryParams.get('workload') || '';
+        const initialPath = workload ? `/workloads/${workload}` : '';
+        const isLocal = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
+        const baseUrl = isLocal 
+            ? 'http://localhost:5174'
+            : 'https://workload-catalog-app-369234493812.us-central1.run.app';
+        return `${baseUrl}${initialPath}`;
+    }, []);
+
+    useEffect(() => {
+        const handleMessage = (event) => {
+            if (event.data && event.data.type === 'workload-catalog-navigate') {
+                const path = event.data.path;
+                const params = new URLSearchParams(window.location.search);
+                if (path && path.startsWith('/workloads/')) {
+                    const workloadId = path.replace('/workloads/', '').trim().toLowerCase().replace(/\s+/g, '-');
+                    params.set('workload', workloadId);
+                } else {
+                    params.delete('workload');
+                }
+                window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+            }
+        };
+
+        window.addEventListener('message', handleMessage);
+        return () => {
+            window.removeEventListener('message', handleMessage);
+        };
+    }, []);
+
+    const handleShare = () => {
+        navigator.clipboard.writeText(window.location.href)
+            .then(() => {
+                setCopied(true);
+                setTimeout(() => setCopied(false), 2000);
+            })
+            .catch((err) => {
+                console.error('Failed to copy link: ', err);
+            });
+    };
+
     return (
         <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col items-center pt-16">
             
@@ -37,17 +83,17 @@ const WorkloadCatalog = ({ onNavigateBack }) => {
                         <MessageCircle className="w-4 h-4 mr-2" /> Contact us
                     </a>
                     <button 
-                        className="px-4 py-2 text-sm font-medium rounded-md text-slate-500 bg-slate-800/50 cursor-not-allowed flex items-center border border-slate-700/50 relative"
-                        disabled
+                        onClick={handleShare}
+                        className="px-4 py-2 text-sm font-medium rounded-md text-slate-300 bg-slate-800 hover:bg-slate-700 active:bg-slate-600 transition-colors flex items-center border border-slate-700 relative"
                     >
-                        <Share2 className="w-4 h-4 mr-2" /> Share link 
+                        <Share2 className="w-4 h-4 mr-2" /> {copied ? 'Copied!' : 'Share view'}
                     </button>
                 </div>
             </header>
 
             <main className="w-full px-8 py-6 pl-28 flex flex-col relative w-full h-[calc(100vh-4rem)]">
                 <iframe 
-                    src="https://workload-catalog-app-369234493812.us-central1.run.app/" 
+                    src={iframeSrc} 
                     className="w-full h-full border-0" 
                     title="Workload catalog"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
@@ -59,3 +105,4 @@ const WorkloadCatalog = ({ onNavigateBack }) => {
 };
 
 export default WorkloadCatalog;
+


### PR DESCRIPTION
## What does this PR do?

Return the feature where the workload catalog item is present in the URL.

## Why is this change needed?

Feature was removed with this change: https://github.com/llm-d/llm-d-prism/commit/d008828eb075d5d778ef4d00a505a314139cb475 

## How was this tested?

- [X] Manual testing performed

## Checklist

- [X] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [X] Code follows project [contributing guidelines](CONTRIBUTING.md)
