### PR TITLE
implement GCS metadata indexing and backfill CLI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/storage": "^7.21.0",
         "@tailwindcss/vite": "^4.1.17",
         "clsx": "^2.1.1",
+        "commander": "^14.0.3",
         "compression": "^1.7.4",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
@@ -2492,6 +2493,15 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/commander": {
+      "version": "14.0.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+      "integrity": "sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/compressible": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "preview": "vite preview",
     "update-metrics": "python3 tools/update_arena_scores.py",
+    "backfill-metadata": "tsx tools/backfill_metadata/index.ts",
     "artifactregistry-login": "npm_config_registry=https://registry.npmjs.org npx google-artifactregistry-auth",
     "zipline": "rm -f zipline-upload.zip && npm run build && zip -r zipline-upload.zip dist/*"
   },
@@ -19,6 +20,7 @@
     "@google-cloud/storage": "^7.21.0",
     "@tailwindcss/vite": "^4.1.17",
     "clsx": "^2.1.1",
+    "commander": "^14.0.3",
     "compression": "^1.7.4",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",

--- a/server/results/api.ts
+++ b/server/results/api.ts
@@ -96,3 +96,42 @@ export interface PrismResultContext {
     model_name: { value: string };
     run_label: { value: string };
 }
+
+/**
+ * Minified summary structure stored inside the GCS metadata field `prism_summary`.
+ * Contains the key metrics, metadata, and workload configuration for a stage.
+ */
+export interface PrismSummaryEntry {
+    runLabel: string;
+    github_author?: any;
+    model: string;
+    model_name: string;
+    hardware: string;
+    precision: string;
+    backend: string;
+    isl: number;
+    osl: number;
+    timestamp: string | null;
+    throughput: number | null;
+    latency: {
+        mean: number | null;
+    };
+    components: any[];
+    metadata: {
+        model_name: string;
+        backend: string;
+        hardware: string;
+        accelerator_type: string;
+        accelerator_count: number;
+        precision: string;
+        timestamp: string | null;
+        tp: number;
+        architecture: string;
+        components: any[];
+    };
+    workload: {
+        input_tokens: number;
+        output_tokens: number;
+        stage: number;
+    };
+}

--- a/server/results/gcs.ts
+++ b/server/results/gcs.ts
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import type { PrismResultPayload, PrismSubmissionState, PrismResultContext } from './api.ts';
+import type { PrismResultPayload, PrismSubmissionState, PrismResultContext, PrismSummaryEntry } from './api.ts';
 import { Storage } from '@google-cloud/storage';
+import { parseReportV02, stageToEntry } from '../../src/utils/benchmarkReportV02Parser.js';
+import { parseJsonEntry } from '../../src/utils/dataParser.js';
+import yaml from 'js-yaml';
 
 export const storage = new Storage(
     process.env.GOOGLE_APPLICATION_DEFAULT_CREDENTIALS
@@ -35,6 +38,7 @@ export function getPrismResultsBucket(): string {
 
 export type ResultsListItem = Omit<PrismResultPayload, 'entries'> & {
     state: PrismSubmissionState;
+    summary?: PrismSummaryEntry[];
 };
 
 export interface ListResultsOptions {
@@ -61,6 +65,43 @@ function decodePageToken(tokenStr: string): { gcsToken: string; skipCount: numbe
     } catch (e) {
         return { gcsToken: '', skipCount: 0 };
     }
+}
+
+function resolveRunTimestamp(path: string, metadata?: any, summary?: any): string | null {
+    if (summary) {
+        if (Array.isArray(summary) && summary[0]?.timestamp) return String(summary[0].timestamp);
+        if (summary.timestamp) return String(summary.timestamp);
+    }
+    const customTs = metadata?.metadata?.timestamp || metadata?.customMetadata?.timestamp;
+    if (customTs) return String(customTs);
+
+    const isoDateMatch = path.match(/(\d{4}-\d{2}-\d{2})/);
+    if (isoDateMatch) {
+        return `${isoDateMatch[1]}T00:00:00Z`;
+    }
+    const compactDateMatch = path.match(/runner-(\d{4})(\d{2})(\d{2})/);
+    if (compactDateMatch) {
+        return `${compactDateMatch[1]}-${compactDateMatch[2]}-${compactDateMatch[3]}T00:00:00Z`;
+    }
+
+    return metadata?.timeCreated || metadata?.updated || null;
+}
+
+function resolveModelName(path: string, metadata?: any, summary?: any): string {
+    const fromMeta = metadata?.contexts?.custom?.model_name?.value || metadata?.metadata?.model_name;
+    if (fromMeta && fromMeta !== 'Unknown') return String(fromMeta);
+
+    if (summary) {
+        if (Array.isArray(summary) && summary[0]?.model_name && summary[0].model_name !== 'Unknown') return String(summary[0].model_name);
+        if (summary.model_name && summary.model_name !== 'Unknown') return String(summary.model_name);
+    }
+
+    const filename = path.split('/').pop() || '';
+    if (filename && filename !== 'Unknown' && !filename.startsWith('runner-')) {
+        return filename.replace(/\.json$/, '').replace(/\.yaml$/, '');
+    }
+
+    return 'Unknown';
 }
 
 /**
@@ -100,6 +141,7 @@ export async function listResults(options: ListResultsOptions): Promise<ListResu
     const matchesFilters = (state: PrismSubmissionState, user: string): boolean => {
         return filters.every(f => f(state, user));
     };
+
 
     // Construct single query filter parameter if possible as GCS side optimization
     let gcsFilter: string | undefined;
@@ -145,7 +187,10 @@ export async function listResults(options: ListResultsOptions): Promise<ListResu
             const runIdMatch = file.name.match(/prism-results-store\/([^/]+)\.v1\.json/);
             const runId = runIdMatch ? runIdMatch[1] : String(customContexts.run_id?.value || customMetadata.run_id || '');
             const runLabel = String(customContexts.run_label?.value || customMetadata.run_label || customMetadata.runLabel || runId);
-            const model_name = String(customContexts.model_name?.value || customMetadata.model_name || 'Unknown');
+            const summaryVal = customMetadata.prism_summary;
+            const summary = summaryVal ? JSON.parse(String(summaryVal)) : undefined;
+
+            const model_name = resolveModelName(file.name, metadata, summary);
             const hardware_name = String(customContexts.hardware_name?.value || customMetadata.hardware_name || 'Unknown');
 
             matchedItems.push({
@@ -160,7 +205,8 @@ export async function listResults(options: ListResultsOptions): Promise<ListResu
                 github_author: {
                     username: itemUser || 'Unknown'
                 },
-                submitted_at: metadata?.timeCreated || metadata?.updated || null
+                submitted_at: resolveRunTimestamp(file.name, metadata, summary),
+                summary
             });
         }
 
@@ -227,6 +273,63 @@ export async function readResultMetadata(runId: string): Promise<{ user: string;
     }
 }
 
+function extractSummaryFromPayload(payload: PrismResultPayload): any[] {
+    const entries: any[] = [];
+    if (payload.entries && Array.isArray(payload.entries)) {
+        for (const entry of payload.entries) {
+            const parsedStage = parseReportV02(entry.raw_report, entry.filename);
+            if (parsedStage) {
+                parsedStage.runId = payload.runId;
+                parsedStage.runLabel = payload.runLabel;
+                parsedStage.run_metadata = payload.run_metadata;
+                if (payload.metadata?.config) {
+                    parsedStage.config = payload.metadata.config;
+                }
+                const fullEntry = stageToEntry(parsedStage);
+                if (payload.github_author) {
+                    fullEntry.github_author = payload.github_author;
+                }
+                entries.push(fullEntry);
+            }
+        }
+    }
+    
+    return entries.map(e => ({
+        runLabel: e.runLabel || e.run_description || '',
+        github_author: e.github_author,
+        model: e.model || e.model_name || 'Unknown',
+        model_name: e.model_name || e.model || 'Unknown',
+        hardware: e.hardware || e.metadata?.hardware || 'Unknown',
+        precision: e.precision || e.metadata?.precision || 'Unknown',
+        backend: e.backend || e.metadata?.backend || 'Unknown',
+        isl: e.isl || e.workload?.input_tokens || 0,
+        osl: e.osl || e.workload?.output_tokens || 0,
+        timestamp: e.timestamp || e.metadata?.timestamp || null,
+        throughput: e.throughput || e.metrics?.throughput || null,
+        latency: {
+            mean: e.latency?.mean ?? e.metrics?.latency?.mean ?? null
+        },
+        components: e.components || e.metadata?.components || [],
+        metadata: {
+            model_name: e.metadata?.model_name || e.model_name || 'Unknown',
+            backend: e.metadata?.backend || e.backend || 'Unknown',
+            hardware: e.metadata?.hardware || e.hardware || 'Unknown',
+            accelerator_type: e.metadata?.accelerator_type || e.hardware || 'Unknown',
+            accelerator_count: e.metadata?.accelerator_count || 1,
+            precision: e.metadata?.precision || 'Unknown',
+            timestamp: e.metadata?.timestamp || e.timestamp || null,
+            tp: e.metadata?.tp || 1,
+            architecture: e.metadata?.architecture || 'aggregate',
+            components: e.metadata?.components || e.components || []
+        },
+        workload: {
+            input_tokens: e.workload?.input_tokens || e.isl || 0,
+            output_tokens: e.workload?.output_tokens || e.osl || 0,
+            stage: e.workload?.stage ?? 1
+        }
+    }));
+}
+
 export async function writeResult(
     runId: string,
     payload: PrismResultPayload,
@@ -246,16 +349,302 @@ export async function writeResult(
         run_label: { value: payload.runLabel || runId }
     } satisfies PrismResultContext;
 
+    const summary = extractSummaryFromPayload(payload);
+    const summaryStr = JSON.stringify(summary);
+
     try {
         await file.save(JSON.stringify(payload), {
             contentType: 'application/json',
             metadata: {
                 contexts: {
                     custom: contextsCustom
+                },
+                metadata: {
+                    prism_summary: summaryStr
                 }
             }
         });
     } catch (e: any) {
         throw new Error(`GCS upload failed: ${e.message}`);
     }
+}
+
+export interface ListBenchmarksOptions {
+    bucket?: string;
+    prefix?: string;
+    limit: number;
+    pageToken?: string;
+    username?: string | null;
+    permission?: string;
+}
+
+export interface BenchmarkListItem {
+    runId: string;
+    runLabel: string | null;
+    isFromResultStore: boolean;
+    github_author?: { username: string };
+    model_name?: string;
+    hardware?: { hardware_name: string };
+    state?: string;
+    submitted_at: string | null;
+    downloadUrl: string;
+    summary?: any[];
+}
+
+export interface ListBenchmarksResult {
+    items: BenchmarkListItem[];
+    nextPageToken: string | null;
+}
+
+export async function listBenchmarks(options: ListBenchmarksOptions): Promise<ListBenchmarksResult> {
+    const { bucket: bucketParam, prefix, limit, pageToken, username, permission } = options;
+    const bucketName = bucketParam || getPrismResultsBucket();
+    
+    const { gcsToken, skipCount } = pageToken ? decodePageToken(pageToken) : { gcsToken: '', skipCount: 0 };
+    
+    const matchedItems: BenchmarkListItem[] = [];
+    const seenRunIds = new Set<string>();
+    let currentGcsToken = gcsToken;
+    let currentSkipCount = skipCount;
+    let hasMoreGcs = true;
+
+    while (matchedItems.length < limit && hasMoreGcs) {
+        const maxResults = 100;
+        const [files, nextQuery] = await storage.bucket(bucketName).getFiles({
+            prefix: prefix || undefined,
+            maxResults,
+            pageToken: currentGcsToken || undefined,
+            autoPaginate: false
+        });
+
+        const batchGroups: { [runId: string]: { file: any; originalIndex: number }[] } = {};
+        const groupOrder: string[] = [];
+
+        let i = currentSkipCount;
+        for (; i < files.length; i++) {
+            const file = files[i];
+            if (file.name.endsWith('/') || file.name.endsWith('.keep') || file.name.split('/').pop()?.startsWith('.')) {
+                continue;
+            }
+            const baseName = (file.name.split('/').pop() || '').toLowerCase();
+            if (baseName === 'per_request_lifecycle_metrics.json') {
+                continue;
+            }
+            const isResultsStoreFile = file.name.startsWith('prism-results-store/');
+            const isCandidate = baseName.startsWith('benchmark_report') && 
+                                (baseName.endsWith('.json') || baseName.endsWith('.yaml') || baseName.endsWith('.yml'));
+            if (!isResultsStoreFile && !isCandidate) {
+                continue;
+            }
+
+            const runIdMatch = file.name.match(/prism-results-store\/([^/]+)\.v1\.json/);
+            const runId = isResultsStoreFile
+                ? (runIdMatch ? runIdMatch[1] : String(file.metadata?.contexts?.custom?.run_id?.value || file.metadata?.metadata?.run_id || file.name))
+                : (file.name.includes('/') ? file.name.substring(0, file.name.lastIndexOf('/')) : file.name);
+
+            if (seenRunIds.has(runId)) {
+                continue;
+            }
+
+            if (!batchGroups[runId]) {
+                batchGroups[runId] = [];
+                groupOrder.push(runId);
+            }
+            batchGroups[runId].push({ file, originalIndex: i });
+        }
+
+        let groupIdx = 0;
+        for (; groupIdx < groupOrder.length && matchedItems.length < limit; groupIdx++) {
+            const runId = groupOrder[groupIdx];
+            const group = batchGroups[runId];
+
+            // If a folder has BRV02 OR BRV01 files, skip raw log and raw json entries
+            const brGroup = group.filter(g => {
+                const base = (g.file.name.split('/').pop() || '').toLowerCase();
+                return base.startsWith('benchmark_report');
+            });
+            const targetGroup = brGroup.length > 0 ? brGroup : group;
+
+            // Prioritize the file that has metadata summary
+            const representativeObj = targetGroup.find(g => g.file.metadata?.metadata?.prism_summary) || targetGroup[0];
+            const file = representativeObj.file;
+
+            const metadata = file.metadata;
+            const customContexts = metadata?.contexts?.custom || {};
+            const customMetadata = metadata?.metadata || {};
+            const isResultsStoreFile = file.name.startsWith('prism-results-store/');
+
+            const itemUser = String(customContexts.github_user?.value || customMetadata.user || '');
+            const itemState = String(customContexts.submission_state?.value || customMetadata.state || 'submitted_pending_processing');
+
+            // Enforce authorization for Results Store files
+            if (isResultsStoreFile && permission !== 'admin') {
+                const isApproved = itemState === 'public' || itemState === 'promoted';
+                const isOwn = !!(username && itemUser.toLowerCase() === username.toLowerCase());
+                if (!isApproved && !isOwn) {
+                    continue;
+                }
+            }
+
+            seenRunIds.add(runId);
+
+            const rawRunLabel = customContexts.run_label?.value || customMetadata.run_label || customMetadata.runLabel;
+            const runLabel = rawRunLabel ? String(rawRunLabel) : null;
+            const summaryVal = customMetadata.prism_summary;
+            const summary = summaryVal ? JSON.parse(String(summaryVal)) : undefined;
+
+            const downloadPath = isResultsStoreFile ? file.name : runId;
+
+            const item: BenchmarkListItem = {
+                runId,
+                runLabel,
+                isFromResultStore: isResultsStoreFile,
+                github_author: itemUser ? { username: itemUser } : undefined,
+                submitted_at: resolveRunTimestamp(file.name, metadata, summary),
+                downloadUrl: `/api/benchmarks/content?path=${encodeURIComponent(downloadPath)}&bucket=${encodeURIComponent(bucketName)}`,
+                summary
+            };
+
+            if (isResultsStoreFile) {
+                const model_name = resolveModelName(file.name, metadata, summary);
+                const hardware_name = String(customContexts.hardware_name?.value || customMetadata.hardware_name || 'Unknown');
+                item.model_name = model_name;
+                item.hardware = {
+                    hardware_name
+                };
+                item.state = itemState;
+            }
+
+            matchedItems.push(item);
+        }
+
+        if (matchedItems.length === limit) {
+            let nextSkipCount = files.length;
+            if (groupIdx < groupOrder.length) {
+                const nextGroup = batchGroups[groupOrder[groupIdx]];
+                nextSkipCount = nextGroup[0].originalIndex;
+            }
+            const nextGcsToken = nextQuery?.pageToken || '';
+
+            let nextPageToken: string | null = null;
+            if (nextSkipCount < files.length) {
+                nextPageToken = encodePageToken({ gcsToken: currentGcsToken, skipCount: nextSkipCount });
+            } else if (nextGcsToken) {
+                nextPageToken = encodePageToken({ gcsToken: nextGcsToken, skipCount: 0 });
+            }
+
+            return {
+                items: matchedItems,
+                nextPageToken
+            };
+        }
+
+        if (nextQuery?.pageToken) {
+            currentGcsToken = nextQuery.pageToken;
+            currentSkipCount = 0;
+        } else {
+            hasMoreGcs = false;
+        }
+    }
+
+    return {
+        items: matchedItems,
+        nextPageToken: null
+    };
+}
+
+export async function readBenchmarkContent(bucketParam: string | undefined, path: string): Promise<string> {
+    const bucketName = bucketParam || getPrismResultsBucket();
+    const isFile = path.endsWith('.json') || path.endsWith('.yaml') || path.endsWith('.yml') || path.endsWith('.log');
+
+    if (isFile) {
+        const file = storage.bucket(bucketName).file(path);
+        const [contents] = await file.download();
+        return contents.toString('utf8');
+    }
+
+    // It's a directory/prefix path. List all candidate files inside, download, and merge them.
+    const [files] = await storage.bucket(bucketName).getFiles({
+        prefix: path.endsWith('/') ? path : `${path}/`
+    });
+
+    // Filter candidateFiles to only BRV01/BRV02 reports
+    const candidateFiles = files.filter(f => {
+        const baseName = (f.name.split('/').pop() || '').toLowerCase();
+        return baseName.startsWith('benchmark_report') && 
+               (baseName.endsWith('.json') || baseName.endsWith('.yaml') || baseName.endsWith('.yml'));
+    });
+
+    const v01Entries: any[] = [];
+    const v02Entries: any[] = [];
+
+    await Promise.all(candidateFiles.map(async f => {
+        try {
+            const [contents] = await f.download();
+            const contentStr = contents.toString('utf8');
+
+            let parsedDoc: any = null;
+            let isYaml = false;
+            let isJson = false;
+
+            try {
+                parsedDoc = JSON.parse(contentStr);
+                isJson = true;
+            } catch {
+                try {
+                    parsedDoc = yaml.load(contentStr);
+                    isYaml = true;
+                } catch {
+                    // Not valid JSON/YAML. Could be a raw log file.
+                }
+            }
+
+            let fileEntries: any[] = [];
+            let isV02File = false;
+
+            if (parsedDoc && typeof parsedDoc === 'object' && !Array.isArray(parsedDoc)) {
+                if (parsedDoc.version === '0.2') {
+                    isV02File = true;
+                    const parsedStage = parseReportV02(parsedDoc, f.name);
+                    if (parsedStage) {
+                        const entry = stageToEntry(parsedStage);
+                        fileEntries = [entry];
+                    }
+                } else if (parsedDoc.metrics || parsedDoc.load_summary) {
+                    const entry = parseJsonEntry({ ...parsedDoc, source: 'gcs' }, f.name);
+                    fileEntries = [entry];
+                }
+            }
+
+            if (fileEntries.length > 0) {
+                fileEntries.forEach(e => {
+                    if (!e.timestamp) {
+                        e.timestamp = resolveRunTimestamp(f.name);
+                        if (e.metadata) {
+                            e.metadata.timestamp = e.timestamp;
+                        }
+                    }
+                    if (!e.runLabel) {
+                        const parts = f.name.split('/');
+                        parts.pop();
+                        const folderBase = parts.filter(Boolean).pop() || '';
+                        e.runLabel = folderBase || null;
+                    }
+                    e._source_file = f.name;
+                });
+
+                if (isV02File) {
+                    v02Entries.push(...fileEntries);
+                } else {
+                    v01Entries.push(...fileEntries);
+                }
+            }
+        } catch (err: any) {
+            console.warn(`[readBenchmarkContent] Failed to parse file ${f.name}:`, err.message);
+        }
+    }));
+
+    // Apply V0.2 vs V0.1 precedence rules
+    const finalEntries = v02Entries.length > 0 ? v02Entries : v01Entries;
+    return JSON.stringify(finalEntries);
 }

--- a/server/results/index.ts
+++ b/server/results/index.ts
@@ -16,16 +16,20 @@ import { Router } from 'express';
 import { listResultsHandler } from './routes/list.ts';
 import { submitResultsHandler } from './routes/submit.ts';
 import { getResultsHandler } from './routes/get.ts';
+import { listBenchmarksHandler, getBenchmarkContentHandler } from './routes/benchmarks.ts';
 
 export const resultsRouter = Router();
 
 resultsRouter.get('/api/results', listResultsHandler);
 resultsRouter.post('/api/results', submitResultsHandler);
 resultsRouter.get('/api/results/:runId', getResultsHandler);
+resultsRouter.get('/api/benchmarks', listBenchmarksHandler);
+resultsRouter.get('/api/benchmarks/content', getBenchmarkContentHandler);
 
 export * from './routes/list.ts';
 export * from './routes/submit.ts';
 export * from './routes/get.ts';
+export * from './routes/benchmarks.ts';
 export * from './processing.ts';
 export * from './gcs.ts';
 export * from './api.ts';

--- a/server/results/routes/benchmarks.ts
+++ b/server/results/routes/benchmarks.ts
@@ -1,0 +1,121 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Request, Response } from 'express';
+import { validateGitHubToken } from '../../oauth.ts';
+import { listBenchmarks, readBenchmarkContent, readResultMetadata } from '../gcs.ts';
+
+export async function listBenchmarksHandler(req: Request, res: Response) {
+    const token = req.headers['x-prism-github-token'] as string | undefined;
+    let username: string | null = null;
+    let permission = 'none';
+
+    if (token) {
+        try {
+            const authResult = await validateGitHubToken(token);
+            username = authResult.username;
+            permission = authResult.permission;
+        } catch (e: any) {
+            console.warn('[Benchmarks API] Invalid session token:', e.message);
+        }
+    }
+
+    const bucket = req.query.bucket as string | undefined;
+    const prefix = req.query.prefix as string | undefined;
+    const limit = Math.min(parseInt(req.query.limit as string || '', 10) || 20, 100);
+    const pageToken = req.query.pageToken as string | undefined;
+
+    try {
+        const results = await listBenchmarks({
+            bucket,
+            prefix,
+            limit,
+            pageToken,
+            username,
+            permission
+        });
+        res.json(results);
+    } catch (error: any) {
+        console.error('[Benchmarks List Error]', error);
+        res.status(500).json({ error: 'Failed to list benchmarks', details: error.message });
+    }
+}
+
+export async function getBenchmarkContentHandler(req: Request, res: Response) {
+    const token = req.headers['x-prism-github-token'] as string | undefined;
+    let username: string | null = null;
+    let permission = 'none';
+
+    if (token) {
+        try {
+            const authResult = await validateGitHubToken(token);
+            username = authResult.username;
+            permission = authResult.permission;
+        } catch (e: any) {
+            console.warn('[Benchmarks Content API] Invalid session token:', e.message);
+        }
+    }
+
+    const path = req.query.path as string;
+    const bucket = req.query.bucket as string | undefined;
+
+    if (!path) {
+        return res.status(400).json({ error: 'Missing path parameter.' });
+    }
+
+    try {
+        // Enforce authorization for prism-results-store files
+        if (path.startsWith('prism-results-store/')) {
+            const runIdMatch = path.match(/prism-results-store\/([^/]+)\.v1\.json/);
+            const runId = runIdMatch ? runIdMatch[1] : '';
+            if (runId) {
+                const metadata = await readResultMetadata(runId);
+                if (!metadata) {
+                    return res.status(404).json({ error: 'Result not found' });
+                }
+
+                const { user: itemUser, state: itemState } = metadata;
+                let allowed = false;
+                if (permission === 'admin') {
+                    allowed = true;
+                } else {
+                    if (itemState === 'public' || itemState === 'promoted') {
+                        allowed = true;
+                    } else if (username && itemUser.toLowerCase() === username.toLowerCase()) {
+                        allowed = true;
+                    }
+                }
+
+                if (!allowed) {
+                    return res.status(403).json({ error: 'Access denied. You do not have permissions to view this result.' });
+                }
+            }
+        }
+
+        const content = await readBenchmarkContent(bucket, path);
+        
+        if (path.endsWith('.json')) {
+            res.setHeader('Content-Type', 'application/json');
+        } else if (path.endsWith('.yaml') || path.endsWith('.yml')) {
+            res.setHeader('Content-Type', 'text/yaml');
+        } else {
+            res.setHeader('Content-Type', 'text/plain');
+        }
+        res.send(content);
+
+    } catch (error: any) {
+        console.error('[Benchmark Content Error]', error);
+        res.status(500).json({ error: 'Failed to retrieve benchmark content', details: error.message });
+    }
+}

--- a/specs/main/results-api/README.md
+++ b/specs/main/results-api/README.md
@@ -55,9 +55,9 @@ upstream repository:
   [Benchmark Report README](https://github.com/llm-d/llm-d-benchmark/blob/main/llmdbenchmark/analysis/benchmark_report/README.md)
 - **JSON Schema:**
   [br_v0_2_json_schema.json](https://github.com/llm-d/llm-d-benchmark/blob/main/llmdbenchmark/analysis/benchmark_report/br_v0_2_json_schema.json)
-  - _Note:_ The JSON schema is historically too strict for practical ingestion.
-    Prism treats all fields in this schema as optional/partial by default to
-    handle missing or incomplete metrics gracefully.
+    - _Note:_ The JSON schema is historically too strict for practical
+      ingestion. Prism treats all fields in this schema as optional/partial by
+      default to handle missing or incomplete metrics gracefully.
 - **Canonical Example:**
   [br_v0_2_example.yaml](https://github.com/llm-d/llm-d-benchmark/blob/main/llmdbenchmark/analysis/benchmark_report/br_v0_2_example.yaml)
 
@@ -77,21 +77,21 @@ The shared isomorphic parser validates a complete bundle under the following
 criteria:
 
 1. **Root Fields Check:**
-   - `format` must be exactly `"brv02"`.
-   - `model_name` must be present and not `'Unknown'`.
-   - When uploading to the cloud (`isUpload: true`), `hardware.hardware_name`
-     must be present and not `'Unknown'` or `'Unknown Hardware'`.
+    - `format` must be exactly `"brv02"`.
+    - `model_name` must be present and not `'Unknown'`.
+    - When uploading to the cloud (`isUpload: true`), `hardware.hardware_name`
+      must be present and not `'Unknown'` or `'Unknown Hardware'`.
 2. **Stage Consistency Checks:**
-   - Every stage entry in the `entries` array is parsed and analyzed.
-   - **Model Consistency:** The model parsed from each stage report must exactly
-     match the root-level `model_name`.
-   - **Hardware Consistency:** The hardware parsed from each stage report must
-     exactly match the root-level `hardware.hardware_name`.
-   - **Run UID Integrity:** If specified, the stage's internal `run.uid` must
-     match `entry.run_uid`.
+    - Every stage entry in the `entries` array is parsed and analyzed.
+    - **Model Consistency:** The model parsed from each stage report must
+      exactly match the root-level `model_name`.
+    - **Hardware Consistency:** The hardware parsed from each stage report must
+      exactly match the root-level `hardware.hardware_name`.
+    - **Run UID Integrity:** If specified, the stage's internal `run.uid` must
+      match `entry.run_uid`.
 3. **Metric Integrity Validation:**
-   - Rejects any stage with zero or negative performance metrics (e.g.,
-     throughput <= 0, or E2E request latency <= 0).
+    - Rejects any stage with zero or negative performance metrics (e.g.,
+      throughput <= 0, or E2E request latency <= 0).
 
 ### 4.3 Fallback and Enrichment Flow
 
@@ -135,33 +135,39 @@ location of the benchmark files is instead determined by the deployment
 environment:
 
 - **`staged`** (Staged):
-  - **Benchmark is locally stored in the browser**, user has not submitted yet.
-  - Useful for previewing benchmarks before submitting.
-  - Useful if user doesn’t even want to upload, they just wanted to locally store it for themselves to view.
+    - **Benchmark is locally stored in the browser**, user has not submitted
+      yet.
+    - Useful for previewing benchmarks before submitting.
+    - Useful if user doesn’t even want to upload, they just wanted to locally
+      store it for themselves to view.
 - **`submitted_pending_processing`** (Submitted, Pending Processing):
-  - **Benchmark made it into Prism Cloud** (staging GCS bucket).
-  - Pending automated preliminary processing and filtering.
-    - NOW: includes basic sanity checks:
-      - Are any results zeroed?
-      - Are there too many request failures?
-      - Does it include attributions? Correct formatting (BRV02)?
-    - FUTURE: can include more checks as part of the *validation pipeline*.
-  - Can tack on more metadata or override them on server side.
-    - NOW: necessary for proper attribution enforcement.
-    - FUTURE: necessary for input sanitization in the future.
+    - **Benchmark made it into Prism Cloud** (staging GCS bucket).
+    - Pending automated preliminary processing and filtering.
+        - NOW: includes basic sanity checks:
+            - Are any results zeroed?
+            - Are there too many request failures?
+            - Does it include attributions? Correct formatting (BRV02)?
+        - FUTURE: can include more checks as part of the _validation pipeline_.
+    - Can tack on more metadata or override them on server side.
+        - NOW: necessary for proper attribution enforcement.
+        - FUTURE: necessary for input sanitization in the future.
 - **`submitted_pending_review`** (Submitted, Pending Final Review):
-  - User review, if necessary.
-    - Eventually this stage will be skipped straight to the next one once validation pipeline is robust enough.
-  - See [\[External\] llm-d Results Store Submission Policy](https://docs.google.com/document/u/0/d/1EZI-VYXdM9V3KnoWkFIXmihrgO2t7YZZhgeMuIlZDpI/edit?resourcekey=0-xQu9xYrRcroMn5yogcb_xg).
+    - User review, if necessary.
+        - Eventually this stage will be skipped straight to the next one once
+          validation pipeline is robust enough.
+    - See
+      [\[External\] llm-d Results Store Submission Policy](https://docs.google.com/document/u/0/d/1EZI-VYXdM9V3KnoWkFIXmihrgO2t7YZZhgeMuIlZDpI/edit?resourcekey=0-xQu9xYrRcroMn5yogcb_xg).
 - **`public`** (Public):
-  - All reviews done, benchmark now public in the sea of benchmarks.
-  - **UNCLEAR:** Clean way to show potentially thousands of benchmarks, Manage Benchmarks page **will not scale**.
+    - All reviews done, benchmark now public in the sea of benchmarks.
+    - **UNCLEAR:** Clean way to show potentially thousands of benchmarks, Manage
+      Benchmarks page **will not scale**.
 - **`promoted`** (Public, Promoted):
-  - If chosen during submission to be one of the well-lit paths, then benchmark results have been included in said well-lit path’s results.
-  - Implies additional visibility from just sea of benchmarks.
+    - If chosen during submission to be one of the well-lit paths, then
+      benchmark results have been included in said well-lit path’s results.
+    - Implies additional visibility from just sea of benchmarks.
 - **`rejected`** (Rejected):
-  - Failed any of the above checks (or include reason otherwise).
-  - Deleted off cloud.
+    - Failed any of the above checks (or include reason otherwise).
+    - Deleted off cloud.
 
 ### 6.2 State Transitions
 
@@ -177,10 +183,10 @@ stateDiagram-v2
 ```
 
 - Permissions & Authentication:
-  - `staged`: Open to all (no login required).
-  - `submitted_pending_processing`: Requires GitHub OAuth. Only allowlisted
-    users can submit.
-  - `submitted_pending_review` -> `public`: Requires Admin privileges.
+    - `staged`: Open to all (no login required).
+    - `submitted_pending_processing`: Requires GitHub OAuth. Only allowlisted
+      users can submit.
+    - `submitted_pending_review` -> `public`: Requires Admin privileges.
 
 ### 6.3 Synchronous vs. Asynchronous Validation
 
@@ -208,16 +214,16 @@ This section describes the storage backend using Google Cloud Storage (GCS).
 ### 7.1 Bucket Architecture
 
 - **Staging Bucket (`gs://llm-d-benchmarks-staging/prism-results-store/*`):**
-  - **Local Dev/Staging Environment:** Managed wholly inside this bucket. Stores
-    all benchmark uploads AND approvals (across all states).
-  - **Production Environment:** Never touched.
+    - **Local Dev/Staging Environment:** Managed wholly inside this bucket.
+      Stores all benchmark uploads AND approvals (across all states).
+    - **Production Environment:** Never touched.
 - **Production Bucket (`gs://llm-d-benchmarks/prism-results-store/*`):**
-  - **Local Dev/Staging Environment:** Read-only (never written to). Used for
-    reading data and configurations.
-  - **Production Environment:** Managed wholly inside this bucket. Stores all
-    benchmark uploads AND approvals (across all states).
+    - **Local Dev/Staging Environment:** Read-only (never written to). Used for
+      reading data and configurations.
+    - **Production Environment:** Managed wholly inside this bucket. Stores all
+      benchmark uploads AND approvals (across all states).
 - **IAM configuration files (`gs://llm-d-benchmarks/prism-iam/*`):**
-  - Dedicated bucket for access control files.
+    - Dedicated bucket for access control files.
 
 ### 7.2 File Pathing
 
@@ -245,16 +251,16 @@ to allow listing and filtering without reading the file contents.
 
 - **Maximum Contexts:** 50 keys per object.
 - **Required Metadata Contexts:**
-  - `submission_state`: The submission status (e.g.,
-    `submitted_pending_processing`, `submitted_pending_review`, `public`,
-    `promoted`). Maps to `PrismResultContext.submission_state`.
-  - `github_user`: The GitHub username of the contributor (for attribution).
-    Maps to `PrismResultContext.github_user`.
-  - `run_id`: The unique run identifier.
+    - `submission_state`: The submission status (e.g.,
+      `submitted_pending_processing`, `submitted_pending_review`, `public`,
+      `promoted`). Maps to `PrismResultContext.submission_state`.
+    - `github_user`: The GitHub username of the contributor (for attribution).
+      Maps to `PrismResultContext.github_user`.
+    - `run_id`: The unique run identifier.
 - **Optional/Future Contexts:**
-  - `hardware_name`: Normalized accelerator name.
-  - `model_name`: Normalized model name.
-  - `run_label`: Human-friendly run description label.
+    - `hardware_name`: Normalized accelerator name.
+    - `model_name`: Normalized model name.
+    - `run_label`: Human-friendly run description label.
 
 ### 7.4 GCS Listing & Pagination Strategy (Logical Operator Workaround)
 
@@ -270,12 +276,12 @@ constraint while keeping GCS-side filtering fast and optimized:
 2. **Client-Side Split-Listing Strategy:** To display a unified dashboard with
    both the user's own benchmarks (staged/pending/processing/etc.) and public
    approved benchmarks:
-   - The frontend client fires two separate listing requests to the backend with
-     separate query params and pagination strings (e.g. one for `own=true` and
-     another for `status=public` / `status=promoted`).
-   - The frontend displays the user's own benchmarks on top. It lists the
-     current user's benchmarks until exhausted, then paginates/transitions to
-     listing the public ones.
+    - The frontend client fires two separate listing requests to the backend
+      with separate query params and pagination strings (e.g. one for `own=true`
+      and another for `status=public` / `status=promoted`).
+    - The frontend displays the user's own benchmarks on top. It lists the
+      current user's benchmarks until exhausted, then paginates/transitions to
+      listing the public ones.
 
 ---
 
@@ -311,9 +317,9 @@ To support scaling beyond GCS object context limits (50 keys max, pagination
 issues), a database migration (e.g., BigQuery or Spanner) is planned.
 
 - **Requirements:**
-  - Latency < 10 seconds for listing and filtering > 100k benchmarks.
-  - Full support for pagination.
-  - Support for batch processing raw data for well-lit path analysis.
+    - Latency < 10 seconds for listing and filtering > 100k benchmarks.
+    - Full support for pagination.
+    - Support for batch processing raw data for well-lit path analysis.
 
 ---
 

--- a/specs/main/results-api/iam.md
+++ b/specs/main/results-api/iam.md
@@ -11,18 +11,29 @@ Prism uses GitHub OAuth for user authentication. When a user logs in, they
 authorize the Prism GitHub App, which issues an access token.
 
 1. **Token Verification**:
-   - The client includes the token in the `X-Prism-Github-Token` header for
-     request authorization.
-   - The backend queries `GET https://api.github.com/user` to verify the token's
-     validity and retrieve the authenticated user's GitHub username.
+    - The client includes the token in the `X-Prism-Github-Token` header for
+      request authorization.
+    - The backend queries `GET https://api.github.com/user` to verify the
+      token's validity and retrieve the authenticated user's GitHub username.
 
 ### 1.1 Base URL & OAuth Redirect URI (`PUBLIC_URL`)
 
-When initiating the OAuth flow, the backend must construct the absolute `redirect_uri` pointing back to its callback handler (`/api/auth/github/callback`). The base URL of the deployment is resolved using the `PUBLIC_URL` environment variable:
+When initiating the OAuth flow, the backend must construct the absolute
+`redirect_uri` pointing back to its callback handler
+(`/api/auth/github/callback`). The base URL of the deployment is resolved using
+the `PUBLIC_URL` environment variable:
 
-- **What it does:** Sets the canonical external URL of the Prism deployment (e.g. `https://prism-dashboard.com` or `http://localhost:8081`).
-- **Why it's needed:** Behind reverse proxies, load balancers, or CDN endpoints, request headers (like `req.protocol` or `req.get('host')`) can be modified or stripped. Setting `PUBLIC_URL` explicitly guarantees the correct hostname and HTTPS protocol are utilized for building OAuth callback targets, preventing GitHub authorization redirect failures.
-- **Fallback Behavior:** If `PUBLIC_URL` is omitted (default: empty/undefined), the server dynamically detects the base URL from the incoming request headers, supporting the `X-Forwarded-Host` and `X-Forwarded-Proto` headers when running behind trusted proxies.
+- **What it does:** Sets the canonical external URL of the Prism deployment
+  (e.g. `https://prism-dashboard.com` or `http://localhost:8081`).
+- **Why it's needed:** Behind reverse proxies, load balancers, or CDN endpoints,
+  request headers (like `req.protocol` or `req.get('host')`) can be modified or
+  stripped. Setting `PUBLIC_URL` explicitly guarantees the correct hostname and
+  HTTPS protocol are utilized for building OAuth callback targets, preventing
+  GitHub authorization redirect failures.
+- **Fallback Behavior:** If `PUBLIC_URL` is omitted (default: empty/undefined),
+  the server dynamically detects the base URL from the incoming request headers,
+  supporting the `X-Forwarded-Host` and `X-Forwarded-Proto` headers when running
+  behind trusted proxies.
 
 ---
 
@@ -64,15 +75,15 @@ the following GCS paths:
 
 - **Local Development / Staging Mode** (when `llm-d-benchmarks-staging` is
   present in `DEFAULT_BUCKETS`):
-  - **User Allowlist**:
-    `gs://llm-d-benchmarks-staging/prism-iam/github-user-allowlist.txt`
-  - **Admin Allowlist**:
-    `gs://llm-d-benchmarks-staging/prism-iam/github-admin-allowlist.txt`
+    - **User Allowlist**:
+      `gs://llm-d-benchmarks-staging/prism-iam/github-user-allowlist.txt`
+    - **Admin Allowlist**:
+      `gs://llm-d-benchmarks-staging/prism-iam/github-admin-allowlist.txt`
 - **Production Mode**:
-  - **User Allowlist**:
-    `gs://llm-d-benchmarks/prism-iam/github-user-allowlist.txt`
-  - **Admin Allowlist**:
-    `gs://llm-d-benchmarks/prism-iam/github-admin-allowlist.txt`
+    - **User Allowlist**:
+      `gs://llm-d-benchmarks/prism-iam/github-user-allowlist.txt`
+    - **Admin Allowlist**:
+      `gs://llm-d-benchmarks/prism-iam/github-admin-allowlist.txt`
 
 ---
 

--- a/specs/main/results-api/metadata-indexing.md
+++ b/specs/main/results-api/metadata-indexing.md
@@ -1,0 +1,356 @@
+# GCS Metadata Indexing & Backfill Specification
+
+## Status: Implemented
+
+## Overview
+
+Prism's "Manage Benchmarks" dashboard currently scans GCS buckets by listing all
+files and then downloading each file to parse its content on the client side.
+This causes significant network overhead and slow initial page loads, especially
+as the number of benchmark runs grows.
+
+To optimize this, we implement a **GCS Metadata Indexing** strategy. Instead of
+downloading full payload files (`.v1.json` or `.yaml` reports), we extract key
+performance metrics and metadata during ingestion (or via a backfill process)
+and store them as a minified JSON string in a GCS custom metadata field. The
+client can then retrieve all necessary metrics for listing and rendering the
+dashboard directly from the bucket's list response.
+
+### Design Requirements
+
+- **No Data Creation or Inference During Indexing:** The indexing process must
+  not create, guess, or infer any additional information (such as setting
+  fallback timestamps to the current date or GCS file modification times) if
+  fields are missing in the source payload. All data normalization, inference,
+  and formatting must be handled solely by the client-side parsers. Missing
+  fields must be represented as `null`.
+
+---
+
+## Technical Design
+
+#### Displayed and Filtered Fields Mapping
+
+> [!NOTE]
+>
+> **Decision: Omitted Sorting Functionality** To simplify the initial prototype,
+> we have decided to completely omit sorting functionality. The dashboard will
+> display benchmarks in a default order (chronological by default). The sorting
+> fields have been removed from this specification.
+
+The following table documents all benchmark fields that are currently displayed
+in the UI or available as filters in the dashboard, along with their source JSON
+paths within a standard BRV0.2 benchmark report.
+
+| Field Name                 | UI Filter Name          | Displayed Location              | Source Path in BRV0.2 YAML/JSON                                                                          |
+| :------------------------- | :---------------------- | :------------------------------ | :------------------------------------------------------------------------------------------------------- |
+| **Model**                  | Models                  | Row Title (Model Name)          | `scenario.stack[primary].standardized.model.name` <br>OR `scenario.load.native.config.server.model_name` |
+| **Hardware**               | Accelerators            | Hardware (Accelerator name)     | `scenario.stack[primary].standardized.accelerator.model`                                                 |
+| **Accelerator Count**      | Accelerator Count       | Hardware (Count prefix)         | `scenario.stack[primary].standardized.accelerator.count`                                                 |
+| **Tensor Parallelism**     | Tensor Parallelism (TP) | Nodes (TP suffix)               | `scenario.stack[primary].standardized.accelerator.parallelism.tp`                                        |
+| **Nodes**                  | -                       | Nodes (Node count)              | Derived: `accelerator_count / tp`                                                                        |
+| **Input Len (ISL)**        | Input (ISL)             | Input Len Column / Card Header  | `scenario.load.standardized.input_seq_len.value`                                                         |
+| **Output Len (OSL)**       | Output (OSL)            | Output Len Column / Card Header | `scenario.load.standardized.output_seq_len.value`                                                        |
+| **Model Server / Backend** | Model Server            | Configuration Label             | `scenario.load.standardized.tool` <br>OR `scenario.stack[primary].standardized.tool`                     |
+| **Precision**              | Precisions              | -                               | N/A (Hardcoded to `'Unknown'` for BRV0.2)                                                                |
+| **Machine Type**           | Machine Type            | -                               | N/A (Not supported for BRV0.2)                                                                           |
+| **Serving Stack**          | Serving Stack           | -                               | N/A (Not supported for BRV0.2)                                                                           |
+| **Optimizations**          | Optimizations           | -                               | N/A (Not supported for BRV0.2)                                                                           |
+| **Components**             | Components              | -                               | Keys of `scenario.stack`                                                                                 |
+| **P/D Node Ratio**         | P/D Node Ratio          | -                               | N/A (Not supported for BRV0.2)                                                                           |
+| **Workload Type / Ratio**  | Workload Type           | -                               | N/A (Not supported for BRV0.2)                                                                           |
+| **Use Case**               | Use Case                | -                               | N/A (Not supported for BRV0.2)                                                                           |
+| **Date/Timestamp**         | -                       | Card Header                     | `run.time.start`                                                                                         |
+| **Stages**                 | -                       | Card Header (Stage count)       | Count of stages in run (based on `scenario.load.standardized.stage`)                                     |
+| **Max Throughput**         | -                       | Card Header                     | Max `results.request_performance.aggregate.throughput.output_token_rate.mean` across stages              |
+| **Min Latency**            | -                       | Card Header                     | Min `results.request_performance.aggregate.latency.request_latency.mean` across stages                   |
+
+_Note: `primary` refers to the primary component resolved from `scenario.stack`
+(typically the component with role `aggregate`/`decode` or kind
+`inference_engine`). Card Header metrics for single-stage runs display that
+stage's metric; for multi-stage runs, they display the metric of the "peak"
+stage (highest output throughput)._
+
+### Custom Metadata Schema
+
+We will store the indexed metrics in a single GCS custom metadata key:
+`prism_summary`. The value of this key will be a minified JSON array of
+`NormalizedBenchmarkEntry` structures containing all fields required for
+rendering and filtering in the UI (excluding detailed stage-level metrics, raw
+reports, and diagnostics to keep size under GCS limits):
+
+```json
+[
+    {
+        "runLabel": "Llama3-H100-TP8",
+        "github_author": {
+            "username": "diamondburned"
+        },
+        "model": "meta-llama-llama-3-8b-instruct",
+        "model_name": "meta-llama-llama-3-8b-instruct",
+        "hardware": "H100",
+        "precision": "Unknown",
+        "backend": "vllm",
+        "isl": 512,
+        "osl": 128,
+        "timestamp": "2026-07-09T10:00:00Z",
+        "throughput": 2500.0,
+        "latency": {
+            "mean": 120.5
+        },
+        "components": ["LeaderWorkerSet"],
+        "metadata": {
+            "model_name": "meta-llama-llama-3-8b-instruct",
+            "backend": "vllm",
+            "hardware": "H100",
+            "accelerator_type": "H100",
+            "accelerator_count": 8,
+            "precision": "Unknown",
+            "timestamp": "2026-07-09T10:00:00Z",
+            "tp": 8,
+            "architecture": "aggregate",
+            "components": ["LeaderWorkerSet"]
+        },
+        "workload": {
+            "input_tokens": 512,
+            "output_tokens": 128,
+            "stage": 1
+        }
+    }
+]
+```
+
+---
+
+## System Architecture & Implementation
+
+### 1. Metadata Backfill & Validation Utility
+
+The project includes a command-line backfill utility script at
+[index.ts](../../../tools/backfill_metadata/index.ts). It scans target GCS
+buckets, parses benchmark files, and populates the `prism_summary` custom GCS
+metadata field.
+
+- **Command**: `npm run backfill-metadata -- <mode> [options]`
+- **Positional Arguments**:
+    - `mode`: Execution mode. Either `quick` (skips files already having
+      `prism_summary` metadata) or `force` (unconditionally re-parses and
+      updates GCS metadata if changed).
+- **Options**:
+    - `-d, --dry-run`: Preview changes without updating GCS metadata.
+    - `-e, --env <env>`: Target environment bucket. Defaults to `staging`
+      (`gs://llm-d-benchmarks-staging`). Use `prod` or `production` to target
+      `gs://llm-d-benchmarks`.
+- **Ad-hoc Folder Qualification & File-Level Indexing Strategy**:
+    - Objects outside `/prism-results-store` are grouped by their direct parent
+      directory (`runId`).
+    - **Qualified File Types**:
+        - **BRV0.2 Reports (`.yaml` / `.yml`)**: YAML files starting with
+          `version: '0.2'` parsed using `parseReportV02`.
+        - **Legacy & Stage Reports (`.json` / `.yaml`)**: Files matching old
+          report patterns `benchmark_report,.*` (excluding BRV0.2 versions) with
+          `.metrics` or files named `stage_X_lifecycle_metrics.json` /
+          `summary_lifecycle_metrics.json` containing `.load_summary` (referred
+          to as BRV0.1).
+        - **Log Files (`.log`)**: Standard execution logs (`stdout.log` and
+          `stderr.log`) parsed using `parseLogFile` to extract embedded latency
+          profiles or lifecycle outputs.
+    - **Explicit Exclusion (`per_request_lifecycle_metrics.json`)**:
+        - The `per_request_lifecycle_metrics.json` file MUST ALWAYS BE IGNORED
+          during backfill scanning, server-side content retrieval, and client
+          fallbacks due to its excessively large file size (per-token arrays).
+    - **BRV0.2 vs BRV0.1 Precedence Rules**:
+        - If a folder contains both BRV0.2 (BRV02) and legacy BRV0.1 report
+          files:
+            - **Indexing (Backfill)**: Only BRV0.2 files are parsed to generate
+              the `prism_summary` metadata list. The resulting BRV0.2 summary is
+              written to the GCS custom metadata on all parsed files (both
+              BRV0.1 and BRV0.2) so that any listing file representative holds
+              the preferred BRV0.2 index.
+            - **Content Retrieval (`GET /api/benchmarks/content`)**: The server
+              will only process and merge parsed BRV0.2 files, completely
+              ignoring BRV0.1 files in that directory.
+    - **File-Level Summary Metadata**:
+        - Instead of sharing a merged summary across all files in a folder, each
+          qualified file is parsed independently and assigned a separate,
+          file-specific `prism_summary` metadata string containing only the
+          stage/profile entries extracted from that file.
+    - In keeping with the **Design Requirements**, all dynamic timestamps are
+      stripped out and set to `null` if no stable timestamp is present in the
+      payload or filename, ensuring stable deterministic hashes. The folder base
+      name is used as the deterministic `runLabel`.
+
+### 2. Ingestion-Time Indexing (Results Store)
+
+When benchmarks are submitted to `POST /api/results`:
+
+1. The backend ingestion flow invokes `extractSummaryFromPayload` in
+   [gcs.ts](../../../server/results/gcs.ts).
+2. It parses each stage entry in the payload, maps them to minified summary
+   structures, and returns a serialized summary array.
+3. The server writes the serialized JSON string to the GCS standard custom
+   metadata field `metadata.prism_summary` inside `writeResult`, ensuring it is
+   saved in GCS at the time of upload.
+
+### 3. Backend HTTP API Endpoints
+
+The Express server exposes two endpoints for listing and retrieval under
+[benchmarks.ts](../../../server/results/routes/benchmarks.ts):
+
+#### `GET /api/benchmarks`
+
+- **Purpose**: Lists benchmark summaries in GCS.
+- **Parameters**: `bucket` (optional target bucket), `prefix` (optional GCS path
+  filter).
+- **GCS Listing Deduplication & Representative Selection**:
+    - Objects are batched and grouped by their `runId` (the direct parent folder
+      path).
+    - The server scans files inside each folder and selects a single
+      representative file containing a valid `prism_summary` (preferring files
+      like `summary_lifecycle_metrics.json` or `stdout.log` over individual
+      stage files) to provide the metadata summary for the list response.
+    - Paging state and nextPageToken cursors are calculated based on original
+      GCS file indices to ensure paging reliability.
+- **Authorization**: Standard Results Store restrictions apply to
+  `prism-results-store/` objects (Admins see all, standard users see own or
+  public/promoted).
+
+#### `GET /api/benchmarks/content`
+
+- **Purpose**: Retrieves the full text content of a GCS benchmark file or merges
+  all qualified files inside a folder run.
+- **Parameters**: `path` (GCS object path or folder path), `bucket` (target GCS
+  bucket).
+- **Behavior**:
+    - If `path` is a single file path (ends with a standard file extension like
+      `.json`, `.yaml`, etc.), the endpoint returns the raw file contents (if
+      not ignored).
+    - If `path` represents an ad-hoc directory path, the endpoint lists all
+      files matching that prefix inside the bucket, filters out ignored files
+      such as `per_request_lifecycle_metrics.json`, downloads and parses all
+      qualified JSON/log files in the folder, injects the `_source_file`
+      filename to each parsed object, and returns a merged JSON array.
+- **Authorization**: Enforces standard Results Store access checks for
+  `prism-results-store/` paths.
+
+#### Troubleshooting: Missing Results Store Benchmarks
+
+Because all Results Store benchmark files uploaded to
+`gs://llm-d-benchmarks-staging` or `gs://llm-d-benchmarks` default to a
+`submission_state` of `submitted_pending_review`, access controls are strictly
+enforced:
+
+- **Anonymous Users**: Cannot see any Results Store files in GCS listings.
+- **Standard Users**: Can only see files they authored (`github_user` metadata
+  matches the authenticated session user).
+- **Admins**: Can see all submissions.
+
+If developers are running the Prism application locally and do not see their
+`prism-results-store` benchmarks in the GCS connection lists, they must:
+
+1. Ensure the GitHub OAuth environment variables (`GITHUB_CLIENT_ID` and
+   `GITHUB_CLIENT_SECRET`) are configured in their local
+   environment/`docker-compose.yml`.
+2. Authenticate/log in with the GitHub account that matches the `github_user`
+   custom metadata value on their uploaded GCS run objects.
+
+### 4. Client Integration & Lazy Loading Flow
+
+#### A. Listing Mode (Fast Path)
+
+1. The [useGCS.js](../../../src/hooks/useGCS.js) hook fetches the list of
+   benchmarks via `GET /api/benchmarks?bucket=...`.
+2. If `prism_summary` is present in the item metadata, it directly maps the
+   minified stage entries, flags them as `isFull: false`, and loads them into
+   the state cache, bypassing file downloads entirely.
+3. If the metadata is missing, it falls back to downloading the full object
+   content and parsing it client-side as before, marking them `isFull: true`.
+
+#### B. Dynamic Fetching (Comparison Mode)
+
+1. When a user selects a benchmark config for comparison, a `useEffect` hook in
+   [useDashboardData.jsx](../../../src/hooks/useDashboardData.jsx) checks for
+   entries in the selection group that only have summary data (`!d.isFull`).
+2. It gathers all unique GCS file URLs in the group and triggers a lazy download
+   via `GET /api/benchmarks/content`.
+3. Upon retrieval, entries are parsed, flagged as `isFull: true`, and replace
+   the matching summary entries in the dashboard `data` array.
+
+#### C. Spinner Overlay UX
+
+- While detailed metrics are being lazy-fetched, the comparison charts
+  ([RunComparisonChart.jsx](../../../src/components/Dashboard/RunComparisonChart.jsx)
+  and
+  [ThroughputCostChart.jsx](../../../src/components/Dashboard/ThroughputCostChart.jsx))
+  render a loading spinner overlay to keep the UX clean and premium.
+
+---
+
+### Future Work: Periodic Cloud Run Job
+
+To ensure that the metadata index remains accurate and up-to-date over time
+(especially for ad-hoc uploads that bypass the Results Store ingestion flow, or
+in case of schema/parser updates), we will transition the backfill script into a
+managed, periodic background job.
+
+#### 1. Architecture Overview
+
+```mermaid
+sequenceDiagram
+    participant CloudScheduler as Cloud Scheduler (Cron)
+    participant CloudRun as Cloud Run Job (Node.js)
+    participant GCS as GCS Bucket (llm-d-benchmarks)
+
+    CloudScheduler->>CloudRun: Trigger Job (Trigger execution)
+    Note over CloudRun: Runs tools/backfill_metadata/index.ts
+    CloudRun->>GCS: List Objects (prefix search)
+    GCS-->>CloudRun: Return Object List
+    Note over CloudRun: Identifies files missing index (quick mode)<br/>or validates existing (force mode)
+    rect rgb(240, 248, 255)
+        Note over CloudRun, GCS: For each file to process:
+        CloudRun->>GCS: Read File Content
+        GCS-->>CloudRun: Return Content
+        Note over CloudRun: Parses and generates summary
+        CloudRun->>GCS: Update Metadata (prism_summary)
+    end
+    CloudRun-->>CloudScheduler: Job Completed (Success/Failure status)
+```
+
+#### 2. Implementation Steps
+
+1.  **Containerization:**
+    - Create a `Dockerfile` for the backfill script environment.
+    - Package `tools/backfill_metadata/index.ts` along with necessary parsers
+      and dependencies.
+2.  **Cloud Run Job Deployment:**
+    - Deploy the container as a **Cloud Run Job** (designed for
+      run-to-completion tasks).
+    - Configure service account permissions: The job needs
+      `roles/storage.objectAdmin` on `gs://llm-d-benchmarks/` to read files and
+      update metadata.
+3.  **Cloud Scheduler Setup:**
+    - Create a **Cloud Scheduler** trigger.
+    - Configure it to run on a periodic cron schedule (e.g., `@daily` at
+      midnight, or `@weekly`).
+    - Target the Scheduler to trigger the Cloud Run Job.
+4.  **Monitoring & Alerting:**
+    - Configure Cloud Logging to capture script output.
+    - **Execution Metrics:** At the end of each run, the job must log a
+      structured JSON summary of execution metrics to Cloud Logging:
+        ```json
+        {
+            "event": "backfill_complete",
+            "timestamp": "2026-07-09T12:00:00Z",
+            "duration_seconds": 45.2,
+            "metrics": {
+                "files_found": 150,
+                "files_checked": 120,
+                "files_processed_success": 15,
+                "files_skipped": 100,
+                "files_updated": 15,
+                "errors": 5
+            }
+        }
+        ```
+    - Set up alerts for job failures or high error rates based on these
+      structured logs.

--- a/specs/main/results-api/routes.md
+++ b/specs/main/results-api/routes.md
@@ -31,10 +31,12 @@ Resolves the current session state.
 
 ### `POST /api/auth/github/refresh`
 
-Exchanges a valid refresh token for a new set of GitHub access and refresh tokens.
+Exchanges a valid refresh token for a new set of GitHub access and refresh
+tokens.
 
 - **Request Body:** `{ "refresh_token": "<token>" }`
-- **Response (200 OK):** `{ "access_token": "<token>", "expires_in": <seconds>, "refresh_token": "<token>", "refresh_token_expires_in": <seconds> }`
+- **Response (200 OK):**
+  `{ "access_token": "<token>", "expires_in": <seconds>, "refresh_token": "<token>", "refresh_token_expires_in": <seconds> }`
 
 ### `POST /api/auth/github/logout`
 
@@ -61,6 +63,21 @@ Submits a benchmark result bundle to the active results store.
 
 Retrieves the complete payload of a single benchmark submission run bundle by
 its UUID.
+
+### `GET /api/benchmarks`
+
+Lists benchmark summaries in a target bucket and prefix, retrieving the minified
+`prism_summary` array from metadata. Each returned item includes an
+`isFromResultStore` boolean indicating whether the benchmark belongs to the
+`prism-results-store/` submission pipeline (`true`) or is a legacy upload
+(`false`). When `isFromResultStore` is `true`, `state` is guaranteed to be set.
+For legacy benchmarks outside the Results Store pipeline (`false`), fields like
+`state`, `model_name`, and `hardware` are omitted.
+
+### `GET /api/benchmarks/content`
+
+Retrieves the full content of a single benchmark run by its GCS path and bucket.
+Enforces Results Store access controls.
 
 ---
 

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -208,7 +208,7 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
         addToast, removeToast,
         siteName, setSiteName,
         contactUrl, setContactUrl,
-        fetchConfig, fetchBucketData, fetchGiqData,
+        fetchConfig, fetchBucketData, fetchGiqData, loadMoreGcs,
         fetchQualityData, fetchLocalData, fetchArchivedData,
         loadAllData, handleLpgFileUpload, handleLpgGcsScan, handleLpgGcsLoad, syncDriveData,
         restoreSampleData, removeSampleData, removeLLMDData,
@@ -500,6 +500,7 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
             throw e;
         }
     };
+
 
     const refreshSource = async (sourceType, id, mode = 'full') => {
         setGcsLoading(true);
@@ -1424,7 +1425,16 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
 
         // 2. Process groups
         groups.forEach((groupingData, benchmarkKey) => {
-            const model = groupingData[0].model_name || groupingData[0].model;
+            const firstEntry = groupingData[0];
+            const isFromResultStore = firstEntry.isFromResultStore || false;
+            const runLabel = firstEntry.runLabel ?? null;
+            const rawModel = firstEntry.model_name || firstEntry.model;
+            const hasModel = rawModel && rawModel !== 'Unknown';
+
+            // For non-result-store benchmarks, show model name first instead of run label
+            const model = (!isFromResultStore)
+                ? (hasModel ? rawModel : 'Unknown')
+                : (runLabel || (hasModel ? rawModel : 'Unknown'));
 
             const maxTput = Math.max(0, ...groupingData.map(x => Number(x.throughput || 0)).filter(t => !isNaN(t)));
             const minLatEntries = groupingData.map(x => Number(x.latency?.mean || 0)).filter(l => !isNaN(l) && l > 0);
@@ -1489,6 +1499,7 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
             stats.push({
                 benchmarkKey,
                 model,
+                isFromResultStore,
                 configuration, // Explicitly pass configuration
                 maxTput,
                 minLat,
@@ -1948,6 +1959,7 @@ const Dashboard = ({ onNavigateBack, onNavigate, dashboardState: propState, dash
                     driveProgress={driveProgress}
                     driveError={driveError}
                     refreshSource={refreshSource}
+                    loadMoreGcs={loadMoreGcs}
                     setApiConfigs={setApiConfigs}
                     setData={setData}
                     setSelectedSources={setSelectedSources}

--- a/src/components/Dashboard/FilterPanel.jsx
+++ b/src/components/Dashboard/FilterPanel.jsx
@@ -59,7 +59,7 @@ export const FilterPanel = ({
                         </button>
                     </h2>
                     {isFiltersExpanded && (
-                        <div className="w-56 opacity-60 hover:opacity-100 transition-opacity">
+                        <div className="w-56 opacity-40 pointer-events-none select-none" title="Disabled during GCS pagination">
                             <MultiSelectDropdown 
                                 label="Origin / Folder"
                                 options={filterOptions.origins || []}
@@ -73,8 +73,13 @@ export const FilterPanel = ({
                 </div>
                 {/* Filter Groups - Compact Layout */}
                 {isFiltersExpanded && (
-                    <>
-                        <div className="flex flex-col md:flex-row gap-4 border-t border-slate-200 dark:border-slate-700/50 pt-2">
+                    <div className="relative">
+                        <div className="absolute inset-0 bg-slate-50/20 dark:bg-slate-900/20 z-20 backdrop-blur-[0.5px] rounded-lg flex items-center justify-center pointer-events-auto">
+                            <span className="bg-amber-50 dark:bg-amber-950/80 text-amber-800 dark:text-amber-300 border border-amber-200 dark:border-amber-800/80 px-3 py-1.5 rounded-md text-[11px] font-medium shadow-sm flex items-center gap-1.5 select-none">
+                                ⚠️ Filters disabled during GCS pagination
+                            </span>
+                        </div>
+                        <div className="flex flex-col md:flex-row gap-4 border-t border-slate-200 dark:border-slate-700/50 pt-2 opacity-40 pointer-events-none select-none">
                     
                     {/* Section 1: Application / Model Server */}
                     <div className="flex-1 min-w-[200px]">
@@ -241,7 +246,7 @@ export const FilterPanel = ({
                 baselineBenchmarkKey={baselineBenchmarkKey}
                 setBaselineBenchmarkKey={setBaselineBenchmarkKey}
             />
-            </>
+            </div>
             )}
         </div>
       </div>

--- a/src/components/Dashboard/RunComparisonChart.jsx
+++ b/src/components/Dashboard/RunComparisonChart.jsx
@@ -224,6 +224,13 @@ export const RunComparisonChart = ({
         });
     };
 
+    const isStillLoading = useMemo(() => {
+        return filteredBySource.some(d => {
+            const key = getBenchmarkKey(d);
+            return selectedBenchmarks.has(key) && !d.isFull && d.downloadUrl;
+        });
+    }, [filteredBySource, selectedBenchmarks, getBenchmarkKey]);
+
     // Build chart data once per render, computing values and diffs for EVERY
     // stat the metric supports (cheap; lets us re-render without recomputing
     // when the user toggles stat visibility).
@@ -478,7 +485,12 @@ export const RunComparisonChart = ({
             </div>
 
             <div className="h-72">
-                {hasPlotData ? (
+                {isStillLoading ? (
+                    <div className="h-full flex flex-col items-center justify-center text-center">
+                        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-cyan-500 mb-2"></div>
+                        <p className="text-sm text-slate-500 dark:text-slate-400">Loading detailed performance metrics...</p>
+                    </div>
+                ) : hasPlotData ? (
                     <ResponsiveContainer width="100%" height="100%">
                         <BarChart
                             // Recharts caches per-bar layout by registration order, so

--- a/src/components/Dashboard/ThroughputCostChart.jsx
+++ b/src/components/Dashboard/ThroughputCostChart.jsx
@@ -32,6 +32,13 @@ export const ThroughputCostChart = (props) => {
         baselineBenchmarkKey
     } = props;
 
+    const isStillLoading = React.useMemo(() => {
+        return filteredBySource.some(d => {
+            const key = getBenchmarkKey(d);
+            return selectedBenchmarks.has(key) && !d.isFull && d.downloadUrl;
+        });
+    }, [filteredBySource, selectedBenchmarks, getBenchmarkKey]);
+
     // We can infer canShowPerChip
     const validData = filteredBySource.filter(d => selectedModels.has(d.model));
     const canShowPerChip = validData.every(d => d.accelerator_count > 0);
@@ -927,6 +934,13 @@ export const ThroughputCostChart = (props) => {
                                    isAnimationActive={false}
                                />
                           )}
+                      
+                      {isStillLoading && (
+                          <div className="absolute inset-0 z-20 bg-slate-900/10 dark:bg-slate-950/20 backdrop-blur-xs flex flex-col items-center justify-center text-center">
+                              <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-cyan-500 mb-2"></div>
+                              <p className="text-sm font-medium text-slate-600 dark:text-slate-400">Loading detailed performance metrics...</p>
+                          </div>
+                      )}
                         </LineChart>
                       </ResponsiveContainer>
                   </div>

--- a/src/components/Dashboard/UnifiedDataTable.jsx
+++ b/src/components/Dashboard/UnifiedDataTable.jsx
@@ -203,7 +203,16 @@ export const UnifiedDataTable = (props) => {
                                                           )}
                                                       </button>
                                                     <div>
-                                                        {benchmarkData[0]?.runLabel || (stat.model_name || stat.model || meta.model_name)}
+                                                        {(() => {
+                                                            const isFromResultStore = stat.isFromResultStore || benchmarkData[0]?.isFromResultStore;
+                                                            const runLabel = stat.runLabel || benchmarkData[0]?.runLabel;
+                                                            const modelStr = stat.model_name || stat.model || meta.model_name;
+                                                            const hasModel = modelStr && modelStr !== 'Unknown';
+                                                            if (!isFromResultStore) {
+                                                                return hasModel ? modelStr : 'Unknown';
+                                                            }
+                                                            return runLabel || (hasModel ? modelStr : 'Unknown');
+                                                        })()}
                                                     </div>
                                                 </div>
                                            </td>
@@ -276,8 +285,16 @@ export const UnifiedDataTable = (props) => {
                                               <tr>
                                                   <td colSpan="10" className="p-0">
                                                       <div className="bg-slate-50 dark:bg-slate-900/50 border-t border-slate-200 dark:border-slate-700 p-2">
-                                                          {/* Run Metadata Header */}
-                                                          <div className="mb-2 px-2 text-[10px] sm:text-xs text-slate-500 font-mono flex flex-wrap gap-x-4 gap-y-1 items-center bg-slate-100 dark:bg-slate-800/50 py-1.5 rounded">
+                                                          {benchmarkData.some(d => !d.isFull && d.downloadUrl) ? (
+                                                              <div className="p-5 border border-slate-200 dark:border-slate-700/60 rounded-lg bg-white dark:bg-slate-800/80 animate-pulse space-y-2.5 m-2">
+                                                                  <div className="h-4 bg-slate-200 dark:bg-slate-700/60 rounded w-full" />
+                                                                  <div className="h-4 bg-slate-200/80 dark:bg-slate-700/45 rounded w-5/6" />
+                                                                  <div className="h-4 bg-slate-200/60 dark:bg-slate-700/30 rounded w-4/6" />
+                                                              </div>
+                                                          ) : (
+                                                              <>
+                                                                  {/* Run Metadata Header */}
+                                                                  <div className="mb-2 px-2 text-[10px] sm:text-xs text-slate-500 font-mono flex flex-wrap gap-x-4 gap-y-1 items-center bg-slate-100 dark:bg-slate-800/50 py-1.5 rounded">
 
                                                               {benchmarkData[0]?.timestamp && (
                                                                   <span className="flex items-center gap-1">
@@ -352,6 +369,8 @@ export const UnifiedDataTable = (props) => {
                                                                </tbody>
                                                            </table>
                                                        </div>
+                                                              </>
+                                                          )}
                                                        </div>
                                                   </td>
                                               </tr>

--- a/src/components/DataConnections/CustomGCSPanel.jsx
+++ b/src/components/DataConnections/CustomGCSPanel.jsx
@@ -18,7 +18,7 @@ import { getSourceTypeStyle } from "../../utils/dashboardHelpers";
 
 export const CustomGCSPanel = ({
     connectionType, setConnectionType, availableSources, gcsProfiles, 
-    selectedSources, setSelectedSources, removeBucket, refreshSource, 
+    selectedSources, setSelectedSources, removeBucket, refreshSource, loadMoreGcs,
     newBucketAlias, setNewBucketAlias, newBucketName, setNewBucketName, 
     handleAddBucket, gcsLoading, awsBucketConfigs, handleAddAWSBucket, removeAWSBucket,
     gcsSuccess, gcsError
@@ -139,7 +139,17 @@ export const CustomGCSPanel = ({
                                                       <span>Restoring...</span>
                                                   </div>
                                               ) : (
-                                                  <span>{profile.entryCount} benchmarks loaded</span>
+                                                  <div className="flex items-center gap-2">
+                                                      <span>{profile.entryCount} benchmarks loaded</span>
+                                                      {profile.nextPageToken && (
+                                                          <button 
+                                                              onClick={() => loadMoreGcs('gcs', profile.bucketName)}
+                                                              className="text-[10px] text-blue-600 hover:underline font-semibold"
+                                                          >
+                                                              ● Load More
+                                                          </button>
+                                                      )}
+                                                  </div>
                                               )}
                                           </span>
                                       </div>

--- a/src/components/DataConnectionsPanel.jsx
+++ b/src/components/DataConnectionsPanel.jsx
@@ -23,14 +23,14 @@ import { getBenchmarkKey, getIntegrationSourceType, getSourceTypeStyle } from ".
 const DataConnectionsPanel = (props) => {
   const [localSampleError, setLocalSampleError] = React.useState(false);
   const [localSampleColor, setLocalSampleColor] = React.useState(null);
-    const { showDataPanel, setShowDataPanel, INTEGRATIONS, apiConfigs, data, bucketConfigs, availableSources, showSampleData, enableLLMDResults, setEnableLLMDResults, expandedIntegration, setExpandedIntegration, setApiError, setGcsError, setLpgError, removeSampleData, removeLLMDData, restoreSampleData, driveLoading, driveStatus, driveProgress, driveError, refreshSource, setApiConfigs, setData, setSelectedSources, setAvailableSources, newProjectId, setNewProjectId, newAuthToken, setNewAuthToken, handleAddApiSource, gcsLoading, gcsError, apiError, lpgError, handleLpgFileUpload, handleLpgGcsScan, handleLpgGcsLoad, hostProject, lpgLoading, lpgPasteText, setLpgPasteText, setLpgLoading, parseLogFile, gcsSuccess, setGcsSuccess, connectionType, setConnectionType, gcsProfiles, selectedSources, removeBucket, newBucketAlias, setNewBucketAlias, newBucketName, setNewBucketName, handleAddBucket, chartMode, tputType, costMode, latType, selectedModels, activeFilters, xAxisMax, showPerChip, showSelectedOnly, showPareto, showLabels, showDataLabels, setIsInspectorOpen, qualityMetrics, setQualityInspectOpen, fetchQualityData, state, awsBucketConfigs, handleAddAWSBucket, removeAWSBucket, addToast, brv02Runs, brv02Error, setBrv02Error, handleBrv02Upload, removeBrv02Run, brv02CustomLabels, setBrv02CustomLabels, brv02Loading } = props;
+    const { showDataPanel, setShowDataPanel, INTEGRATIONS, apiConfigs, data, bucketConfigs, availableSources, showSampleData, enableLLMDResults, setEnableLLMDResults, expandedIntegration, setExpandedIntegration, setApiError, setGcsError, setLpgError, removeSampleData, removeLLMDData, restoreSampleData, driveLoading, driveStatus, driveProgress, driveError, refreshSource, loadMoreGcs, setApiConfigs, setData, setSelectedSources, setAvailableSources, newProjectId, setNewProjectId, newAuthToken, setNewAuthToken, handleAddApiSource, gcsLoading, gcsError, apiError, lpgError, handleLpgFileUpload, handleLpgGcsScan, handleLpgGcsLoad, hostProject, lpgLoading, lpgPasteText, setLpgPasteText, setLpgLoading, parseLogFile, gcsSuccess, setGcsSuccess, connectionType, setConnectionType, gcsProfiles, selectedSources, removeBucket, newBucketAlias, setNewBucketAlias, newBucketName, setNewBucketName, handleAddBucket, chartMode, tputType, costMode, latType, selectedModels, activeFilters, xAxisMax, showPerChip, showSelectedOnly, showPareto, showLabels, showDataLabels, setIsInspectorOpen, qualityMetrics, setQualityInspectOpen, fetchQualityData, state, awsBucketConfigs, handleAddAWSBucket, removeAWSBucket, addToast, brv02Runs, brv02Error, setBrv02Error, handleBrv02Upload, removeBrv02Run, brv02CustomLabels, setBrv02CustomLabels, brv02Loading } = props;
   const [activeOrder, setActiveOrder] = React.useState(() => INTEGRATIONS ? INTEGRATIONS.map(i => i.id) : []);
   const [prevActiveIds, setPrevActiveIds] = React.useState(new Set());
   
     const handleClearCache = async () => {
         try {
             // GCS relies on IndexedDB caching
-            const dbRequest = window.indexedDB.deleteDatabase('PrismCache');
+            const dbRequest = window.indexedDB.deleteDatabase('PrismCacheDB');
             dbRequest.onsuccess = () => {
                 addToast('Cache cleared successfully. Please reload the page.', 'success');
                 setTimeout(() => window.location.reload(), 1500);
@@ -461,7 +461,7 @@ const DataConnectionsPanel = (props) => {
                         connectionType={connectionType} setConnectionType={setConnectionType}
                         availableSources={availableSources} gcsProfiles={gcsProfiles}
                         selectedSources={selectedSources} setSelectedSources={setSelectedSources}
-                        removeBucket={removeBucket} refreshSource={refreshSource}
+                        removeBucket={removeBucket} refreshSource={refreshSource} loadMoreGcs={loadMoreGcs}
                         newBucketAlias={newBucketAlias} setNewBucketAlias={setNewBucketAlias}
                         newBucketName={newBucketName} setNewBucketName={setNewBucketName}
                         handleAddBucket={handleAddBucket} gcsLoading={gcsLoading}

--- a/src/components/ManageBenchmarks.jsx
+++ b/src/components/ManageBenchmarks.jsx
@@ -54,22 +54,23 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
         removeBrv02Run,
         expandedModels,
         setExpandedModels,
-        handleValidatedUpload
+        handleValidatedUpload,
+        gcsProfiles,
+        loadMoreGcs
     } = dashboardData;
 
     const [isUploadDialogOpen, setIsUploadDialogOpen] = React.useState(false);
     const [initialStagedFiles, setInitialStagedFiles] = React.useState([]);
     const [activeTab, setActiveTab] = React.useState('all'); // 'all' or 'submissions'
 
-    const [submissions, setSubmissions] = React.useState([]);
+    const [serverSubmissions, setServerSubmissions] = React.useState([]);
     const [isLoadingSubmissions, setIsLoadingSubmissions] = React.useState(false);
 
-    // Queries the server's filesystem for actually staged runs, falling back to and
-    // merging with browser local storage runs for a seamless and responsive experience.
+    // Queries the server's filesystem once on mount for staged runs
     React.useEffect(() => {
         let isMounted = true;
 
-        const loadSubmissions = async () => {
+        const loadServerSubmissions = async () => {
             setIsLoadingSubmissions(true);
             try {
                 const res = await fetch('/api/local/list');
@@ -80,7 +81,7 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
                     item.name.endsWith('prism_run_upload.json')
                 );
 
-                const serverSubmissions = [];
+                const fetchedSubmissions = [];
                 if (uploadFiles.length > 0) {
                     const fetchPromises = uploadFiles.map(async (file) => {
                         try {
@@ -105,68 +106,19 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
                     });
                     
                     const resolved = await Promise.all(fetchPromises);
-                    serverSubmissions.push(...resolved.filter(Boolean));
+                    fetchedSubmissions.push(...resolved.filter(Boolean));
                 }
-
-                const mergedList = [...serverSubmissions];
-                if (brv02Runs && brv02Runs.length > 0) {
-                    brv02Runs.forEach(run => {
-                        if (!mergedList.some(s => s.runId === run.runId)) {
-                            const firstStage = run.stages?.[0];
-                            const resolvedModel = firstStage?.scenario?.model || run.run_metadata?.model || "Custom Model";
-                            const resolvedHw = firstStage?.scenario?.hardware || run.run_metadata?.accelerator || "Detected Hardware";
-                            const submittedAt = firstStage?.timestamp || run.run_metadata?.timestamp || new Date().toISOString().split('T')[0];
-
-                            mergedList.push({
-                                id: `dyn-${run.runId}`,
-                                runId: run.runId,
-                                model: resolvedModel,
-                                hardware: resolvedHw,
-                                wellLitPath: run.wellLitPath || "none / custom",
-                                submittedAt: typeof submittedAt === 'string' ? submittedAt.split('T')[0] : new Date().toISOString().split('T')[0],
-                                status: "staged",
-                                feedback: ""
-                            });
-                        }
-                    });
-                }
-
-                // Sort chronologically (latest submissions first)
-                mergedList.sort((a, b) => b.submittedAt.localeCompare(a.submittedAt));
 
                 if (isMounted) {
-                    setSubmissions(mergedList);
+                    setServerSubmissions(fetchedSubmissions);
                 }
             } catch (error) {
-                console.error("Failed to load submissions:", error);
+                console.error("Failed to load server submissions:", error);
                 if (isMounted) {
                     addToast({
                         message: "Failed to load submitted runs from backend server.",
                         type: "error"
                     });
-                    
-                    const fallbackList = [];
-                    if (brv02Runs && brv02Runs.length > 0) {
-                        brv02Runs.forEach(run => {
-                            const firstStage = run.stages?.[0];
-                            const resolvedModel = firstStage?.scenario?.model || run.run_metadata?.model || "Custom Model";
-                            const resolvedHw = firstStage?.scenario?.hardware || run.run_metadata?.accelerator || "Detected Hardware";
-                            const submittedAt = firstStage?.timestamp || run.run_metadata?.timestamp || new Date().toISOString().split('T')[0];
-
-                            fallbackList.push({
-                                id: `dyn-${run.runId}`,
-                                runId: run.runId,
-                                model: resolvedModel,
-                                hardware: resolvedHw,
-                                wellLitPath: run.wellLitPath || "none / custom",
-                                submittedAt: typeof submittedAt === 'string' ? submittedAt.split('T')[0] : new Date().toISOString().split('T')[0],
-                                status: "staged",
-                                feedback: ""
-                            });
-                        });
-                        fallbackList.sort((a, b) => b.submittedAt.localeCompare(a.submittedAt));
-                    }
-                    setSubmissions(fallbackList);
                 }
             } finally {
                 if (isMounted) {
@@ -175,12 +127,39 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
             }
         };
 
-        loadSubmissions();
+        loadServerSubmissions();
 
         return () => {
             isMounted = false;
         };
-    }, [brv02Runs, addToast]);
+    }, []);
+
+    const submissions = React.useMemo(() => {
+        const mergedList = [...serverSubmissions];
+        if (brv02Runs && brv02Runs.length > 0) {
+            brv02Runs.forEach(run => {
+                if (!mergedList.some(s => s.runId === run.runId)) {
+                    const firstStage = run.stages?.[0];
+                    const resolvedModel = firstStage?.scenario?.model || run.run_metadata?.model || "Custom Model";
+                    const resolvedHw = firstStage?.scenario?.hardware || run.run_metadata?.accelerator || "Detected Hardware";
+                    const submittedAt = firstStage?.timestamp || run.run_metadata?.timestamp || new Date().toISOString().split('T')[0];
+
+                    mergedList.push({
+                        id: `dyn-${run.runId}`,
+                        runId: run.runId,
+                        model: resolvedModel,
+                        hardware: resolvedHw,
+                        wellLitPath: run.wellLitPath || "none / custom",
+                        submittedAt: typeof submittedAt === 'string' ? submittedAt.split('T')[0] : new Date().toISOString().split('T')[0],
+                        status: "staged",
+                        feedback: ""
+                    });
+                }
+            });
+        }
+        mergedList.sort((a, b) => b.submittedAt.localeCompare(a.submittedAt));
+        return mergedList;
+    }, [serverSubmissions, brv02Runs]);
 
     const openUploadDialogWithFiles = (files) => {
         let fileList = [];
@@ -805,7 +784,8 @@ export default function ManageBenchmarks({ onNavigate, onNavigateBack, dashboard
                                 UnifiedDataTable,
                                 hideShowSelectedOnly: true,
                                 renameClearToUnselectAll: true,
-                                brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run
+                                brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run,
+                                gcsProfiles, selectedSources, loadMoreGcs
                             }}
                         />
                     </div>

--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -39,7 +39,8 @@ export const FilterPanel = ({
     UnifiedDataTable,
     hideShowSelectedOnly,
     renameClearToUnselectAll,
-    brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run
+    brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run,
+    gcsProfiles, selectedSources, loadMoreGcs
 }) => {
     const [groupBy, setGroupBy] = useState(() => {
         try {
@@ -73,7 +74,7 @@ export const FilterPanel = ({
         const defaults = {
             hardware: true,
             timestamp: true,
-            stage: true,
+            stage: false,
             nodes: false,
             islOsl: false,
             maxTput: true,
@@ -233,7 +234,6 @@ export const FilterPanel = ({
                                 {Object.entries({
                                     hardware: 'Hardware',
                                     timestamp: 'Timestamp',
-                                    stage: 'Stage',
                                     nodes: 'Nodes & Parallelism',
                                     islOsl: 'ISL/OSL',
                                     maxTput: 'Max TPUT',
@@ -475,6 +475,9 @@ export const FilterPanel = ({
                 brv02CustomLabels={brv02CustomLabels}
                 setBrv02CustomLabels={setBrv02CustomLabels}
                 removeBrv02Run={removeBrv02Run}
+                gcsProfiles={gcsProfiles}
+                selectedSources={selectedSources}
+                loadMoreGcs={loadMoreGcs}
             />
         </div>
     );

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React, { useState } from 'react';
-import { RotateCcw, ChevronDown, ChevronUp, Star, CheckSquare, Square, Check, Pencil, Trash2, X, FileText } from 'lucide-react';
+import { RotateCcw, ChevronDown, ChevronUp, Star, CheckSquare, Square, Check, Pencil, Trash2, X, FileText, Loader } from 'lucide-react';
 import { getEffectiveTp, getBucket, getSourceTag, getSourceType, getSourceTypeStyle, formatOriginLabel } from '../../utils/dashboardHelpers';
 import yaml from 'js-yaml';
 
@@ -57,13 +57,16 @@ export const UnifiedDataTable = (props) => {
         hideShowSelectedOnly = false,
         renameClearToUnselectAll = false,
         brv02Runs = [], brv02CustomLabels = {}, setBrv02CustomLabels, removeBrv02Run,
+        gcsProfiles = [],
+        selectedSources = new Set(),
+        loadMoreGcs,
         groupBy = 'Model',
         sortByField = 'timestamp',
         sortDirection = 'desc',
         visibleSpecs = {
             hardware: true,
             timestamp: true,
-            stage: true,
+            stage: false,
             nodes: false,
             islOsl: false,
             maxTput: true,
@@ -378,6 +381,27 @@ export const UnifiedDataTable = (props) => {
         setSelectedBenchmarks(newSelected);
     };
 
+    const activeProfilesWithMore = React.useMemo(() => {
+        if (!gcsProfiles || !selectedSources) return [];
+        return gcsProfiles.filter(p => 
+            p.type === 'gcs' && 
+            p.nextPageToken && 
+            selectedSources.has(`gcs:${p.bucketName}`)
+        );
+    }, [gcsProfiles, selectedSources]);
+
+    const isLoadingMore = React.useMemo(() => {
+        return activeProfilesWithMore.some(p => p.loading);
+    }, [activeProfilesWithMore]);
+
+    const handleLoadMoreAll = async () => {
+        for (const p of activeProfilesWithMore) {
+            if (loadMoreGcs) {
+                await loadMoreGcs('gcs', p.bucketName);
+            }
+        }
+    };
+
     return (
         <div className="flex flex-col gap-3">
             {/* Action Bar */}
@@ -457,6 +481,16 @@ export const UnifiedDataTable = (props) => {
                                 )}
                             </div>
                         </>
+                    )}
+                    {activeProfilesWithMore.length > 0 && (
+                        <button
+                            onClick={handleLoadMoreAll}
+                            disabled={isLoadingMore}
+                            className="px-3 py-1.5 text-xs font-semibold rounded shadow-sm border transition-colors flex items-center gap-1.5 text-white bg-blue-600 hover:bg-blue-500 border-blue-500/20 disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            {isLoadingMore && <Loader size={12} className="animate-spin" />}
+                            Load More
+                        </button>
                     )}
                 </div>
             </div>
@@ -595,28 +629,6 @@ export const UnifiedDataTable = (props) => {
                                                                  }
                                                              }
 
-                                                             if (visibleSpecs.stage) {
-                                                                 const isBrv02Run = benchmarkData[0]?.source?.startsWith('brv02:');
-                                                                 if (isBrv02Run) {
-                                                                     const stageCount = benchmarkData.length;
-                                                                     specs.push(
-                                                                         <span key="stage" className="inline-flex items-center gap-1">
-                                                                             <span className="text-slate-400 dark:text-slate-500 font-normal">Stages:</span>
-                                                                             <span className="font-semibold text-slate-700 dark:text-slate-300">{stageCount} stage{stageCount === 1 ? '' : 's'}</span>
-                                                                         </span>
-                                                                     );
-                                                                 } else {
-                                                                     const stageVal = benchmarkData[0]?.workload?.stage;
-                                                                     if (stageVal !== undefined && stageVal !== null && stageVal !== '') {
-                                                                         specs.push(
-                                                                             <span key="stage" className="inline-flex items-center gap-1">
-                                                                                 <span className="text-slate-400 dark:text-slate-500 font-normal">Stage:</span>
-                                                                                 <span className="font-semibold text-slate-700 dark:text-slate-300">{stageVal}</span>
-                                                                             </span>
-                                                                         );
-                                                                     }
-                                                                 }
-                                                             }
 
                                                              if (visibleSpecs.hardware) {
                                                                 specs.push(
@@ -815,16 +827,24 @@ export const UnifiedDataTable = (props) => {
                                                                              ) : (
                                                                                     <div className="flex items-center gap-1.5 min-w-0 flex-wrap">
                                                                                         <span className="font-bold text-sm sm:text-base text-slate-800 dark:text-slate-100 truncate">
-                                                                                            {isBrv02 
-                                                                                                ? (brv02CustomLabels[runId] || benchmarkData[0]?.runLabel || stat.model_name || stat.model || meta.model_name)
-                                                                                                : (stat.model_name || stat.model || meta.model_name)}
+                                                                                            {(() => {
+                                                                                                const isFromResultStore = stat.isFromResultStore || benchmarkData[0]?.isFromResultStore;
+                                                                                                const customLabel = isBrv02 ? brv02CustomLabels[runId] : null;
+                                                                                                const runLabel = customLabel || stat.runLabel || benchmarkData[0]?.runLabel;
+                                                                                                const modelStr = stat.model_name || stat.model || meta.model_name;
+                                                                                                const hasModel = modelStr && modelStr !== 'Unknown';
+                                                                                                if (!isFromResultStore) {
+                                                                                                    return hasModel ? modelStr : 'Unknown';
+                                                                                                }
+                                                                                                return runLabel || (hasModel ? modelStr : 'Unknown');
+                                                                                            })()}
                                                                                         </span>
                                                                                         {isBrv02 && (
                                                                                             <button
                                                                                                 onClick={(e) => {
                                                                                                     e.stopPropagation();
                                                                                                     setEditingRunId(runId);
-                                                                                                    setEditingValue(brv02CustomLabels[runId] || benchmarkData[0]?.runLabel || (stat.model_name || stat.model || meta.model_name));
+                                                                                                    setEditingValue(brv02CustomLabels[runId] || stat.runLabel || benchmarkData[0]?.runLabel || (stat.model_name || stat.model || meta.model_name));
                                                                                                 }}
                                                                                                title="Rename run"
                                                                                                className="p-1 text-slate-300 dark:text-slate-600 hover:text-cyan-400 transition-colors flex-shrink-0"
@@ -904,91 +924,97 @@ export const UnifiedDataTable = (props) => {
                                                     </div>
                                                 </div>
                                             </div>
-
                                              {/* Expanded Table Details */}
                                              {isExpanded && (
                                                  <div className="border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/30 p-4">
-
-                                                      <div className="overflow-x-auto rounded border border-slate-200 dark:border-slate-700">
-                                                          <table className="w-full text-left text-slate-600 dark:text-slate-300 text-xs bg-white dark:bg-slate-800">
-                                                              <thead className="bg-slate-100 dark:bg-slate-700/50 text-slate-700 dark:text-slate-100 uppercase text-[10px] font-medium border-b border-slate-200 dark:border-slate-700">
-                                                                  <tr>
-                                                                      {isBrv02 && <th className="px-3 py-2 w-12 text-center">Stage</th>}
-                                                                      <th className="px-4 py-2">{isBrv02 ? 'QPS' : 'QPS'}</th>
-                                                                      <th className="px-2 py-2">Input Tok/s</th>
-                                                                      <th className="px-2 py-2">Output Tok/s</th>
-                                                                      <th className="px-2 py-2">Total Tok/s</th>
-                                                                      <th className="px-2 py-2">NTPOT (ms)</th>
-                                                                      <th className="px-2 py-2">TPOT (ms)</th>
-                                                                      <th className="px-2 py-2">ITL (ms)</th>
-                                                                      <th className="px-2 py-2">TTFT (ms)</th>
-                                                                      <th className="px-2 py-2">E2E (s)</th>
-                                                                      <th className="px-2 py-2">Cost/1M In ($)</th>
-                                                                      <th className="px-2 py-2">Cost/1M Out ($)</th>
-                                                                      <th className="px-2 py-2">Input Len</th>
-                                                                      <th className="px-2 py-2">Output Len</th>
-                                                                      <th className="px-2 py-2 w-16 text-center">Raw</th>
-                                                                  </tr>
-                                                              </thead>
-                                                              <tbody className="divide-y divide-slate-100 dark:divide-slate-700/50">
-                                                                  {[...benchmarkData]
-                                                                      .sort((a, b) => (a.workload?.stage ?? 0) - (b.workload?.stage ?? 0))
-                                                                      .map((d, index) => (
-                                                                          <tr key={index} className="hover:bg-slate-50 dark:hover:bg-slate-700/30">
-                                                                              {isBrv02 && (
-                                                                                  <td className="px-3 py-2 text-center font-mono w-12 text-slate-500 border-r border-slate-100 dark:border-slate-700">
-                                                                                      {d.workload?.stage ?? '-'}
-                                                                                  </td>
-                                                                              )}
-                                                                              <td className="px-4 py-2 font-mono">
-                                                                                  {(d.metrics?.request_rate?.toFixed(2) || d.qps?.toFixed(2) || '-')}
-                                                                              </td>
-                                                                              <td className="px-2 py-2 font-mono">{d.metrics?.input_tput?.toFixed(0) || '-'}</td>
-                                                                              <td className="px-2 py-2 font-mono">{d.metrics?.output_tput?.toFixed(0) || d.throughput?.toFixed(0) || '-'}</td>
-                                                                              <td className="px-2 py-2 font-mono font-medium">{d.metrics?.total_tput?.toFixed(0) || '-'}</td>
-                                                                              <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.ntpot?.toFixed(2) || d.ntpot?.toFixed(2) || '-'}</td>
-                                                                              <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.tpot?.toFixed(2) || d.time_per_output_token?.toFixed(2) || '-'}</td>
-                                                                              <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.itl?.toFixed(2) || d.itl?.toFixed(2) || '-'}</td>
-                                                                              <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.ttft?.mean?.toFixed(2) || d.ttft?.mean?.toFixed(2) || '-'}</td>
-                                                                              <td className="px-2 py-2 font-mono text-[10px]">{((d.metrics?.e2e_latency || d.latency?.mean) / 1000)?.toFixed(2) || '-'}</td>
-                                                                              <td className="px-2 py-2 font-mono text-[10px] text-slate-500">
-                                                                                  {d.metrics?.cost?.explicit_input > 0 ? `$${d.metrics.cost.explicit_input.toFixed(4)}` : '-'}
-                                                                              </td>
-                                                                              <td className="px-2 py-2 font-mono text-[10px] text-slate-500">
-                                                                                  {d.metrics?.cost?.explicit_output > 0 ? `$${d.metrics.cost.explicit_output.toFixed(4)}` : '-'}
-                                                                              </td>
-                                                                              <td className="px-2 py-2 font-mono text-[10px]">{d.isl?.toFixed(0) || d.workload?.input_tokens?.toFixed(0) || '-'}</td>
-                                                                              <td className="px-2 py-2 font-mono text-[10px]">{d.osl?.toFixed(0) || d.workload?.output_tokens?.toFixed(0) || '-'}</td>
-                                                                              <td className="px-2 py-2 text-center">
-                                                                                  <button
-                                                                                      disabled={!d.rawReport}
-                                                                                      onClick={(e) => {
-                                                                                          e.stopPropagation();
-                                                                                          try {
-                                                                                              setRawYamlContent(d.rawReport ? yaml.dump(d.rawReport, { noRefs: true }) : '');
-                                                                                          } catch (err) {
-                                                                                              console.error("Failed to dump raw report to YAML:", err);
-                                                                                              setRawYamlContent("Error rendering raw report.");
-                                                                                          }
-                                                                                          setRawYamlTitle(d.source_info?.file_identifier || d.filename || `Stage ${d.workload?.stage}`);
-                                                                                      }}
-                                                                                      title="Raw"
-                                                                                      className={`p-1 rounded transition-colors ${
-                                                                                          d.rawReport 
-                                                                                              ? 'text-slate-400 hover:text-blue-500 dark:text-slate-500 dark:hover:text-blue-400 cursor-pointer' 
-                                                                                              : 'text-slate-200 dark:text-slate-800 cursor-not-allowed opacity-50'
-                                                                                      }`}
-                                                                                  >
-                                                                                      <FileText size={14} />
-                                                                                  </button>
-                                                                              </td>
-                                                                          </tr>
-                                                                      ))}
-                                                              </tbody>
-                                                          </table>
-                                                      </div>
-                                                </div>
-                                            )}
+                                                     {benchmarkData.some(d => !d.isFull && d.downloadUrl) ? (
+                                                         <div className="p-6 border border-slate-200 dark:border-slate-700/60 rounded-lg bg-white dark:bg-slate-800/80 animate-pulse space-y-3">
+                                                             <div className="h-5 bg-slate-200 dark:bg-slate-700/60 rounded w-full" />
+                                                             <div className="h-4 bg-slate-200/80 dark:bg-slate-700/45 rounded w-5/6" />
+                                                             <div className="h-4 bg-slate-200/60 dark:bg-slate-700/30 rounded w-4/6" />
+                                                         </div>
+                                                     ) : (
+                                                         <div className="overflow-x-auto rounded border border-slate-200 dark:border-slate-700">
+                                                             <table className="w-full text-left text-slate-600 dark:text-slate-300 text-xs bg-white dark:bg-slate-800">
+                                                                 <thead className="bg-slate-100 dark:bg-slate-700/50 text-slate-700 dark:text-slate-100 uppercase text-[10px] font-medium border-b border-slate-200 dark:border-slate-700">
+                                                                     <tr>
+                                                                         {isBrv02 && <th className="px-3 py-2 w-12 text-center">Stage</th>}
+                                                                         <th className="px-4 py-2">{isBrv02 ? 'QPS' : 'QPS'}</th>
+                                                                         <th className="px-2 py-2">Input Tok/s</th>
+                                                                         <th className="px-2 py-2">Output Tok/s</th>
+                                                                         <th className="px-2 py-2">Total Tok/s</th>
+                                                                         <th className="px-2 py-2">NTPOT (ms)</th>
+                                                                         <th className="px-2 py-2">TPOT (ms)</th>
+                                                                         <th className="px-2 py-2">ITL (ms)</th>
+                                                                         <th className="px-2 py-2">TTFT (ms)</th>
+                                                                         <th className="px-2 py-2">E2E (s)</th>
+                                                                         <th className="px-2 py-2">Cost/1M In ($)</th>
+                                                                         <th className="px-2 py-2">Cost/1M Out ($)</th>
+                                                                         <th className="px-2 py-2">Input Len</th>
+                                                                         <th className="px-2 py-2">Output Len</th>
+                                                                         <th className="px-2 py-2 w-16 text-center">Raw</th>
+                                                                     </tr>
+                                                                 </thead>
+                                                                 <tbody className="divide-y divide-slate-100 dark:divide-slate-700/50">
+                                                                     {[...benchmarkData]
+                                                                         .sort((a, b) => (a.workload?.stage ?? 0) - (b.workload?.stage ?? 0))
+                                                                         .map((d, index) => (
+                                                                             <tr key={index} className="hover:bg-slate-50 dark:hover:bg-slate-700/30">
+                                                                                 {isBrv02 && (
+                                                                                     <td className="px-3 py-2 text-center font-mono w-12 text-slate-500 border-r border-slate-100 dark:border-slate-700">
+                                                                                         {d.workload?.stage ?? '-'}
+                                                                                     </td>
+                                                                                 )}
+                                                                                 <td className="px-4 py-2 font-mono">
+                                                                                     {(d.metrics?.request_rate?.toFixed(2) || d.qps?.toFixed(2) || '-')}
+                                                                                 </td>
+                                                                                 <td className="px-2 py-2 font-mono">{d.metrics?.input_tput?.toFixed(0) || '-'}</td>
+                                                                                 <td className="px-2 py-2 font-mono">{d.metrics?.output_tput?.toFixed(0) || d.throughput?.toFixed(0) || '-'}</td>
+                                                                                 <td className="px-2 py-2 font-mono font-medium">{d.metrics?.total_tput?.toFixed(0) || '-'}</td>
+                                                                                 <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.ntpot?.toFixed(2) || d.ntpot?.toFixed(2) || '-'}</td>
+                                                                                 <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.tpot?.toFixed(2) || d.time_per_output_token?.toFixed(2) || '-'}</td>
+                                                                                 <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.itl?.toFixed(2) || d.itl?.toFixed(2) || '-'}</td>
+                                                                                 <td className="px-2 py-2 font-mono text-[10px]">{d.metrics?.ttft?.mean?.toFixed(2) || d.ttft?.mean?.toFixed(2) || '-'}</td>
+                                                                                 <td className="px-2 py-2 font-mono text-[10px]">{((d.metrics?.e2e_latency || d.latency?.mean) / 1000)?.toFixed(2) || '-'}</td>
+                                                                                 <td className="px-2 py-2 font-mono text-[10px] text-slate-500">
+                                                                                     {d.metrics?.cost?.explicit_input > 0 ? `$${d.metrics.cost.explicit_input.toFixed(4)}` : '-'}
+                                                                                 </td>
+                                                                                 <td className="px-2 py-2 font-mono text-[10px] text-slate-500">
+                                                                                     {d.metrics?.cost?.explicit_output > 0 ? `$${d.metrics.cost.explicit_output.toFixed(4)}` : '-'}
+                                                                                 </td>
+                                                                                 <td className="px-2 py-2 font-mono text-[10px]">{d.isl?.toFixed(0) || d.workload?.input_tokens?.toFixed(0) || '-'}</td>
+                                                                                 <td className="px-2 py-2 font-mono text-[10px]">{d.osl?.toFixed(0) || d.workload?.output_tokens?.toFixed(0) || '-'}</td>
+                                                                                 <td className="px-2 py-2 text-center">
+                                                                                     <button
+                                                                                         disabled={!d.rawReport}
+                                                                                         onClick={(e) => {
+                                                                                             e.stopPropagation();
+                                                                                             try {
+                                                                                                 setRawYamlContent(d.rawReport ? yaml.dump(d.rawReport, { noRefs: true }) : '');
+                                                                                             } catch (err) {
+                                                                                                 console.error("Failed to dump raw report to YAML:", err);
+                                                                                                 setRawYamlContent("Error rendering raw report.");
+                                                                                             }
+                                                                                             setRawYamlTitle(d.source_info?.file_identifier || d.filename || `Stage ${d.workload?.stage}`);
+                                                                                         }}
+                                                                                         title="Raw"
+                                                                                         className={`p-1 rounded transition-colors ${
+                                                                                             d.rawReport 
+                                                                                                 ? 'text-slate-400 hover:text-blue-500 dark:text-slate-500 dark:hover:text-blue-400 cursor-pointer' 
+                                                                                                 : 'text-slate-200 dark:text-slate-800 cursor-not-allowed opacity-50'
+                                                                                         }`}
+                                                                                     >
+                                                                                         <FileText size={14} />
+                                                                                     </button>
+                                                                                 </td>
+                                                                             </tr>
+                                                                         ))}
+                                                                 </tbody>
+                                                             </table>
+                                                         </div>
+                                                     )}
+                                                 </div>
+                                             )}
                                         </div>
                                     );
                                 })}

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -24,10 +24,22 @@ import { useLLMD } from './useLLMD';
 import { useAWS } from './useAWS';
 import { getBenchmarkKey } from '../utils/dashboardHelpers';
 
+const decodeGcsPath = (urlStr) => {
+    if (!urlStr) return '';
+    try {
+        const match = urlStr.match(/[?&]path=([^&]+)/);
+        return match ? decodeURIComponent(match[1]) : urlStr;
+    } catch {
+        return urlStr;
+    }
+};
+
 export const useDashboardData = (initialState, dashboardState) => {
     const { selectedBenchmarks, setSelectedBenchmarks, xAxisMax, setXAxisMax } = dashboardState;
     const pendingRequests = useRef(new Map());
+    const pendingDetailedRequests = useRef(new Set());
     const [data, setData] = useState([]);
+    const [expandedModels, setExpandedModels] = useState(new Set());
     const dataRef = useRef(data);
     useEffect(() => { dataRef.current = data; }, [data]);
     const [loading, setLoading] = useState(true);
@@ -98,6 +110,207 @@ export const useDashboardData = (initialState, dashboardState) => {
             console.error("Failed to persist brv02 selected stages to LocalStorage:", e);
         }
     }, [brv02SelectedStages]);
+
+    const loadDetailedMetrics = useCallback(async (downloadUrls) => {
+        const token = localStorage.getItem('github_oauth_token');
+        const headers = token ? { 'X-Prism-Github-Token': token } : {};
+        
+        const urlsToFetch = downloadUrls.filter(url => {
+            if (!url || pendingDetailedRequests.current.has(url)) {
+                return false;
+            }
+            pendingDetailedRequests.current.add(url);
+            return true;
+        });
+
+        if (urlsToFetch.length === 0) return;
+
+        await Promise.all(urlsToFetch.map(async (url) => {
+            try {
+                const res = await fetch(url, { headers });
+                if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
+                
+                const content = await res.text();
+                let parsedEntries = [];
+
+                if (url.includes('prism-results-store/')) {
+                    const payload = JSON.parse(content);
+                    const parsedStages = [];
+                    for (const entry of payload.entries) {
+                        const parsedStage = parseReportV02(entry.raw_report, entry.filename);
+                        if (parsedStage) {
+                            parsedStage.runId = payload.runId;
+                            parsedStage.runLabel = payload.runLabel;
+                            parsedStage.run_metadata = payload.run_metadata;
+                            if (payload.metadata?.config) {
+                                parsedStage.config = payload.metadata.config;
+                            }
+                            const fullEntry = stageToEntry(parsedStage);
+                            if (payload.github_author) {
+                                fullEntry.github_author = payload.github_author;
+                            }
+                            fullEntry.isFull = true;
+                            fullEntry.downloadUrl = url;
+                            parsedStages.push(fullEntry);
+                        }
+                    }
+                    parsedEntries = parsedStages;
+                } else {
+                    try {
+                        const jsonContent = JSON.parse(content);
+                        if (Array.isArray(jsonContent)) {
+                            const entries = [];
+                            for (const item of jsonContent) {
+                                if (item && typeof item === 'object' && item.metadata && (item.workload || item.metrics || item.latency)) {
+                                    item.isFull = true;
+                                    item.downloadUrl = url;
+                                    entries.push(item);
+                                } else if (item.metrics || item.load_summary) {
+                                    const filename = item._source_file || url;
+                                    const entry = parseJsonEntry({ ...item, source: 'gcs' }, filename);
+                                    entry.isFull = true;
+                                    entry.downloadUrl = url;
+                                    entries.push(entry);
+                                } else if (item.latency) {
+                                    item.isFull = true;
+                                    item.downloadUrl = url;
+                                    entries.push(item);
+                                }
+                            }
+                            parsedEntries = entries;
+                        } else if (jsonContent && typeof jsonContent === 'object') {
+                            if (jsonContent.metadata && (jsonContent.workload || jsonContent.metrics || jsonContent.latency)) {
+                                jsonContent.isFull = true;
+                                jsonContent.downloadUrl = url;
+                                parsedEntries = [jsonContent];
+                            } else if (jsonContent.metrics || jsonContent.load_summary) {
+                                const entry = parseJsonEntry({ ...jsonContent, source: 'gcs' }, url);
+                                entry.isFull = true;
+                                entry.downloadUrl = url;
+                                parsedEntries = [entry];
+                            } else if (jsonContent.latency) {
+                                jsonContent.isFull = true;
+                                jsonContent.downloadUrl = url;
+                                parsedEntries = [jsonContent];
+                            }
+                        }
+                    } catch {
+                        // Log parsing
+                    }
+                    if (parsedEntries.length === 0) {
+                        const logs = parseLogFile(content, url);
+                        logs.forEach(e => {
+                            e.isFull = true;
+                            e.downloadUrl = url;
+                        });
+                        parsedEntries = logs;
+                    }
+                }
+
+                if (parsedEntries.length > 0) {
+                    setData(prev => {
+                        const targetPath = decodeGcsPath(url);
+                        const filtered = prev.filter(d => decodeGcsPath(d.downloadUrl) !== targetPath);
+                        const oldMatch = prev.find(d => decodeGcsPath(d.downloadUrl) === targetPath);
+                        const source = oldMatch?.source || 'gcs';
+                        
+                        const updatedEntries = parsedEntries.map(e => {
+                            e.source = source;
+                            e.isFull = true;
+                            e.downloadUrl = url;
+                            e.isFromResultStore = oldMatch?.isFromResultStore ?? url.includes('prism-results-store/');
+                            e.source_info = {
+                                ...(e.source_info || {}),
+                                type: 'storage',
+                                origin: source,
+                                raw_url: url
+                            };
+                            if (!e.source_info.file_identifier) {
+                                e.source_info.file_identifier = decodeURIComponent(url).split('/').pop() || 'unknown';
+                            }
+                            e.raw_url = url;
+
+                            if (e.latency?.mean && e.latency.mean < 100) {
+                                e.latency.mean *= 1000;
+                                if (e.latency.p50) e.latency.p50 *= 1000;
+                                if (e.latency.p99) e.latency.p99 *= 1000;
+                                if (e.latency.min) e.latency.min *= 1000;
+                                if (e.latency.max) e.latency.max *= 1000;
+                            }
+                            if (e.ttft?.mean && e.ttft.mean < 100) {
+                                e.ttft.mean *= 1000;
+                                if (e.ttft.p50) e.ttft.p50 *= 1000;
+                                if (e.ttft.p99) e.ttft.p99 *= 1000;
+                                if (e.ttft.min) e.ttft.min *= 1000;
+                                if (e.ttft.max) e.ttft.max *= 1000;
+                            }
+                            return e;
+                        });
+
+                        const oldKey = oldMatch ? getBenchmarkKey(oldMatch) : null;
+                        const newKeys = new Set(updatedEntries.map(e => getBenchmarkKey(e)));
+
+                        if (oldKey && !newKeys.has(oldKey)) {
+                            setSelectedBenchmarks(prevSel => {
+                                if (prevSel.has(oldKey)) {
+                                    const nextSel = new Set(prevSel);
+                                    nextSel.delete(oldKey);
+                                    newKeys.forEach(k => nextSel.add(k));
+                                    return nextSel;
+                                }
+                                return prevSel;
+                            });
+
+                            setExpandedModels(prevExp => {
+                                if (prevExp.has(oldKey) || (oldMatch.model && prevExp.has(oldMatch.model)) || (oldMatch.model_name && prevExp.has(oldMatch.model_name))) {
+                                    const nextExp = new Set(prevExp);
+                                    nextExp.delete(oldKey);
+                                    if (oldMatch.model) nextExp.delete(oldMatch.model);
+                                    if (oldMatch.model_name) nextExp.delete(oldMatch.model_name);
+                                    newKeys.forEach(k => nextExp.add(k));
+                                    return nextExp;
+                                }
+                                return prevExp;
+                            });
+                        }
+
+                        return [...filtered, ...updatedEntries];
+                    });
+                } else {
+                    setData(prev => prev.map(d => (d.downloadUrl && decodeGcsPath(d.downloadUrl) === decodeGcsPath(url)) ? { ...d, isFull: true } : d));
+                }
+            } catch (err) {
+                console.error(`Failed to load detailed metrics for ${url}:`, err);
+                setData(prev => prev.map(d => (d.downloadUrl && decodeGcsPath(d.downloadUrl) === decodeGcsPath(url)) ? { ...d, isFull: true } : d));
+            } finally {
+                pendingDetailedRequests.current.delete(url);
+            }
+        }));
+    }, []);
+
+    useEffect(() => {
+        const fetchNeeded = new Set();
+        data.forEach((d) => {
+            if (!d.isFull && d.downloadUrl && !pendingDetailedRequests.current.has(d.downloadUrl)) {
+                const key = getBenchmarkKey(d);
+                const isSelected = selectedBenchmarks && selectedBenchmarks.has(key);
+                const isExpanded = expandedModels && (
+                    expandedModels.has(key) || 
+                    (d.model && expandedModels.has(d.model)) || 
+                    (d.model_name && expandedModels.has(d.model_name))
+                );
+                const isUnknown = !d.model || d.model === 'Unknown' || d.model_name === 'Unknown';
+                
+                if (isSelected || isExpanded || isUnknown) {
+                    fetchNeeded.add(d.downloadUrl);
+                }
+            }
+        });
+
+        if (fetchNeeded.size > 0) {
+            loadDetailedMetrics(Array.from(fetchNeeded));
+        }
+    }, [data, selectedBenchmarks, expandedModels, loadDetailedMetrics]);
 
     useEffect(() => {
         // Automatically sync all benchmark stage runs into the main scatter plot data array
@@ -198,7 +411,6 @@ export const useDashboardData = (initialState, dashboardState) => {
     const [newProjectId, setNewProjectId] = useState("");
     const [newAuthToken, setNewAuthToken] = useState("");
     const [showSampleData, setShowSampleData] = useState(true);
-    const [expandedModels, setExpandedModels] = useState(new Set());
     const [debugInfo, setDebugInfo] = useState(null);
     const [qualityInspectOpen, setQualityInspectOpen] = useState(false);
     const [expandedIntegration, setExpandedIntegration] = useState(null);
@@ -240,15 +452,15 @@ export const useDashboardData = (initialState, dashboardState) => {
         localStorage.setItem('prism_saved_sources', JSON.stringify(toSave));
     }, [bucketConfigs, awsBucketConfigs, apiConfigs, selectedSources, enableLLMDResults]);
 
-    const removeToast = (id) => {
+    const removeToast = useCallback((id) => {
         setToasts(prev => prev.filter(t => t.id !== id));
-    };
+    }, []);
 
-    const addToast = (message, type = 'info') => {
+    const addToast = useCallback((message, type = 'info') => {
         const id = Date.now() + Math.random();
         setToasts(prev => [...prev, { id, message, type }]);
         setTimeout(() => removeToast(id), 8000); // 8 Seconds
-    };
+    }, [removeToast]);
 
     // --- Extracted Block ---
     // Drive Sync Function
@@ -557,19 +769,7 @@ export const useDashboardData = (initialState, dashboardState) => {
                     setAvailableSources(prev => new Set([...prev, ...newSources]));
                     setSelectedSources(prev => new Set([...prev, ...newSources]));
 
-                    // Update models
-                    const allKeys = new Set();
-                    allResults.forEach(r => {
-                        const sourceKey = `${r.type}:${r.id}`;
-                        r.entries.forEach(e => {
-                            allKeys.add(getBenchmarkKey({ ...e, source: sourceKey }));
-                        });
-                    });
 
-                    setSelectedBenchmarks(prev => {
-                        if (prev.size > 0) return prev;
-                        return allKeys;
-                    });
                 }
 
                 if (saved.qualityScoresEnabled) {
@@ -603,20 +803,36 @@ export const useDashboardData = (initialState, dashboardState) => {
         }
     }, [loading]);
 
-    const updateSourceData = (sourceKey, newEntries, profile) => {
+    const updateSourceData = (sourceKey, newEntries, profile, mode = 'replace') => {
+        const append = mode === 'append' || mode === true;
         const normalized = newEntries.map(e => ({ ...e, source: sourceKey }));
 
         setData(prev => {
-            // Remove existing entries for this source
-            const filtered = prev.filter(d => d.source !== sourceKey);
-            // Add new entries, ensuring unique IDs
+            const filtered = append ? prev : prev.filter(d => d.source !== sourceKey);
             const next = [...filtered, ...normalized].map((d, i) => ({ ...d, id: i }));
             return next;
         });
 
         setGcsProfiles(prev => {
-            const existing = prev.filter(p => `${p.type}:${p.bucketName}` !== sourceKey);
-            return [...existing, profile];
+            const match = prev.find(p => `${p.type}:${p.bucketName}` === sourceKey);
+            if (match && append) {
+                return prev.map(p => {
+                    if (`${p.type}:${p.bucketName}` === sourceKey) {
+                        return {
+                            ...p,
+                            files: [...(p.files || []), ...(profile.files || [])],
+                            entryCount: (p.entryCount || 0) + (profile.entryCount || 0),
+                            loadedAt: profile.loadedAt,
+                            nextPageToken: profile.nextPageToken,
+                            loading: false
+                        };
+                    }
+                    return p;
+                });
+            } else {
+                const existing = prev.filter(p => `${p.type}:${p.bucketName}` !== sourceKey);
+                return [...existing, { ...profile, loading: false }];
+            }
         });
 
         setAvailableSources(prev => new Set([...prev, sourceKey]));
@@ -632,6 +848,40 @@ export const useDashboardData = (initialState, dashboardState) => {
             }
             return next;
         });
+    };
+
+    const loadMoreGcs = async (sourceType, id) => {
+        if (sourceType !== 'gcs') return;
+
+        const currentProfile = gcsProfiles.find(p => p.bucketName === id && p.type === 'gcs');
+        if (!currentProfile || !currentProfile.nextPageToken) return;
+
+        // Set loading state on GCS profile card
+        setGcsProfiles(prev => prev.map(p =>
+            p.bucketName === id && p.type === 'gcs' ? { ...p, loading: true } : p
+        ));
+
+        try {
+            const result = await fetchBucketData(id, false, currentProfile.nextPageToken);
+            if (result.profile.error) {
+                setGcsError(result.profile.error);
+                setGcsProfiles(prev => prev.map(p =>
+                    p.bucketName === id && p.type === 'gcs' ? { ...p, loading: false } : p
+                ));
+            } else {
+                updateSourceData(`gcs:${id}`, result.entries, {
+                    ...result.profile,
+                    nextPageToken: result.nextPageToken
+                }, 'append');
+                setGcsSuccess(`Loaded more benchmarks from bucket: ${id}`);
+            }
+        } catch (err) {
+            console.error(`Error loading more benchmarks:`, err);
+            setGcsError(err.message);
+            setGcsProfiles(prev => prev.map(p =>
+                p.bucketName === id && p.type === 'gcs' ? { ...p, loading: false } : p
+            ));
+        }
     };
 
     const handleAddGCSBucket = async (alias = null, bucketNameOverride = null) => {
@@ -1799,7 +2049,7 @@ export const useDashboardData = (initialState, dashboardState) => {
         addToast, removeToast,
         siteName, setSiteName,
         contactUrl, setContactUrl,
-        fetchConfig, fetchBucketData, fetchGiqData,
+        fetchConfig, fetchBucketData, fetchGiqData, loadMoreGcs,
         fetchQualityData, fetchLocalData, fetchArchivedData,
         loadAllData, handleLpgFileUpload, handleLpgGcsScan, handleLpgGcsLoad, syncDriveData,
         restoreSampleData, removeSampleData, removeLLMDData,

--- a/src/hooks/useGCS.js
+++ b/src/hooks/useGCS.js
@@ -14,18 +14,18 @@
 
 import { useCallback } from 'react';
 import { CacheManager } from '../utils/cacheManager';
-import { parseJsonEntry, parseLogFile } from '../utils/dataParser';
 
 export const useGCS = ({ pendingRequests, addToast }) => {
-    const fetchBucketData = useCallback(async (bucket, forceRefresh = false) => {
-        const cleanBucketName = bucket.replace(/^gs:\/\//, '');
+    const fetchBucketData = useCallback(async (bucket, forceRefresh = false, pageToken = '') => {
+        const cleanBucketName = bucket.replace(/^gs:\/\//, '').replace(/\/$/, '');
+        const shouldCache = cleanBucketName !== 'llm-d-benchmarks' && cleanBucketName !== 'llm-d-benchmarks-staging';
 
-        if (pendingRequests.current.has(`gcs:${cleanBucketName}`) && !forceRefresh) {
-             console.log(`[Dedupe] Already fetching ${cleanBucketName}, returning shared promise.`);
+        if (pendingRequests.current.has(`gcs:${cleanBucketName}`) && !forceRefresh && !pageToken) {
+             console.log(`[Dedupe] Already fetching GCS:${cleanBucketName}, returning shared promise.`);
              return pendingRequests.current.get(`gcs:${cleanBucketName}`);
         }
 
-        if (!forceRefresh) {
+        if (shouldCache && !forceRefresh && !pageToken) {
             const cached = await CacheManager.get('gcs', cleanBucketName);
             if (cached) {
                 console.log(`[Cache Hit] Loading GCS bucket ${cleanBucketName} from cache.`);
@@ -34,77 +34,96 @@ export const useGCS = ({ pendingRequests, addToast }) => {
             }
         }
 
-        let usingProxy = false;
-        
         const fetchPromise = (async () => {
             try {
-                let response = await fetch(`https://storage.googleapis.com/storage/v1/b/${cleanBucketName}/o`);
-                
-                if (response.status === 401 || response.status === 403) {
-                    console.log(`[Bucket] Public access denied for ${cleanBucketName}, trying proxy...`);
-                    response = await fetch(`/api/gcs/storage/v1/b/${cleanBucketName}/o`);
-                    if (response.ok) usingProxy = true;
-                }
+                const token = localStorage.getItem('github_oauth_token');
+                const headers = token ? { 'X-Prism-Github-Token': token } : {};
+                const tokenParam = pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : '';
+                const response = await fetch(`/api/benchmarks?bucket=${cleanBucketName}&limit=100${tokenParam}`, { headers });
 
-                if (response.status === 404) throw new Error('Bucket not found.');
-                if (response.status === 401 || response.status === 403) throw new Error('Access denied. Bucket must be public or accessible by server service account.');
-                if (!response.ok) throw new Error(`Failed to access bucket (${response.status}).`);
-                
+                if (!response.ok) throw new Error(`Failed to fetch benchmarks listing (${response.status})`);
+
                 const json = await response.json();
                 if (!json.items) throw new Error('No files found in bucket.');
-
-                const filesToProcess = json.items.filter(item => !item.name.endsWith('/'));
-                if (filesToProcess.length === 0) throw new Error('No valid files found in bucket.');
 
                 const newEntries = [];
                 const fileMetadata = [];
 
-                await Promise.all(filesToProcess.map(async (file) => {
+                json.items.forEach((item) => {
                     try {
-                        let fileUrl = file.mediaLink;
-                        if (usingProxy && fileUrl.startsWith('https://storage.googleapis.com/')) {
-                            const path = fileUrl.replace('https://storage.googleapis.com/', '');
-                            fileUrl = `/api/gcs/${path}`;
-                        }
-
-                        const fileRes = await fetch(fileUrl);
-                        if (!fileRes.ok) throw new Error(`Fetch failed: ${fileRes.status}`);
-                        
-                        const content = await fileRes.text();
+                        const hasSummary = item.summary && Array.isArray(item.summary) && item.summary.length > 0;
                         let entries = [];
 
-                        try {
-                            const jsonContent = JSON.parse(content);
-                            if (jsonContent.metrics || jsonContent.load_summary) {
-                                const entry = parseJsonEntry({ ...jsonContent, source: `gcs:${cleanBucketName}` }, file.name);
-                                entries = [entry];
-                            }
-                        } catch {
-                            // Try parsing as log file
+                        if (hasSummary) {
+                            // Map summary stages directly, marking isFull: false
+                            entries = item.summary.map(s => ({
+                                ...s,
+                                runId: item.runId,
+                                isFromResultStore: item.isFromResultStore || false,
+                                source: `gcs:${cleanBucketName}`,
+                                downloadUrl: item.downloadUrl,
+                                isFull: false
+                            }));
+                        } else {
+                            // Synthesize lightweight summary entry from item listing metadata without fetching content
+                            const runLabel = item.runLabel ?? null;
+                            const hasModel = item.model_name && item.model_name !== 'Unknown';
+                            const displayModel = runLabel || (hasModel ? item.model_name : 'Unknown');
+                            const displayHardware = item.hardware?.hardware_name || 'Unknown';
+
+                            entries = [{
+                                runId: item.runId,
+                                runLabel: runLabel,
+                                isFromResultStore: item.isFromResultStore || false,
+                                model: displayModel,
+                                model_name: hasModel ? item.model_name : 'Unknown',
+                                hardware: displayHardware,
+                                precision: 'Unknown',
+                                backend: 'Unknown',
+                                isl: 0,
+                                osl: 0,
+                                timestamp: item.submitted_at || null,
+                                throughput: null,
+                                latency: { mean: null },
+                                components: [],
+                                metadata: {
+                                    model_name: displayModel,
+                                    backend: 'Unknown',
+                                    hardware: displayHardware,
+                                    accelerator_type: displayHardware,
+                                    accelerator_count: 1,
+                                    precision: 'Unknown',
+                                    timestamp: item.submitted_at || null,
+                                    tp: 1,
+                                    architecture: 'unknown',
+                                    components: []
+                                },
+                                workload: {
+                                    input_tokens: 0,
+                                    output_tokens: 0,
+                                    stage: 1
+                                },
+                                github_author: item.github_author,
+                                source: `gcs:${cleanBucketName}`,
+                                downloadUrl: item.downloadUrl,
+                                isFull: false
+                            }];
                         }
-                        
-                        if (entries.length === 0) {
-                            entries = parseLogFile(content, file.name);
-                        }
-                        
+
                         if (entries.length > 0) {
                             entries.forEach(e => {
-                                e.source = `gcs:${cleanBucketName}`; 
-                                let type = 'storage';
-
-                                if (e.source_info) {
-                                    e.source_info.origin = `gcs:${cleanBucketName}`;
-                                    e.source_info.type = type;
-                                } else {
-                                    e.source_info = {
-                                        type,
-                                        origin: `gcs:${cleanBucketName}`,
-                                        file_identifier: file.name,
-                                        raw_url: file.mediaLink
-                                    };
+                                e.source = `gcs:${cleanBucketName}`;
+                                e.source_info = {
+                                    ...(e.source_info || {}),
+                                    type: 'storage',
+                                    origin: `gcs:${cleanBucketName}`,
+                                    raw_url: item.downloadUrl
+                                };
+                                if (!e.source_info.file_identifier) {
+                                    e.source_info.file_identifier = item.runId;
                                 }
-                                e.raw_url = `https://storage.googleapis.com/${cleanBucketName}/${file.name}`;
-                                
+                                e.raw_url = item.downloadUrl;
+
                                 if (e.latency?.mean && e.latency.mean < 100) {
                                     e.latency.mean *= 1000;
                                     if (e.latency.p50) e.latency.p50 *= 1000;
@@ -121,31 +140,40 @@ export const useGCS = ({ pendingRequests, addToast }) => {
                                 }
                                 newEntries.push(e);
                             });
-                            fileMetadata.push({ name: file.name, entryCount: entries.length });
+                            fileMetadata.push({ name: item.runId, entryCount: entries.length });
                         }
                     } catch (e) {
-                        console.warn(`Failed to process ${file.name}:`, e);
-                        fileMetadata.push({ name: file.name, entryCount: 0, error: e.message });
+                        console.warn(`Failed to process ${item.runId}:`, e);
+                        fileMetadata.push({ name: item.runId, entryCount: 0, error: e.message });
                     }
-                }));
+                });
 
                 const result = {
                     bucketName: cleanBucketName,
                     entries: newEntries,
+                    nextPageToken: json.nextPageToken || null,
                     profile: {
                         bucketName: cleanBucketName,
                         files: fileMetadata,
                         entryCount: fileMetadata.filter(f => f.entryCount > 0).length, 
                         loadedAt: new Date().toISOString(),
-                        error: null
+                        error: null,
+                        nextPageToken: json.nextPageToken || null,
+                        type: 'gcs'
                     }
                 };
-                
-                const saved = await CacheManager.set('gcs', cleanBucketName, result);
-                if (!saved) {
-                    addToast(`[Error] Cache Full - Could not save ${cleanBucketName}`, 'error');
+
+                if (shouldCache && !pageToken) {
+                    const saved = await CacheManager.set('gcs', cleanBucketName, result);
+                    if (!saved) {
+                        addToast(`[Error] Cache Full - Could not save ${cleanBucketName}`, 'error');
+                    } else {
+                        addToast(`[Network] Fetched ${cleanBucketName}`, 'info');
+                    }
+                } else if (!pageToken) {
+                    addToast(`[Network] Fetched ${cleanBucketName} (uncached)`, 'info');
                 } else {
-                    addToast(`[Network] Fetched ${cleanBucketName}`, 'info');
+                    addToast(`[Network] Loaded page from ${cleanBucketName}`, 'info');
                 }
                 return result;
 

--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -32,10 +32,13 @@ const safeNum = (val) => {
     return isNaN(n) ? null : n;
 };
 
-// v0.2 latency values are in seconds — convert to ms for display
-const toMs = (val) => {
+// convert to ms for display, checking units
+const toMs = (val, units = 's') => {
     const n = safeNum(val);
-    return n !== null ? n * 1000 : null;
+    if (n === null) return null;
+    const u = String(units || '').toLowerCase().trim();
+    if (u === 'ms' || u === 'milliseconds' || u.includes('ms')) return n;
+    return n * 1000;
 };
 
 // vllm cache rates are emitted as fractions for kv_cache_usage but as
@@ -164,6 +167,13 @@ export function parseReportV02(yamlText, filename) {
     }
     if (!doc || doc.version !== '0.2') return null;
 
+    // --- Performance ---
+    const reqPerf = doc.results?.request_performance || {};
+    const agg = reqPerf.aggregate || reqPerf;
+    const tput = agg.throughput || {};
+    const lat = agg.latency || {};
+    const reqs = agg.requests || {};
+
     // --- Scenario ---
     const stack = doc.scenario?.stack || [];
     const components = extractComponents(stack);
@@ -186,34 +196,28 @@ export function parseReportV02(yamlText, filename) {
         tp: safeNum(parallelism.tp),
         role: std.role || 'aggregate',
         harness: load.tool || 'unknown',
-        isl: safeNum(load.input_seq_len?.value),
-        osl: safeNum(load.output_seq_len?.value),
+        isl: safeNum(load.input_seq_len?.value) || safeNum(reqs.input_length?.mean) || 0,
+        osl: safeNum(load.output_seq_len?.value) || safeNum(reqs.output_length?.mean) || 0,
         rateQps: safeNum(load.rate_qps),
         concurrency: Number.isFinite(load.concurrency) ? safeNum(load.concurrency) : null,
     };
 
-    // --- Performance ---
-    const agg = doc.results?.request_performance?.aggregate || {};
-    const tput = agg.throughput || {};
-    const lat = agg.latency || {};
-    const reqs = agg.requests || {};
-
     const performance = {
-        outputTokenRate: safeNum(tput.output_token_rate?.mean),
-        inputTokenRate: safeNum(tput.input_token_rate?.mean),
-        requestRate: safeNum(tput.request_rate?.mean),
-        ttftMean: toMs(lat.time_to_first_token?.mean),
-        ttftP50: toMs(lat.time_to_first_token?.p50),
-        ttftP99: toMs(lat.time_to_first_token?.p99),
-        tpotMean: toMs(lat.time_per_output_token?.mean),
-        tpotP50: toMs(lat.time_per_output_token?.p50),
-        tpotP99: toMs(lat.time_per_output_token?.p99),
-        itlMean: toMs(lat.inter_token_latency?.mean),
-        itlP50: toMs(lat.inter_token_latency?.p50),
-        itlP99: toMs(lat.inter_token_latency?.p99),
-        e2eMean: toMs(lat.request_latency?.mean),
-        e2eP50: toMs(lat.request_latency?.p50),
-        e2eP99: toMs(lat.request_latency?.p99),
+        outputTokenRate: safeNum(tput.output_token_rate?.mean) || safeNum(tput.output_token_rate),
+        inputTokenRate: safeNum(tput.input_token_rate?.mean) || safeNum(tput.input_token_rate),
+        requestRate: safeNum(tput.request_rate?.mean) || safeNum(tput.request_rate),
+        ttftMean: toMs(lat.time_to_first_token?.mean || lat.time_to_first_token, lat.time_to_first_token?.units),
+        ttftP50: toMs(lat.time_to_first_token?.p50, lat.time_to_first_token?.units),
+        ttftP99: toMs(lat.time_to_first_token?.p99, lat.time_to_first_token?.units),
+        tpotMean: toMs(lat.time_per_output_token?.mean || lat.time_per_output_token, lat.time_per_output_token?.units),
+        tpotP50: toMs(lat.time_per_output_token?.p50, lat.time_per_output_token?.units),
+        tpotP99: toMs(lat.time_per_output_token?.p99, lat.time_per_output_token?.units),
+        itlMean: toMs(lat.inter_token_latency?.mean || lat.inter_token_latency, lat.inter_token_latency?.units),
+        itlP50: toMs(lat.inter_token_latency?.p50, lat.inter_token_latency?.units),
+        itlP99: toMs(lat.inter_token_latency?.p99, lat.inter_token_latency?.units),
+        e2eMean: toMs(lat.request_latency?.mean || lat.request_latency, lat.request_latency?.units),
+        e2eP50: toMs(lat.request_latency?.p50, lat.request_latency?.units),
+        e2eP99: toMs(lat.request_latency?.p99, lat.request_latency?.units),
         totalRequests: safeNum(reqs.total),
         failures: safeNum(reqs.failures),
     };

--- a/tools/backfill_metadata/index.ts
+++ b/tools/backfill_metadata/index.ts
@@ -1,0 +1,524 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* eslint-disable @typescript-eslint/no-explicit-any, @typescript-eslint/no-unused-vars, no-unused-vars */
+
+import { storage, getPrismResultsBucket } from '../../server/results/gcs.ts';
+import { parseReportV02, stageToEntry } from '../../src/utils/benchmarkReportV02Parser.js';
+import { parseJsonEntry } from '../../src/utils/dataParser.js';
+import { Command } from 'commander';
+import yaml from 'js-yaml';
+import { PrismSummaryEntry } from '../../server/results/api.ts';
+
+async function asyncPool<T, R>(
+    concurrency: number,
+    iterable: T[],
+    iteratorFn: (item: T) => Promise<R>
+): Promise<R[]> {
+    const ret: Promise<R>[] = [];
+    const executing: Set<Promise<any>> = new Set();
+    
+    for (const item of iterable) {
+        const p = Promise.resolve().then(() => iteratorFn(item));
+        ret.push(p);
+        executing.add(p);
+        
+        const clean = () => executing.delete(p);
+        p.then(clean, clean);
+        
+        if (executing.size >= concurrency) {
+            await Promise.race(executing);
+        }
+    }
+    return Promise.all(ret);
+}
+
+function getSummaryFromEntries(entries: any[]): PrismSummaryEntry[] {
+    return entries.map(e => {
+        return {
+            runLabel: e.runLabel || e.run_description || '',
+            github_author: e.github_author,
+            model: e.model || e.model_name || 'Unknown',
+            model_name: e.model_name || e.model || 'Unknown',
+            hardware: e.hardware || e.metadata?.hardware || 'Unknown',
+            precision: e.precision || e.metadata?.precision || 'Unknown',
+            backend: e.backend || e.metadata?.backend || 'Unknown',
+            isl: e.isl || e.workload?.input_tokens || 0,
+            osl: e.osl || e.workload?.output_tokens || 0,
+            timestamp: e.timestamp || e.metadata?.timestamp || null,
+            throughput: e.throughput || e.metrics?.throughput || null,
+            latency: {
+                mean: e.latency?.mean ?? e.metrics?.latency?.mean ?? null
+            },
+            components: e.components || e.metadata?.components || [],
+            metadata: {
+                model_name: e.metadata?.model_name || e.model_name || 'Unknown',
+                backend: e.metadata?.backend || e.backend || 'Unknown',
+                hardware: e.metadata?.hardware || e.hardware || 'Unknown',
+                accelerator_type: e.metadata?.accelerator_type || e.hardware || 'Unknown',
+                accelerator_count: e.metadata?.accelerator_count || 1,
+                precision: e.metadata?.precision || 'Unknown',
+                timestamp: e.metadata?.timestamp || e.timestamp || null,
+                tp: e.metadata?.tp || 1,
+                architecture: e.metadata?.architecture || 'aggregate',
+                components: e.metadata?.components || e.components || []
+            },
+            workload: {
+                input_tokens: e.workload?.input_tokens || e.isl || 0,
+                output_tokens: e.workload?.output_tokens || e.osl || 0,
+                stage: e.workload?.stage ?? 1
+            }
+        };
+    });
+}
+
+async function processResultsStoreFile(file: any, dryRun: boolean): Promise<{ status: 'skipped' | 'updated' | 'error'; error?: string }> {
+    try {
+        const metadata = file.metadata;
+        const customMetadata = metadata?.metadata || {};
+        
+        const [contents] = await file.download();
+        const contentStr = contents.toString('utf8');
+        
+        const payload = JSON.parse(contentStr);
+        if (!payload || !payload.entries) {
+            return { status: 'error', error: 'Invalid Results Store payload: missing entries' };
+        }
+        
+        const entries: any[] = [];
+        for (const entry of payload.entries) {
+            const parsedStage = parseReportV02(entry.raw_report, entry.filename);
+            if (parsedStage) {
+                parsedStage.runId = payload.runId;
+                parsedStage.runLabel = payload.runLabel;
+                parsedStage.run_metadata = payload.run_metadata;
+                if (payload.metadata?.config) {
+                    parsedStage.config = payload.metadata.config;
+                }
+                const fullEntry = stageToEntry(parsedStage);
+                if (payload.github_author) {
+                    fullEntry.github_author = payload.github_author;
+                }
+                entries.push(fullEntry);
+            }
+        }
+
+        if (entries.length === 0) {
+            return { status: 'skipped', error: 'No benchmark entries parsed' };
+        }
+
+        const summary = getSummaryFromEntries(entries);
+        const summaryStr = JSON.stringify(summary);
+
+        const currentSummary = String(customMetadata.prism_summary || '');
+        if (currentSummary === summaryStr) {
+            return { status: 'skipped' };
+        }
+
+        if (!dryRun) {
+            await file.setMetadata({
+                metadata: {
+                    ...customMetadata,
+                    prism_summary: summaryStr
+                }
+            });
+        }
+
+        return { status: 'updated' };
+    } catch (e: any) {
+        return { status: 'error', error: e.message };
+    }
+}
+
+async function run(force: boolean, dryRun: boolean, bucketName: string) {
+    console.log(`Starting backfill. Mode: ${force ? 'force' : 'quick'}, Dry Run: ${dryRun}`);
+
+    const bucket = storage.bucket(bucketName);
+    console.log(`Target GCS Bucket: gs://${bucketName}`);
+
+    let totalFiles = 0;
+    let checkedFiles = 0;
+    let skippedFiles = 0;
+    let updatedFiles = 0;
+    let errorFiles = 0;
+
+    // Fetch all files in the bucket
+    console.log('Listing all files in bucket...');
+    const allFiles: any[] = [];
+    let pageToken: string | undefined = undefined;
+    do {
+        const [files, nextQuery]: [any[], any] = await bucket.getFiles({
+            pageToken,
+            autoPaginate: false
+        });
+        allFiles.push(...files);
+        pageToken = nextQuery?.pageToken;
+    } while (pageToken);
+
+    console.log(`Found ${allFiles.length} GCS objects. Grouping by folder...`);
+
+    const resultsStoreFiles: any[] = [];
+    const adhocFilesByFolder: Map<string, any[]> = new Map();
+
+    for (const file of allFiles) {
+        if (file.name.endsWith('/')) {
+            continue;
+        }
+        if (file.name.endsWith('.keep') || file.name.split('/').pop()?.startsWith('.')) {
+            continue;
+        }
+
+        if (file.name.startsWith('prism-results-store/')) {
+            if (file.name.endsWith('.json')) {
+                resultsStoreFiles.push(file);
+            }
+        } else {
+            const baseName = file.name.split('/').pop() || '';
+            if (baseName === 'per_request_lifecycle_metrics.json') {
+                continue;
+            }
+            const isCandidate = file.name.endsWith('.json') || file.name.endsWith('.yaml') || file.name.endsWith('.yml') || file.name.endsWith('.log');
+            if (isCandidate) {
+                const parts = file.name.split('/');
+                parts.pop();
+                const folderPath = parts.join('/') + '/';
+                
+                if (!adhocFilesByFolder.has(folderPath)) {
+                    adhocFilesByFolder.set(folderPath, []);
+                }
+                adhocFilesByFolder.get(folderPath)!.push(file);
+            }
+        }
+    }
+
+    console.log(`Results Store files to index: ${resultsStoreFiles.length}`);
+    console.log(`Ad-hoc folders containing benchmark runs: ${adhocFilesByFolder.size}`);
+
+    // 1. Process Results Store files in parallel (concurrency: 10)
+    await asyncPool(10, resultsStoreFiles, async (file) => {
+        totalFiles++;
+        const metadata = file.metadata;
+        const customMetadata = metadata?.metadata || {};
+        const hasSummary = !!customMetadata.prism_summary;
+        
+        if (hasSummary && !force) {
+            skippedFiles++;
+            return;
+        }
+        
+        checkedFiles++;
+        console.log(`Processing Results Store run: ${file.name}...`);
+        const res = await processResultsStoreFile(file, dryRun);
+        if (res.status === 'updated') {
+            console.log(`  -> Successfully indexed: ${file.name}`);
+            updatedFiles++;
+        } else if (res.status === 'skipped') {
+            console.log(`  -> Skipped ${file.name}. ${res.error ? `Reason: ${res.error}` : ''}`);
+            skippedFiles++;
+        } else {
+            console.error(`  -> ERROR on ${file.name}: ${res.error}`);
+            errorFiles++;
+        }
+    });
+
+    // 2. Process ad-hoc folders as unified runs in parallel (concurrency: 5)
+    const foldersList = Array.from(adhocFilesByFolder.entries());
+    
+    await asyncPool(5, foldersList, async ([folderPath, files]) => {
+        // Only parse BRV01 and BRV02 report files (benchmark_report prefix with json/yaml/yml extension)
+        const filesToParse = files.filter(f => {
+            const baseName = (f.name.split('/').pop() || '').toLowerCase();
+            return baseName.startsWith('benchmark_report') && 
+                   (baseName.endsWith('.json') || baseName.endsWith('.yaml') || baseName.endsWith('.yml'));
+        });
+
+        if (filesToParse.length === 0) {
+            skippedFiles += files.length;
+            return;
+        }
+
+        totalFiles += files.length;
+
+        // Determine if this folder needs checking
+        const needsIndex = force || filesToParse.some(f => !f.metadata?.metadata?.prism_summary);
+        if (!needsIndex) {
+            skippedFiles += files.length;
+            return;
+        }
+
+        console.log(`Processing folder run: ${folderPath}...`);
+        checkedFiles += filesToParse.length;
+
+        const v01Entries: any[] = [];
+        const v02Entries: any[] = [];
+        const parsedV01Files: any[] = [];
+        const parsedV02Files: any[] = [];
+
+        // Fetch target files in parallel
+        await Promise.all(filesToParse.map(async (file) => {
+            try {
+                const [contents] = await file.download();
+                const contentStr = contents.toString('utf8');
+
+                // Try parsing as YAML/JSON
+                let parsedDoc: any = null;
+                let isYaml = false;
+                let isJson = false;
+
+                try {
+                    parsedDoc = JSON.parse(contentStr);
+                    isJson = true;
+                } catch {
+                    try {
+                        parsedDoc = yaml.load(contentStr);
+                        isYaml = true;
+                    } catch {
+                        // Not valid JSON/YAML. Could be a raw log file.
+                    }
+                }
+
+                let fileEntries: any[] = [];
+                let isV02File = false;
+
+                if (parsedDoc && typeof parsedDoc === 'object') {
+                    if (parsedDoc.version === '0.2') {
+                        isV02File = true;
+                        const parsedStage = parseReportV02(parsedDoc, file.name);
+                        if (parsedStage) {
+                            const entry = stageToEntry(parsedStage);
+                            fileEntries = [entry];
+                        }
+                    } else if (parsedDoc.metrics || parsedDoc.load_summary) {
+                        const entry = parseJsonEntry({ ...parsedDoc, source: 'gcs-backfill' }, file.name);
+                        fileEntries = [entry];
+                    }
+                }
+
+                if (fileEntries.length > 0) {
+                    const hasDate = file.name.match(/(\d{8})-(\d{6})/);
+                    fileEntries.forEach(e => {
+                        if (!hasDate) {
+                            e.timestamp = null;
+                            if (e.metadata) {
+                                e.metadata.timestamp = null;
+                            }
+                        }
+                        const folderBase = folderPath.split('/').filter(Boolean).pop() || '';
+                        e.runLabel = folderBase;
+                    });
+
+                    if (isV02File) {
+                        v02Entries.push(...fileEntries);
+                        parsedV02Files.push(file);
+                    } else {
+                        v01Entries.push(...fileEntries);
+                        parsedV01Files.push(file);
+                    }
+                }
+            } catch (err: any) {
+                console.warn(`  -> Failed to read/parse ${file.name}: ${err.message}`);
+            }
+        }));
+
+        // Apply V0.2 vs V0.1 precedence rules
+        let allEntries: any[] = [];
+        let parsedFilesToUpdate: any[] = [];
+
+        if (v02Entries.length > 0) {
+            allEntries = v02Entries;
+            parsedFilesToUpdate = [...parsedV02Files, ...parsedV01Files];
+        } else {
+            allEntries = v01Entries;
+            parsedFilesToUpdate = parsedV01Files;
+        }
+
+        if (allEntries.length === 0) {
+            console.log(`  -> No result-run files could be parsed in folder: ${folderPath}`);
+            skippedFiles += files.length;
+            return;
+        }
+
+        const summary = getSummaryFromEntries(allEntries);
+        const summaryStr = JSON.stringify(summary);
+
+        // Update metadata for all files in parallel
+        await Promise.all(parsedFilesToUpdate.map(async (file) => {
+            const currentSummary = String(file.metadata?.metadata?.prism_summary || '');
+            if (currentSummary === summaryStr) {
+                skippedFiles++;
+                console.log(`  -> Skipped ${file.name} (Summary metadata already up-to-date)`);
+                return;
+            }
+
+            if (!dryRun) {
+                try {
+                    await file.setMetadata({
+                        metadata: {
+                            ...(file.metadata?.metadata || {}),
+                            prism_summary: summaryStr
+                        }
+                    });
+                    console.log(`  -> Updated summary metadata for ${file.name}`);
+                    updatedFiles++;
+                } catch (err: any) {
+                    console.error(`  -> Failed to update metadata for ${file.name}: ${err.message}`);
+                    errorFiles++;
+                }
+            } else {
+                console.log(`  -> [Dry Run] Would update summary metadata for ${file.name}`);
+                updatedFiles++;
+            }
+        }));
+
+        const unparsedCount = files.length - parsedFilesToUpdate.length;
+        skippedFiles += unparsedCount;
+    });
+
+    console.log(`\nBackfill execution complete.`);
+    console.log(`Metrics:`);
+    console.log(`  Files found:             ${totalFiles}`);
+    console.log(`  Files checked:           ${checkedFiles}`);
+    console.log(`  Files updated:           ${updatedFiles}`);
+    console.log(`  Files skipped:           ${skippedFiles}`);
+    console.log(`  Errors:                  ${errorFiles}`);
+}
+
+async function wipe(dryRun: boolean, bucketName: string) {
+    console.log(`Starting metadata wipe. Dry Run: ${dryRun}`);
+
+    const bucket = storage.bucket(bucketName);
+    console.log(`Target GCS Bucket: gs://${bucketName}`);
+
+    let totalFiles = 0;
+    let filesWithSummary = 0;
+    let wipedFiles = 0;
+    let errorFiles = 0;
+
+    // Fetch all files in the bucket
+    console.log('Listing all files in bucket...');
+    const allFiles: any[] = [];
+    let pageToken: string | undefined = undefined;
+    do {
+        const [files, nextQuery]: [any[], any] = await bucket.getFiles({
+            pageToken,
+            autoPaginate: false
+        });
+        allFiles.push(...files);
+        pageToken = nextQuery?.pageToken;
+    } while (pageToken);
+
+    totalFiles = allFiles.length;
+    console.log(`Found ${totalFiles} GCS objects in total. Scanning for prism_summary metadata...`);
+
+    const filesToWipe: any[] = [];
+
+    for (const file of allFiles) {
+        if (file.name.endsWith('/')) {
+            continue;
+        }
+        const hasSummary = !!file.metadata?.metadata?.prism_summary;
+        if (hasSummary) {
+            filesToWipe.push(file);
+        }
+    }
+
+    filesWithSummary = filesToWipe.length;
+    console.log(`Found ${filesWithSummary} objects containing prism_summary metadata.`);
+
+    if (filesWithSummary === 0) {
+        console.log('Nothing to wipe.');
+        return;
+    }
+
+    // Process wiping in parallel (concurrency: 10)
+    await asyncPool(10, filesToWipe, async (file) => {
+        console.log(`Wiping prism_summary from: ${file.name}...`);
+        
+        if (!dryRun) {
+            try {
+                const customMetadata = file.metadata?.metadata || {};
+                await file.setMetadata({
+                    metadata: {
+                        ...customMetadata,
+                        prism_summary: null
+                    }
+                });
+                console.log(`  -> Successfully wiped: ${file.name}`);
+                wipedFiles++;
+            } catch (err: any) {
+                console.error(`  -> ERROR wiping ${file.name}: ${err.message}`);
+                errorFiles++;
+            }
+        } else {
+            console.log(`  -> [Dry Run] Would wipe: ${file.name}`);
+            wipedFiles++;
+        }
+    });
+
+    console.log(`\nWipe execution complete.`);
+    console.log(`Metrics:`);
+    console.log(`  Total GCS objects:       ${totalFiles}`);
+    console.log(`  Objects with metadata:   ${filesWithSummary}`);
+    console.log(`  Objects wiped:           ${wipedFiles}`);
+    console.log(`  Errors:                  ${errorFiles}`);
+}
+
+const program = new Command();
+
+program
+    .name('backfill-metadata')
+    .description('Manage and backfill GCS benchmark metadata')
+    .argument('<mode>', 'Execution mode: "quick" (skips already indexed), "force" (re-validates and overrides), or "wipe" (wipes prism_summary)')
+    .option('-d, --dry-run', 'Preview changes without uploading/updating metadata', false)
+    .option('-e, --env <env>', 'Target environment: "staging" or "prod" (or "production")', 'staging')
+    .action(async (mode, options) => {
+        if (mode !== 'quick' && mode !== 'force' && mode !== 'wipe') {
+            console.error(`Error: invalid mode "${mode}". Mode must be either "quick", "force", or "wipe".`);
+            program.help();
+            return;
+        }
+        
+        const env = options.env;
+        if (env !== 'staging' && env !== 'prod' && env !== 'production') {
+            console.error(`Error: invalid env "${env}". Env must be either "staging" or "prod" (or "production").`);
+            program.help();
+            return;
+        }
+        
+        const dryRun = !!options.dryRun;
+        const bucketName = env === 'staging' ? 'llm-d-benchmarks-staging' : 'llm-d-benchmarks';
+        
+        if (mode === 'wipe') {
+            try {
+                await wipe(dryRun, bucketName);
+            } catch (err) {
+                console.error('Fatal wipe error:', err);
+                process.exit(1);
+            }
+        } else {
+            const force = mode === 'force';
+            try {
+                await run(force, dryRun, bucketName);
+            } catch (err) {
+                console.error('Fatal backfill error:', err);
+                process.exit(1);
+            }
+        }
+    });
+
+if (process.argv.length <= 2) {
+    program.help();
+}
+
+program.parse(process.argv);


### PR DESCRIPTION
Previously, when the Manage Benchmarks page is loaded, the client needs to download every single file from GCS buckets before it can display results.

This change introduces "backfilling" of benchmark result indexing, where a script goes over what's already in the canonical GCS buckets (`gs://llm-d-benchmarks` and `gs://llm-d-benchmarks-staging`) and tack on a Prism metadata field that contains specific values from the benchmark report files. This way, rather than downloading each file, benchmark values can be fetched in bulk in one go, saving lots of API requests.

## What's Changed

- Add a metadata backfill CLI tool (tools/backfill_metadata/index.ts) to index and write minified run summaries to prism_summary custom metadata on GCS object runs.
- Implement BRV0.2 vs BRV0.1 precedence rules:
  - During backfill indexing, if BRV0.2 files are present in an ad-hoc folder, they are used to generate the summary metadata, which is written back to all parsed files (BRV0.1 and BRV0.2).
  - During folder content merging (readBenchmarkContent), if BRV0.2 files exist, only BRV0.2 files are parsed and returned.
- Support pre-unified entries in the client-side downloader (useGCS and useDashboardData) to handle pre-converted server content.
- Document full system specification sheet, precedence rules, and troubleshooting guidelines in specs/main/results-api/metadata-indexing.md.
- Fix client-side CacheManager IndexedDB database name mismatch (PrismCache -> PrismCacheDB) in the connections panel.

## Backfilling Guide

Ensure the local machine's `gcloud` CLI is logged in, then run:

```
$ npm run backfill-metadata -- force -e prod

> prism@0.0.0 backfill-metadata
> tsx tools/backfill_metadata/index.ts force -e prod

Starting backfill. Mode: force, Dry Run: false
Target GCS Bucket: gs://llm-d-benchmarks
Listing all files in bucket...
Found 40692 GCS objects. Grouping by folder...
Results Store files to index: 0
Ad-hoc folders containing benchmark runs: 1866
Processing folder run: agentic-workloads/llm-d-optimized-baseline/reports-20260522-091130/...
  -> Updated summary metadata for agentic-workloads/llm-d-optimized-baseline/reports-20260522-091130/benchmark_report_v02.yaml
  -> Updated summary metadata for agentic-workloads/llm-d-optimized-baseline/reports-20260522-091130/stage_0_lifecycle_metrics.json
  -> Updated summary metadata for agentic-workloads/llm-d-optimized-baseline/reports-20260522-091130/summary_lifecycle_metrics.json
Processing folder run: agentic-workloads/llm-d-optimized-baseline/reports-20260522-094901/...
  -> Updated summary metadata for agentic-workloads/llm-d-optimized-baseline/reports-20260522-094901/benchmark_report_v02.yaml
  -> Updated summary metadata for agentic-workloads/llm-d-optimized-baseline/reports-20260522-094901/stage_0_lifecycle_metrics.json
  -> Updated summary metadata for agentic-workloads/llm-d-optimized-baseline/reports-20260522-094901/summary_lifecycle_metrics.json
...
```

**As of the time of opening this PR, a backfilling operation is already being performed.**

## Future Work: Periodic Cloud Run Job

To ensure that the metadata index remains accurate and up-to-date over time (especially for ad-hoc uploads that bypass the Results Store ingestion flow, or in case of schema/parser updates), we should eventually transition the backfill script into a managed, periodic background job.