### PR TITLE
docs: make roadmap links relative in contributing guide and agent skill

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,7 @@ To ensure high-fidelity UI/UX design matches technical capabilities and backend 
 
 1. **Product Specification**:
    - Product requirements must be drafted as a spec (e.g., `product_spec.md` or `prd.md`) within a new subdirectory under `specs/changes/[feature-name]/`.
-   - The spec must be referenced in the main roadmap ([specs/main/roadmap.md](file:///usr/local/google/home/jkramberger/jetski-temp/llm-d-prism/specs/main/roadmap.md)), showing the relative prioritization and ordering of the feature specs.
+   - The spec must be referenced in the main roadmap ([specs/main/roadmap.md](specs/main/roadmap.md)), showing the relative prioritization and ordering of the feature specs.
 
 2. **UI/UX Mockups & Functional Specs**:
    - The UI/UX team consumes the product specs and designs the interface mocks.

--- a/skills/enforce-development-loop/SKILL.md
+++ b/skills/enforce-development-loop/SKILL.md
@@ -25,7 +25,7 @@ Use this skill when:
 ### Step 2: Validate Product Phase
 1. Check if the product spec exists: `specs/changes/[feature-name]/product_spec.md` (or `prd.md`, or `proposal.md` with product details).
 2. If it does not exist, pause and instruct the user to draft the Product Spec first.
-3. Check the roadmap ([specs/main/roadmap.md](file:///usr/local/google/home/jkramberger/jetski-temp/llm-d-prism/specs/main/roadmap.md)) to verify if the product spec is referenced.
+3. Check the roadmap ([specs/main/roadmap.md](../../specs/main/roadmap.md)) to verify if the product spec is referenced.
 4. If not referenced, alert the user that the feature is not currently tracked in the roadmap and must be added.
 
 ### Step 3: Validate UI/UX Phase


### PR DESCRIPTION
Fix absolute paths in markdown