### PR TITLE
[WIP] docs: define product-ui-engineering loop and add enforcement skill

### DIFF
--- a/.agents/skills.json
+++ b/.agents/skills.json
@@ -1,0 +1,6 @@
+{
+  "entries": [
+    { "path": "../skills" },
+    { "path": "../users" }
+  ]
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,23 @@ This project adheres to the [Code of Conduct and Covenant](CODE_OF_CONDUCT.md). 
 
 We follow a **lazy consensus** approach: changes proposed by people with responsibility for a problem, without disagreement from others, within a bounded time window of review by their peers, should be accepted.
 
+### Feature Development Lifecycle (Product -> UI/UX -> Engineering)
+
+To ensure high-fidelity UI/UX design matches technical capabilities and backend architecture, all new user-facing features must progress through the following sequential phases:
+
+1. **Product Specification**:
+   - Product requirements must be drafted as a spec (e.g., `product_spec.md` or `prd.md`) within a new subdirectory under `specs/changes/[feature-name]/`.
+   - The spec must be referenced in the main roadmap ([specs/main/roadmap.md](file:///usr/local/google/home/jkramberger/jetski-temp/llm-d-prism/specs/main/roadmap.md)), showing the relative prioritization and ordering of the feature specs.
+
+2. **UI/UX Mockups & Functional Specs**:
+   - The UI/UX team consumes the product specs and designs the interface mocks.
+   - These mocks must be paired with an **Implementation Spec** (e.g., `ui_spec.md`) that outlines each added UI element, component interactions, and intended user flow.
+   - Any UI/UX mock implementations, frontend-only code, or visual prototypes must be pushed to a dedicated `next` branch (separate from `main`) for early feedback and stakeholder review.
+
+3. **Engineering Design & Alignment**:
+   - Engineering consumes the implementation and product specs to produce an **Engineering Design Spec** (e.g., `design.md`), defining changes required in the Prism backend services and the benchmark results store (GCS/Drive schemas).
+   - This phase ensures that backend infrastructure can support the workflows mocked by UI/UX. No code implementing the mock features may be merged to the `main` branch until the Engineering Design Spec has been reviewed and approved.
+
 ### Types of Contributions
 
 #### 1. Features with Public APIs or New Components

--- a/skills/enforce-development-loop/SKILL.md
+++ b/skills/enforce-development-loop/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: enforce-development-loop
+description: Enforce the Product -> UI/UX -> Engineering development loop for new features. Run when starting a feature, reviewing progress, or before merging to main.
+---
+
+# Enforce Development Loop
+
+## Purpose
+
+Enforce the Product -> UI/UX -> Engineering development loop to ensure all user-facing features have product specs, UI/UX mocks with implementation specs, and engineering design specs before core implementation begins. This prevents engineering mismatches and ensures data layer compatibility.
+
+## Usage
+
+Use this skill when:
+- Starting a new feature.
+- Reviewing a feature's progress.
+- Validating a PR before merging.
+
+## Workflow
+
+### Step 1: Identify the Feature Name and Scope
+1. Ask the user for the feature name (which should correspond to a directory under `specs/changes/[feature-name]/`).
+2. If not specified, look for active directories in `specs/changes/` that might be relevant.
+
+### Step 2: Validate Product Phase
+1. Check if the product spec exists: `specs/changes/[feature-name]/product_spec.md` (or `prd.md`, or `proposal.md` with product details).
+2. If it does not exist, pause and instruct the user to draft the Product Spec first.
+3. Check the roadmap ([specs/main/roadmap.md](file:///usr/local/google/home/jkramberger/jetski-temp/llm-d-prism/specs/main/roadmap.md)) to verify if the product spec is referenced.
+4. If not referenced, alert the user that the feature is not currently tracked in the roadmap and must be added.
+
+### Step 3: Validate UI/UX Phase
+1. Check if the UI/UX implementation spec exists: `specs/changes/[feature-name]/ui_spec.md` (or `specs.md` with UI details).
+2. Verify that the UI/UX implementation spec outlines every new/modified UI element and its functionality.
+3. Check if there are active UI/UX mocks or prototypes.
+4. Verify that UI/UX mockup/prototype code is pushed to the `next` branch (or a dedicated feature branch), not `main`.
+   - Run `git branch --contains` or check the current branch name.
+   - If changes are on `main`, alert the user that UI/UX work must be isolated on `next` or a feature branch.
+
+### Step 4: Validate Engineering Phase
+1. Check if the engineering design spec exists: `specs/changes/[feature-name]/design.md`.
+2. Verify that the design spec outlines:
+   - Required changes to the Prism backend.
+   - Required changes to the results store / database schema.
+3. If the UI changes require backend/schema updates and the design spec is missing, pause and instruct the user/agent to draft the Engineering Design Spec first.
+
+### Step 5: Final Compliance Check
+Provide a summary table of the development loop compliance:
+
+| Phase | Artifact / Check | Status | Action Required |
+|---|---|---|---|
+| **Product** | `product_spec.md` / `proposal.md` | [Pass/Fail/Missing] | |
+| **Product** | Referenced in Roadmap | [Pass/Fail/Missing] | |
+| **UI/UX** | `ui_spec.md` / `specs.md` | [Pass/Fail/Missing] | |
+| **UI/UX** | Code isolated (not on `main`) | [Pass/Fail] | |
+| **Engineering**| `design.md` (if needed) | [Pass/Fail/Not Needed] | |
+
+If any critical checks fail, do not proceed with merging implementation code to `main`.

--- a/specs/main/roadmap.md
+++ b/specs/main/roadmap.md
@@ -1,0 +1,45 @@
+# Prism Roadmap & Spec Prioritization
+
+This document tracks upcoming features, their product specifications, and their current phase in the Feature Development Lifecycle.
+
+## Feature Phases
+- **Product**: Specifying product requirements.
+- **UI/UX**: Designing mocks and implementation specs. Pushed to `next` branch.
+- **Engineering**: Backend and data schema design.
+- **Implementation**: Active development on main codebase.
+- **Completed**: Merged to `main` and deployed.
+
+---
+
+## 🗺️ Roadmap & Prioritization
+
+### 🟢 Priority 1: Core Performance Optimization & Gateway Ingestion
+
+1. **Prefix Cache Offloading Guide**
+   - **Product Spec:** [prefix-cache-offload-guide-proposal.md](../changes/prefix-cache-offload-guide-proposal.md)
+   - **Status:** Completed
+   - **Notes:** Baseline caching strategies integrated.
+
+2. **KV Cache Size & Parameter Insights**
+   - **Product Spec:** [kv_cache_optimizations_prd.md](../changes/kv_cache_optimizations_prd.md)
+   - **Status:** Engineering Design
+   - **Notes:** Backend schema changes are currently being reviewed to support indexing KV Cache sizes from Lohi.
+
+### 🟡 Priority 2: Advanced Visualization & Analytics
+
+3. **Disaggregated Benchmarking (P/D Split)**
+   - **Product Spec:** [disagg-benchmarks-proposal.md](../changes/disagg-benchmarks-proposal.md)
+   - **Status:** UI/UX (Mocks on `next` branch)
+   - **Notes:** Initial mockups show side-by-side comparison of Prefill/Decode metrics. Implementation spec is under review.
+
+4. **Predicted Latency-Based Scheduling**
+   - **Product Spec:** [predicted_latency_scheduling_prd.md](../changes/predicted_latency_scheduling_prd.md)
+   - **Status:** Product Spec
+   - **Notes:** High-level spec drafted. Waiting for UI/UX phase.
+
+### 🔴 Priority 3: Explorations & Future Features
+
+5. **Reinforcement Learning Benchmarks Exploration**
+   - **Product Spec:** [rl-benchmarks-exploration.md](../changes/rl-benchmarks-exploration.md)
+   - **Status:** Discovery & Exploration
+   - **Notes:** Early-stage analysis on how to map RL serving workloads.


### PR DESCRIPTION
- Update CONTRIBUTING.md to document the sequential lifecycle: Product Spec -> UI/UX Mockups & Implementation Spec -> Engineering Design Spec.
- Add specs/main/roadmap.md as the high-level roadmap to track and prioritize product specs.
- Add skills/enforce-development-loop/SKILL.md agent skill to automate validation of this development loop.
- Register new skills in .agents/skills.json.
