### PR TITLE
P/D disaggregation dashboard: first production run of the benchmark-to-dashboard pipeline

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -366,6 +366,142 @@ app.get('/api/prefix-cache/data', async (req, res) => {
     }
 });
 
+// --- API: P/D Disaggregation well-lit path data ---
+// Reads llm-d-benchmark BRv0.2.x reports from
+// gs://llm-d-benchmarks/pd-disaggregation/pd-ratio-<P>-<D>/reports-<timestamp>/
+// and returns one normalized run object per P:D ratio (see
+// specs/changes/pd-disaggregation-dashboard/proposal.md).
+app.get('/api/pd-disaggregation/data', async (req, res) => {
+    try {
+        let client;
+        const adcPath = process.env.GOOGLE_APPLICATION_DEFAULT_CREDENTIALS;
+        if (adcPath && fs.existsSync(adcPath)) {
+            try {
+                const creds = JSON.parse(fs.readFileSync(adcPath, 'utf8'));
+                if (creds.type === 'authorized_user') {
+                    client = new UserRefreshClient({
+                        clientId: creds.client_id,
+                        clientSecret: creds.client_secret,
+                        refreshToken: creds.refresh_token
+                    });
+                }
+            } catch (e) {
+                console.warn('Failed to parse ADC file:', e);
+            }
+        }
+
+        if (!client) {
+            client = await auth.getClient();
+        }
+        const token = await client.getAccessToken();
+        const accessToken = token.token;
+
+        let allItems = [];
+        let pageToken = '';
+        let hasMore = true;
+
+        while (hasMore) {
+            const listUrl = `https://storage.googleapis.com/storage/v1/b/llm-d-benchmarks/o?prefix=pd-disaggregation/` +
+                (pageToken ? `&pageToken=${encodeURIComponent(pageToken)}` : '');
+            const response = await fetch(listUrl, {
+                headers: { 'Authorization': `Bearer ${accessToken}` }
+            });
+            if (!response.ok) {
+                throw new Error(`Failed to list GCS bucket: ${response.status}`);
+            }
+            const data = await response.json();
+            if (data.items) {
+                allItems = allItems.concat(data.items);
+            }
+            if (data.nextPageToken) {
+                pageToken = data.nextPageToken;
+            } else {
+                hasMore = false;
+            }
+        }
+
+        // Object layout: pd-disaggregation/pd-ratio-<P>-<D>/reports-<timestamp>/<file>.yaml
+        // Per ratio dir, keep only the lexicographically latest reports-<timestamp>
+        // directory (timestamps are sortable YYYYMMDD-HHMMSS) so re-published runs
+        // supersede older ones.
+        const latestByRatio = new Map();
+        for (const item of allItems) {
+            if (!item.name.endsWith('.yaml')) continue;
+            const parts = item.name.split('/');
+            if (parts.length < 4 || !parts[1].startsWith('pd-ratio-') || !parts[2].startsWith('reports-')) continue;
+            const current = latestByRatio.get(parts[1]);
+            if (!current || parts[2] > current.reportsDir) {
+                latestByRatio.set(parts[1], { reportsDir: parts[2], item });
+            }
+        }
+
+        const results = [];
+
+        await Promise.all([...latestByRatio.values()].map(async ({ item }) => {
+            try {
+                const reportUrl = `https://storage.googleapis.com/storage/v1/b/llm-d-benchmarks/o/${encodeURIComponent(item.name)}?alt=media`;
+                const response = await fetch(reportUrl, {
+                    headers: { 'Authorization': `Bearer ${accessToken}` }
+                });
+                if (!response.ok) return;
+
+                const doc = yaml.load(await response.text());
+
+                // Replica counts come from the stack components, not the path.
+                const stack = doc.scenario?.stack || [];
+                const prefillComp = stack.find(c => c.standardized?.role === 'prefill');
+                const decodeComp = stack.find(c => c.standardized?.role === 'decode');
+                const prefill = prefillComp?.standardized?.replicas || 0;
+                const decode = decodeComp?.standardized?.replicas || 0;
+
+                const aggregate = doc.results?.request_performance?.aggregate || {};
+                const latency = aggregate.latency || {};
+                const throughput = aggregate.throughput || {};
+                const std = prefillComp?.standardized || {};
+
+                results.push({
+                    ratio: `${prefill}:${decode}`,
+                    prefill,
+                    decode,
+                    // Latencies stay in ms as reported; the frontend converts
+                    // TTFT/E2E to seconds for display.
+                    ttft: {
+                        mean: latency.time_to_first_token?.mean || 0,
+                        p90: latency.time_to_first_token?.p90 || 0
+                    },
+                    e2e: {
+                        mean: latency.request_latency?.mean || 0,
+                        p90: latency.request_latency?.p90 || 0
+                    },
+                    itl: {
+                        mean: latency.inter_token_latency?.mean || 0
+                    },
+                    throughput: {
+                        output: throughput.output_token_rate?.mean || 0,
+                        input: throughput.input_token_rate?.mean || 0,
+                        total: throughput.total_token_rate?.mean || 0
+                    },
+                    requests: aggregate.requests?.total || 0,
+                    model: std.model?.name || 'unknown',
+                    accelerator: std.accelerator?.model || 'unknown',
+                    tp: std.accelerator?.parallelism?.tp || 1,
+                    totalReplicas: prefill + decode,
+                    uid: doc.run?.uid || item.name,
+                    reportPath: item.name
+                });
+            } catch (e) {
+                console.error(`Error loading P/D disaggregation report ${item.name} from GCS:`, e);
+            }
+        }));
+
+        results.sort((a, b) => a.prefill - b.prefill);
+        res.json(results);
+    } catch (err) {
+        console.error("Error loading P/D disaggregation GCS reports", err);
+        res.status(500).json({ error: "Failed to load P/D disaggregation reports" });
+    }
+});
+
 app.post('/api/local/submit', async (req, res) => {
     const fs = await import('fs');
     const payload = req.body;

--- a/skills/style.md
+++ b/skills/style.md
@@ -80,10 +80,12 @@ All from `import { ... } from './ui'` (or the relative path to `src/components/u
 | `Panel` | `title, actions, padding: none\|sm\|md` | `bg-white dark:bg-slate-800 rounded-xl border …` shells |
 | `StatCard` | `icon, title, value, details[], onClick, active` | KPI cards (clickable = filter card) |
 | `EmptyState` | `icon, title, message, action` | "No data" markup |
-| `Spinner` / `LoadingState` | `size` / `label` | inline `animate-spin` loaders |
+| `Spinner` / `LoadingState` | `size` / `label, fullPage` | inline `animate-spin` loaders; `fullPage` = pre-data dashboard shell |
 | `PageHeader` | `title, subtitle, badge, onNavigateBack, onToggleMobileNav, actions` | dashboard header chrome |
 | `ShareLinkButton` | — (copies URL + "Link copied!" toast) | per-dashboard share buttons |
-| `ToggleGroup` | `options[{value,label}], value, onChange, fullWidth` | metric/mode pill selectors |
+| `ToggleGroup` | `options[{value,label}], value, onChange, fullWidth` | metric/mode pill selectors (single-select) |
+| `StatPills` | `options[], active[], onToggle` | stat/percentile visibility multi-toggles |
+| `FactCell` | `label, value, title` | scenario-card label + mono value cells |
 
 ## Chart rules
 
@@ -110,16 +112,27 @@ All from `import { ... } from './ui'` (or the relative path to `src/components/u
   Omit options the data lacks — never render a selectable metric that can't be
   plotted — but keep the canonical order and labels for the ones present. Do
   not invent synonyms ("Request latency" → `E2E`; "tok/s" variants → the
-  canonical four). When a metric supports only one stat (e.g. mean-only ITL),
-  render static text ("Mean — only stat reported") in place of the stat
-  selector for that metric, per the no-single-option-filter rule.
+  canonical four).
+- **Stat bars are opacity-encoded, not single-select.** On latency bar charts,
+  render the available stats SIMULTANEOUSLY as grouped bars in the SAME series
+  color at fixed opacities — `P50`/`Mean` = 1, `P90` = 0.6, `P99` = 0.35 (per
+  `<Cell fillOpacity>`; see the Prefix cache latency chart). Visibility is
+  controlled by the `StatPills` primitive in the Filters row ("Stats:" /
+  "Percentiles:"), and tooltip swatches keep the series color at the stat's
+  opacity (`ChartTooltipRow opacity`). When a metric reports only one stat (e.g. mean-only ITL), hide the
+  stat control entirely for that metric — no placeholder text.
 - **Collapsible chart filters.** When a chart has more than one control group,
   put a `Filters` toggle (Button with a ChevronUp/ChevronDown suffix, default
   open) in the `ChartContainer` actions and collapse the control row behind
   it — see the Prefix cache dashboard's `showChartFilters` pattern. A single
   ToggleGroup does not need the collapse.
-- Tooltips: build on `ChartTooltip` + `ChartTooltipRow`. The swatch carries
-  series identity; text wears text tokens, never the series color.
+- **Bar marks**: `radius={[6, 6, 0, 0]}`, `isAnimationActive={false}`,
+  `barCategoryGap="25%"`; `maxBarSize` 80 for single-stat bars, 50 for grouped
+  stat bars. recharts `<Tooltip>` gets `{...tooltipProps()}` (standard hover
+  cursor wash, no animation, correct z-order) — never inline rgba cursors.
+- Tooltips: build on `ChartTooltip` + `ChartTooltipRow` (`opacity` for stat
+  rows). The swatch carries series identity; text wears text tokens, never
+  the series color.
 - ≥2 series → render a `ChartLegend` (entries of `{label, color}`, colors from
   the palette), placed directly below the plot inside the `ChartContainer`;
   a single series needs none (the title names it).
@@ -166,12 +179,29 @@ flat black, it is off-blueprint.
      bg-gradient-to-br from-slate-900/90 via-slate-900/50 to-slate-950/90 p-5
      shadow-2xl backdrop-blur-xl group hover:border-<hue>-500/30`, containing a
      3-column grid: `Overview` (tone cyan — what this path is and why it
-     matters), `Active configuration` / `Selectable optimizations` (the
-     deployment facts or toggleable overlays), and a third column (roadmap,
-     caveats — tone slate).
-   - **Benchmark scenario** (tone sky) — the workload shape and data caveats.
-   - **Primary outcomes** (tone emerald) — the KPI `StatCard` row: 3-4 cards
-     answering "which config wins and by how much".
+     matters), a `Selectable …` column (tone cyan — INTERACTIVE toggles that
+     filter the charts below: optimizations, tiers, or swept configs; active =
+     `border-<hue>-500/30 bg-slate-900/60`, inactive = `opacity-60`; prefer
+     this over static config facts, and never duplicate what the Benchmark
+     scenario card already shows), and a third column (tone slate) of
+     roadmap "Coming soon" chips — data caveats belong in the design spec,
+     not as UI bullet lists.
+   - **Scenario/outcomes row** — ONE `lg:grid-cols-12` row, cards side by
+     side (never stacked full-width sections). Spans: scenario 6 / outcomes 3
+     / action 3 when an Action card is present; scenario 8 / outcomes 4 when
+     it is not.
+     - **Benchmark scenario** (tone sky): gradient card with three internal
+       columns (Infra layer / Model serving / Workload), each a stack of tiny
+       label + `font-mono font-bold text-white` value pairs.
+     - **Primary outcomes** (tone emerald, in a `Panel`): 2-3 SUCCINCT boxes
+       (`bg-slate-800/40 border-slate-700/50 rounded-lg p-2.5`) — one number
+       per outcome, no multi-row KPI cards. Overflow discipline: the left
+       label block gets `min-w-0 pr-2` (so `truncate` works in flex), the
+       value gets `shrink-0`, and unit sub-lines stay terse ("(total tok/s)",
+       "(mean, s)").
+     - **Action** (tone cyan, in a `Panel`, optional): title, one-line blurb,
+       and a full-width hue-colored CTA link (guide/reproduction). Include it
+       when there is a real guide to link; otherwise omit and rebalance.
    - **Charts** — `ChartContainer`s per the chart rules above.
    - **Results table** — every well-lit dashboard ends with the full per-run
      matrix in a `ChartContainer`: charts summarize, the table is the record.
@@ -181,8 +211,10 @@ flat black, it is off-blueprint.
      row/cells highlighted `bg-emerald-900/20` + `text-emerald-300` with a
      success Badge. Units stated in the subtitle.
 5. **PrismHome card** — every well-lit path gets a card in the "Well-lit
-   paths" rail of `src/components/PrismHome.jsx`, in nav order. Copy an
-   existing card's shell (290px, `bg-slate-900/95`, hover lift + hue glow) and
+   paths" rail of `src/components/PrismHome.jsx`, in nav order. The rail is
+   `max-w-6xl`; cards are `w-[246px]` so the row fits with minimal horizontal
+   scroll. Copy an existing card's shell (`bg-slate-900/95`, hover lift + hue
+   glow) and
    fill in: title, 2 hue-tinted tag pills, 1-2 sentence description, a metrics
    preview box (`bg-slate-950/60` with two label/value rows + a small
    hue-tinted visualization), and the gradient `Launch` CTA. These cards are

--- a/specs/changes/pd-disaggregation-dashboard/proposal.md
+++ b/specs/changes/pd-disaggregation-dashboard/proposal.md
@@ -1,0 +1,240 @@
+# Proposal: Prefill/Decode Disaggregation Well-Lit Path Dashboard
+
+- **Status:** Approved at Gate A by @jjk-g (2026-07-16), as written; proposed defaults in §8 confirmed. Stage 2 implemented and verified; awaiting Gate B (implementation PR review).
+- **Pipeline:** `specs/main/dashboard-pipeline.md`, Stage 1 output (per `skills/analyze_benchmark_results.md`)
+- **Change dir:** `specs/changes/pd-disaggregation-dashboard/`
+
+## 1. Context / Intent
+
+Six P/D disaggregation benchmark runs (llm-d-benchmark report format v0.2.1)
+have been published to `gs://llm-d-benchmarks/pd-disaggregation/`. The
+"Prefill/decode disagg" nav item already exists in `LeftNavigation.jsx` but is
+`disabled: true`, and PrismHome lists P/D Disagg only on the roadmap rail. This
+proposal turns those results into the fourth well-lit path dashboard
+(after Intelligent routing, Prefix cache offloading, Agentic serving),
+following the style contract in `skills/style.md`. Prior context:
+`specs/changes/disagg-benchmarks-proposal.md` (analysis PRD) and
+`specs/changes/disagg-guide-proposal.md` (path overview) — neither was
+rejected; this spec is the concrete dashboard for the data we actually have.
+
+## 2. Benchmark scenario (constants across all six runs)
+
+| Facet | Value |
+|---|---|
+| Model | Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 |
+| Accelerator | TPU v7x (Ironwood), 8 chips per replica, TP=8 |
+| Total replicas | 8 (fixed; split between prefill and decode pools) |
+| Engine | vLLM, P/D disaggregation via TPUConnector KV transfer (`kv_producer` / `kv_consumer`), fp8 KV cache, prefix caching disabled, `--max-model-len 65536` |
+| Workload | Agentic multi-turn: 800 requests @ concurrency 40; shared system prompt 3,000 tok; dynamic system prompt mean 160,000 tok; ~540 turns/conversation; ~1,500 input / ~425 output tok per turn (means) |
+| Report format | llm-d-benchmark v0.2.1, validated against `br_v0_2_1_json_schema.json` |
+
+**Sweep dimension (exactly one):** the prefill:decode replica ratio at fixed
+total of 8 replicas — 2:6, 3:5, 4:4, 5:3, 6:2, 7:1. Verified by field-level
+diff of all six reports: only `replicas` (per pool), run identity fields, and
+results vary. The ratio is the x-axis everywhere; no extra selectors needed
+for run dimensions.
+
+## 3. What the data supports (honest audit)
+
+Available per run (`results.request_performance.aggregate`):
+
+| Metric | Stats present | Units (declared inline) | Direction |
+|---|---|---|---|
+| `time_to_first_token` (TTFT) | mean, p90 | ms | lower = better |
+| `request_latency` (E2E) | mean, p90 | ms | lower = better |
+| `inter_token_latency` (ITL) | **mean only** | ms/token | lower = better |
+| `output_token_rate` | mean | tokens/s | higher = better |
+| `input_token_rate` | mean | tokens/s | higher = better |
+| `total_token_rate` | mean | tokens/s | higher = better |
+| `requests.total` | 800 (configured count) | — | — |
+
+Missing / caveats (from `pd-benchmarks/README.md` and report metadata — these
+constrain the design and must be surfaced in the Benchmark scenario panel):
+
+- No p50/p99 for any metric; no TPOT, NTPOT, or QPS. Selectors omit these.
+- ITL is mean-only → per the style contract, its stat selector renders as
+  static text ("Mean — only stat reported").
+- Reports were hand-converted from a summary spreadsheet
+  (`pd-benchmarks/gen_reports.py`).
+- Decode-side `vllm serve` command was not in the source data; decode args
+  mirror prefill with `kv_role` assumed `kv_consumer` (flagged in each decode
+  component's `metadata.description`).
+- vLLM version, load-tool name/version, token source: `unknown`.
+- `requests.total: 800` is the configured count; success/failure breakdown
+  not yet extracted.
+- Latency magnitudes are large (mean TTFT 31 s – 837 s): axis/tooltips/table
+  display in **seconds** for TTFT and E2E (converted from ms at render time,
+  unit stated); ITL stays in ms/token.
+
+Headline result: decode-heavy wins. 2:6 is best on every metric except p90
+TTFT, where 3:5 is marginally better (104.7 s vs 112.6 s). Every step toward
+prefill-heavy is monotonically worse — total throughput spans 7.0× (33,810 →
+4,837 tok/s) and mean TTFT 27× (31.2 s → 837 s). Because 2:6 dominates
+(no Pareto frontier in this sweep), **no trade-off/scatter chart is
+proposed** — it would not earn its place; the two axis charts plus table tell
+the story.
+
+## 4. Dashboard design (per `skills/style.md`)
+
+New component `src/components/PdDisaggregationDashboard.jsx`, view id
+`pd-disaggregation`. Full well-lit path anatomy; **hue identity: violet**
+(per style.md's hue registry: cyan/blue = routing, sky/emerald = prefix
+cache, purple = agentic, violet = P/D disagg).
+
+### Page structure (canonical order)
+
+1. **WellLitHeader** — title "Prefill/Decode Disaggregation", Guided path
+   badge, Share button (plain `ShareLinkButton`; no encoded state beyond
+   defaults — see Open questions).
+2. **Canonical page root + animated background** — the verbatim shell from
+   style.md §3 (dotted grid, glow blobs).
+3. **Hero panel** (`SectionLabel`, hover accent `hover:border-violet-500/30`),
+   3-column grid:
+   - *Overview* (tone cyan): what P/D disaggregation is; why the split pool
+     ratio matters for agentic long-context workloads.
+   - *Active configuration*: model, TPU v7x ×8 chips/replica, TP=8, 8 total
+     replicas, TPUConnector KV transfer, fp8 KV cache.
+   - *Caveats / roadmap* (tone slate): hand-converted reports, mirrored
+     decode args, mean+p90 only; future: aggregated baseline comparison.
+4. **Benchmark scenario** (tone sky): agentic workload shape (800 req,
+   conc 40, ~540 turns, 160k-token dynamic system prompt, 1,500/425 tok per
+   turn) + data caveats.
+5. **Primary outcomes** (tone emerald) — KPI row, 4 `StatCard`s:
+   - **Best configuration — 2:6** ("Wins 5 of 6 reported metrics"; detail:
+     2 prefill / 6 decode replicas).
+   - **Peak total throughput — 33,810 tok/s** @ 2:6 (detail: 7.0× spread
+     across the sweep, worst 4,837 @ 7:1).
+   - **Best mean TTFT — 31.2 s** @ 2:6 (detail: p90 winner is 3:5 at
+     104.7 s).
+   - **Best mean ITL — 78 ms/tok** @ 2:6 (detail: 244.5 @ 7:1; interactivity
+     degrades 3.1×).
+6. **Charts** — two `ChartContainer`s, one axis each, x-axis = P:D ratio in
+   sweep order (2:6 … 7:1), single series (one value per ratio) colored
+   `seriesColor(0)`, no legend needed (single series), tooltips on
+   `ChartTooltip`/`ChartTooltipRow`, grid via `gridProps()`:
+   - **Throughput vs. P:D ratio** (bar chart; higher = better). Metric
+     `ToggleGroup`, canonical order/labels with unsupported options omitted:
+     `Output | Input | Total` (no QPS — not reported). Stat: static text
+     "Mean — only stat reported".
+   - **Latency vs. P:D ratio** (bar chart; lower = better). Metric
+     `ToggleGroup`, canonical order with omissions: `TTFT | ITL | E2E`
+     (no NTPOT/TPOT — not reported). Stat `ToggleGroup` `Mean | P90` for
+     TTFT and E2E; when ITL selected, stat selector is replaced by static
+     text "Mean — only stat reported". Y-axis in seconds for TTFT/E2E,
+     ms/token for ITL. Two control groups → collapsible `Filters` toggle in
+     `ChartContainer` actions (prefix-cache `showChartFilters` pattern).
+7. **Results table** — full per-run matrix in a `ChartContainer`, canonical
+   table styling; units in subtitle ("TTFT/E2E in seconds, ITL in ms/token,
+   throughput in tokens/s"). Columns: P:D ratio, prefill/decode replicas,
+   TTFT mean, TTFT p90, E2E mean, E2E p90, ITL mean, Output tok/s, Input
+   tok/s, Total tok/s, Requests. Best value per metric column highlighted
+   (`text-emerald-300`); winning row (2:6) `bg-emerald-900/20` with a
+   success `Badge`.
+
+### Registration set
+
+- `src/App.jsx`: import + `{currentView === 'pd-disaggregation' && …}` with
+  `onNavigateBack`/`onToggleMobileNav`.
+- `src/components/LeftNavigation.jsx`: flip the existing
+  `pd-disaggregation` item's `disabled: true` → enabled; add an
+  `ITEM_THEMES['pd-disaggregation']` entry in violet.
+- `src/components/PrismHome.jsx`: add the card to the "Well-lit paths" rail
+  in nav order (after Prefix cache offloading): title, 2 violet tag pills
+  (e.g. "KV transfer", "TPU v7x"), 1–2 sentence description, metrics preview
+  box (`bg-slate-950/60`; e.g. "Best ratio 2:6" / "Peak 33.8k tok/s" + small
+  violet-tinted ratio bar viz), gradient Launch CTA. The existing roadmap-rail
+  "Prefill/Decode Disagg" entry is superseded/removed per how prior paths
+  graduated (implementation follows whatever the existing pattern is).
+
+## 5. Data flow
+
+**Source of truth (production):** GCS —
+`gs://llm-d-benchmarks/pd-disaggregation/pd-ratio-<P>-<D>/reports-<timestamp>/benchmark_report_v02.yaml`
+(currently six ratios × one `reports-20260720-100535` dir each; verified by
+listing the bucket). The local `pd-benchmarks/` copies are analysis aids
+only — **the endpoint must read from GCS**.
+
+**Server endpoint:** `GET /api/pd-disaggregation/data` in `server/server.js`,
+same server-side GCS pattern as the existing `/api/prefix-cache/data`
+(lines ~208–367):
+
+1. Auth: `GOOGLE_APPLICATION_DEFAULT_CREDENTIALS` `authorized_user` file via
+   `UserRefreshClient`, falling back to `auth.getClient()` (ADC).
+2. Paginated JSON-API listing of `b/llm-d-benchmarks/o?prefix=pd-disaggregation/`.
+3. Filter to objects ending `.yaml`; group by the `pd-ratio-<P>-<D>` path
+   segment; within each ratio, keep only the **lexicographically latest
+   `reports-<timestamp>` directory** (timestamps are sortable
+   `YYYYMMDD-HHMMSS`), so re-published runs supersede older ones.
+4. Fetch each report (`?alt=media`, bearer token, `Promise.all`), parse with
+   `js-yaml` (already imported), extract fields; per-file failures are logged
+   and skipped (matching the prefix-cache endpoint's resilience).
+5. Respond with the array sorted by prefill count ascending. Errors → 500
+   `{ error }`.
+
+**Normalized run object** (what the frontend receives; latencies in ms as
+reported — frontend converts TTFT/E2E to seconds for display):
+
+```json
+{
+  "ratio": "2:6",
+  "prefill": 2,
+  "decode": 6,
+  "ttft":  { "mean": 31164, "p90": 112646 },
+  "e2e":   { "mean": 76012, "p90": 178718 },
+  "itl":   { "mean": 78 },
+  "throughput": { "output": 295, "input": 33515, "total": 33810 },
+  "requests": 800,
+  "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+  "accelerator": "TPU-v7x-Ironwood",
+  "tp": 8,
+  "totalReplicas": 8,
+  "uid": "agentic-pd-2-6-262144",
+  "reportPath": "pd-disaggregation/pd-ratio-2-6/reports-20260720-100535/benchmark_report_v02.yaml"
+}
+```
+
+`prefill`/`decode` come from the report's `scenario.stack[]` components
+(`role: prefill|decode` → `standardized.replicas`), not from parsing the
+object path; the path segment is only used for grouping/latest-dir selection.
+Frontend fetches once on mount; `LoadingState` while `null`, `EmptyState` on
+error/empty.
+
+## 6. Implementation checklist (from `skills/style.md`)
+
+1. Spec approved at Gate A (this document).
+2. Data in: `/api/pd-disaggregation/data` endpoint (§5).
+3. Scaffold `src/components/PdDisaggregationDashboard.jsx` from the style.md
+   recipe skeleton (ui primitives only).
+4. Register the view in `src/App.jsx`.
+5. Enable nav in `LeftNavigation.jsx` + violet `ITEM_THEMES` entry.
+6. Apply full well-lit path anatomy (§4) incl. PrismHome card.
+7. Self-check: style.md ratchet checklist, `npm run lint` (zero new errors),
+   `npm run build`, drive via `npm run dev` (verify all six runs returned
+   from GCS).
+
+## 7. Success criteria
+
+- Dashboard reachable from nav + PrismHome; renders all six ratios fetched
+  live from GCS via the new endpoint (no bundled/local data).
+- Charts/table/KPIs match §4 exactly; canonical selector sets with
+  unsupported options omitted; every metric direction stated in UI copy.
+- Data caveats from §3 visible in the scenario panel.
+- Ratchet greps clean on touched files; lint/build green.
+
+## 8. Open questions (for Gate A reviewers — answers are not assumed)
+
+1. **Share-link state:** should metric/stat selector state be encoded in the
+   share URL (`getShareUrl`) like some dashboards, or is a plain
+   `ShareLinkButton` acceptable for v1? Proposal default: plain button.
+2. **Chart mark:** bars proposed for both charts (6 discrete ratios). Line
+   marks would imply continuity between ratios; flagging in case reviewers
+   prefer the line style used elsewhere.
+3. **PrismHome roadmap rail:** confirm the roadmap "Prefill/Decode Disagg"
+   entry should be replaced by the well-lit path card (matching how earlier
+   paths graduated).
+4. **Latency display unit:** seconds for TTFT/E2E (values up to 937 s)
+   proposed; confirm reviewers don't want raw ms for consistency with other
+   dashboards.
+
+Per the pipeline: these proposed defaults are **not** self-approving; no
+application code is written until Gate A approval arrives.

--- a/specs/changes/ui-style-blueprint/design.md
+++ b/specs/changes/ui-style-blueprint/design.md
@@ -83,6 +83,12 @@ Requested by refactor agents but deliberately not added in the migration pass:
   (the results-matrix style), and the **PrismHome path card shell** — each now
   has 3+ copy-paste instances; extraction candidates surfaced by the second
   clean-run agent.
+- **Hero selectable toggle buttons** (3 dashboards) and **primary-outcome
+  boxes** (3 dashboards) — extraction candidates from the P/D iteration.
+  Shared **number formatters** (tok/s, ms→s) are still per-dashboard.
+  (`StatPills`, `FactCell`, `tooltipProps()`, `ChartTooltipRow opacity`, and
+  `LoadingState fullPage` graduated from this list during the P/D audit;
+  existing dashboards migrate onto them opportunistically.)
 - **Gradient hero CTAs and hue-matched tag pills** (PrismHome, wizard CTAs) —
   intentionally bespoke brand flourishes, not primitives.
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ import WorkloadCatalog from './components/WorkloadCatalog';
 import RegressionsAnalysisDashboard from './components/RegressionsAnalysisDashboard';
 import AgenticWorkloadsDashboard from './components/AgenticWorkloadsDashboard';
 import PrefixCacheOffloadingDashboard from './components/PrefixCacheOffloadingDashboard';
+import PdDisaggregationDashboard from './components/PdDisaggregationDashboard';
 import SubmitValidationPage from './components/DataConnections/SubmitValidationPage';
 
 import LeftNavigation from './components/LeftNavigation';
@@ -235,6 +236,7 @@ function App() {
             {currentView === 'schema-explorer' && <SchemaExplorer onNavigateBack={() => handleNavigate('home')} />}
             {currentView === 'workload-catalog' && <WorkloadCatalog onNavigateBack={() => handleNavigate('home')} />}
             {currentView === 'prefix-cache-offloading' && <PrefixCacheOffloadingDashboard onNavigateBack={() => handleNavigate('home')} onNavigate={handleNavigate} onToggleMobileNav={() => setIsMobileNavOpen(!isMobileNavOpen)} />}
+            {currentView === 'pd-disaggregation' && <PdDisaggregationDashboard onNavigateBack={() => handleNavigate('home')} onToggleMobileNav={() => setIsMobileNavOpen(!isMobileNavOpen)} />}
             {currentView === 'regressions-analysis' && <RegressionsAnalysisDashboard onNavigateBack={() => handleNavigate('home')} onToggleMobileNav={() => setIsMobileNavOpen(!isMobileNavOpen)} />}
             {currentView === 'guided-analysis' && <div className="p-8 text-center text-slate-400 mt-20">Guided Analysis Coming Soon... <button onClick={() => handleNavigate('home')} className="underline ml-2 text-indigo-400">Back</button></div>}
           </>

--- a/src/components/LeftNavigation.jsx
+++ b/src/components/LeftNavigation.jsx
@@ -61,6 +61,11 @@ const ITEM_THEMES = {
         activeIcon: 'bg-gradient-to-br from-cyan-500 to-blue-500 text-white shadow-[0_0_15px_rgba(6,182,212,0.35)]',
         indicator: 'bg-gradient-to-b from-cyan-400 to-blue-500 shadow-[0_0_8px_rgba(6,182,212,0.6)]'
     },
+    'pd-disaggregation': {
+        activeBg: 'bg-gradient-to-r from-violet-950/20 via-purple-950/10 to-slate-950/20 border-violet-500/20 text-violet-300',
+        activeIcon: 'bg-gradient-to-br from-violet-500 to-purple-500 text-white shadow-[0_0_15px_rgba(139,92,246,0.35)]',
+        indicator: 'bg-gradient-to-b from-violet-400 to-purple-500 shadow-[0_0_8px_rgba(139,92,246,0.6)]'
+    },
     'agentic-serving': {
         activeBg: 'bg-gradient-to-r from-emerald-950/20 via-teal-950/10 to-slate-950/20 border-emerald-500/20 text-emerald-300',
         activeIcon: 'bg-gradient-to-br from-emerald-500 to-teal-500 text-white shadow-[0_0_15px_rgba(16,185,129,0.35)]',

--- a/src/components/PdDisaggregationDashboard.jsx
+++ b/src/components/PdDisaggregationDashboard.jsx
@@ -1,0 +1,523 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Prefill/Decode Disaggregation well-lit path dashboard.
+// Design spec: specs/changes/pd-disaggregation-dashboard/proposal.md
+// (approved at Gate A). Six benchmark runs sweeping the prefill:decode
+// replica ratio at a fixed total of 8 replicas; data served from GCS via
+// /api/pd-disaggregation/data.
+
+import React, { useState, useMemo, useEffect } from 'react';
+import {
+    BarChart, Bar, Cell, CartesianGrid, Tooltip, ResponsiveContainer
+} from 'recharts';
+import { Split, ChevronDown, ChevronUp } from 'lucide-react';
+import {
+    WellLitHeader, Badge, Button, Panel, SectionLabel, ToggleGroup, StatPills,
+    FactCell, LoadingState, EmptyState, ChartContainer, ChartTooltip,
+    ChartTooltipRow, ChartXAxis, ChartYAxis, gridProps, tooltipProps, seriesColor
+} from './ui';
+import { cn } from '../utils/cn';
+
+const THROUGHPUT_LABELS = {
+    output: 'Output Tokens/sec',
+    input: 'Input Tokens/sec',
+    total: 'Total Tokens/sec',
+};
+
+const LATENCY_LABELS = {
+    ttft: 'Time To First Token (s)',
+    itl: 'Inter-Token Latency (ms/token)',
+    e2e: 'E2E Latency (s)',
+};
+
+const fmtTok = (v) => Math.round(v).toLocaleString();
+const fmtSec = (ms) => (ms / 1000).toLocaleString(undefined, { maximumFractionDigits: 1 });
+
+const ThroughputTooltip = ({ active, payload }) => {
+    if (!active || !payload?.length) return null;
+    const d = payload[0].payload;
+    return (
+        <ChartTooltip title={`P:D ratio ${d.ratio}`}>
+            <ChartTooltipRow color={d.fill} label={d.metricLabel} value={fmtTok(d.value)} unit=" tok/s" />
+        </ChartTooltip>
+    );
+};
+
+const LatencyTooltip = ({ active, payload }) => {
+    if (!active || !payload?.length) return null;
+    const d = payload[0].payload;
+    return (
+        <ChartTooltip title={`P:D ratio ${d.ratio} — ${d.metricLabel}`}>
+            {payload.map(entry => (
+                <ChartTooltipRow
+                    key={entry.name}
+                    color={d.fill}
+                    opacity={entry.name === 'Mean' ? 1 : 0.6}
+                    label={entry.name}
+                    value={typeof entry.value === 'number' ? entry.value.toLocaleString(undefined, { maximumFractionDigits: 1 }) : entry.value}
+                    unit={d.unit}
+                />
+            ))}
+        </ChartTooltip>
+    );
+};
+
+export default function PdDisaggregationDashboard({ onNavigateBack, onToggleMobileNav }) {
+    const [runs, setRuns] = useState(null);
+    const [loadFailed, setLoadFailed] = useState(false);
+
+    // Chart controls (canonical selector sets trimmed to what the data
+    // supports: no QPS, no NTPOT/TPOT, no P50/P99 — see the design spec).
+    const [thruMetric, setThruMetric] = useState('total'); // 'output' | 'input' | 'total'
+    const [latMetric, setLatMetric] = useState('ttft'); // 'ttft' | 'itl' | 'e2e'
+    const [visibleStats, setVisibleStats] = useState(['Mean', 'P90']);
+    const [showChartFilters, setShowChartFilters] = useState(true);
+    // Hero "Selectable ratios" toggles — hidden ratios are excluded from both charts.
+    const [hiddenRatios, setHiddenRatios] = useState([]);
+
+    useEffect(() => {
+        let active = true;
+        fetch('/api/pd-disaggregation/data')
+            .then(res => {
+                if (!res.ok) throw new Error(`HTTP ${res.status}`);
+                return res.json();
+            })
+            .then(data => {
+                if (active) setRuns(Array.isArray(data) ? data : []);
+            })
+            .catch(err => {
+                console.error('Failed to load P/D disaggregation reports:', err);
+                if (active) {
+                    setLoadFailed(true);
+                    setRuns([]);
+                }
+            });
+        return () => { active = false; };
+    }, []);
+
+    const outcomes = useMemo(() => {
+        if (!runs || runs.length === 0) return null;
+        const byTotal = [...runs].sort((a, b) => b.throughput.total - a.throughput.total);
+        const bestTotal = byTotal[0];
+        const worstTotal = byTotal[byTotal.length - 1];
+        const bestMeanTtft = runs.reduce((acc, r) => (r.ttft.mean < acc.ttft.mean ? r : acc), runs[0]);
+        const bestP90Ttft = runs.reduce((acc, r) => (r.ttft.p90 < acc.ttft.p90 ? r : acc), runs[0]);
+        const bestItl = runs.reduce((acc, r) => (r.itl.mean < acc.itl.mean ? r : acc), runs[0]);
+        const worstItl = runs.reduce((acc, r) => (r.itl.mean > acc.itl.mean ? r : acc), runs[0]);
+        // The "best config" is the run winning the most of the six reported
+        // metrics (TTFT mean/p90, E2E mean/p90, ITL, total throughput).
+        const wins = new Map(runs.map(r => [r.ratio, 0]));
+        const winnersOf = [
+            runs.reduce((a, r) => (r.ttft.mean < a.ttft.mean ? r : a), runs[0]),
+            bestP90Ttft,
+            runs.reduce((a, r) => (r.e2e.mean < a.e2e.mean ? r : a), runs[0]),
+            runs.reduce((a, r) => (r.e2e.p90 < a.e2e.p90 ? r : a), runs[0]),
+            bestItl,
+            bestTotal,
+        ];
+        winnersOf.forEach(r => wins.set(r.ratio, wins.get(r.ratio) + 1));
+        const bestConfig = runs.reduce((a, r) => (wins.get(r.ratio) > wins.get(a.ratio) ? r : a), runs[0]);
+        return {
+            bestConfig,
+            bestConfigWins: wins.get(bestConfig.ratio),
+            bestTotal,
+            worstTotal,
+            spread: worstTotal.throughput.total > 0 ? bestTotal.throughput.total / worstTotal.throughput.total : 0,
+            bestMeanTtft,
+            bestP90Ttft,
+            bestItl,
+            worstItl,
+        };
+    }, [runs]);
+
+    const scenario = runs && runs.length > 0 ? runs[0] : null;
+    const visibleRuns = useMemo(
+        () => (runs || []).filter(r => !hiddenRatios.includes(r.ratio)),
+        [runs, hiddenRatios]
+    );
+
+    const throughputChartData = useMemo(() => {
+        if (!runs) return [];
+        return visibleRuns.map(r => ({
+            ratio: r.ratio,
+            value: r.throughput[thruMetric],
+            metricLabel: THROUGHPUT_LABELS[thruMetric],
+            fill: seriesColor(0),
+        }));
+    }, [runs, visibleRuns, thruMetric]);
+
+    const latencyChartData = useMemo(() => {
+        if (!runs) return [];
+        return visibleRuns.map(r => {
+            const isItl = latMetric === 'itl';
+            return {
+                ratio: r.ratio,
+                // Plotted values: seconds for TTFT/E2E, ms/token for ITL (mean only).
+                mean: isItl ? r.itl.mean : r[latMetric].mean / 1000,
+                p90: isItl ? null : r[latMetric].p90 / 1000,
+                unit: isItl ? ' ms/tok' : ' s',
+                metricLabel: LATENCY_LABELS[latMetric].replace(/ \(.*\)$/, ''),
+                fill: seriesColor(0),
+            };
+        });
+    }, [runs, visibleRuns, latMetric]);
+
+    // Best (lowest for latency, highest for throughput) value per results-table
+    // metric column, for highlighting.
+    const columnBests = useMemo(() => {
+        if (!runs || runs.length === 0) return null;
+        return {
+            ttftMean: Math.min(...runs.map(r => r.ttft.mean)),
+            ttftP90: Math.min(...runs.map(r => r.ttft.p90)),
+            e2eMean: Math.min(...runs.map(r => r.e2e.mean)),
+            e2eP90: Math.min(...runs.map(r => r.e2e.p90)),
+            itlMean: Math.min(...runs.map(r => r.itl.mean)),
+            output: Math.max(...runs.map(r => r.throughput.output)),
+            input: Math.max(...runs.map(r => r.throughput.input)),
+            total: Math.max(...runs.map(r => r.throughput.total)),
+        };
+    }, [runs]);
+
+    if (runs === null) {
+        return <LoadingState fullPage label="Loading P/D disaggregation benchmarks..." />;
+    }
+
+    return (
+        <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col items-center pt-16 md:pl-24 w-full font-sans relative overflow-hidden bg-[radial-gradient(#334155_1.2px,transparent_1.2px)] bg-[size:24px_24px] bg-repeat">
+            {/* Pulsing Vibrant Neon Glow Background Shapes */}
+            <div className="absolute top-0 -left-1/4 w-1/2 h-1/2 bg-blue-600/25 rounded-full blur-3xl pointer-events-none animate-pulse" />
+            <div className="absolute bottom-0 -right-1/4 w-1/2 h-1/2 bg-emerald-600/25 rounded-full blur-3xl pointer-events-none animate-pulse" style={{ animationDelay: '2s' }} />
+
+            <WellLitHeader
+                pageTitle="Prefill/Decode Disaggregation"
+                onNavigateBack={onNavigateBack}
+                onToggleMobileNav={onToggleMobileNav}
+            />
+
+            <main className="w-full max-w-7xl px-6 py-8 flex flex-col space-y-6">
+                {runs.length === 0 ? (
+                    <ChartContainer>
+                        <EmptyState
+                            icon={<Split className="w-8 h-8" />}
+                            title={loadFailed ? 'Benchmark data unavailable' : 'No benchmark runs found'}
+                            message={loadFailed
+                                ? 'The P/D disaggregation reports could not be loaded from GCS. Check server credentials and try again.'
+                                : 'No reports were found under gs://llm-d-benchmarks/pd-disaggregation/.'}
+                        />
+                    </ChartContainer>
+                ) : (
+                    <>
+                        {/* Hero panel */}
+                        <div className="relative overflow-hidden border border-slate-800/80 rounded-2xl bg-gradient-to-br from-slate-900/90 via-slate-900/50 to-slate-950/90 p-5 shadow-2xl backdrop-blur-xl group transition-all duration-500 hover:border-violet-500/30">
+                            <div className="absolute -top-24 -right-24 w-64 h-64 bg-violet-500/10 rounded-full blur-3xl group-hover:bg-violet-500/20 transition-all duration-700 pointer-events-none" />
+
+                            <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 relative">
+                                {/* Col 1: Overview */}
+                                <div>
+                                    <SectionLabel tone="cyan">Overview</SectionLabel>
+                                    <p className="text-xs text-slate-300 leading-relaxed">
+                                        Prefill/decode disaggregation splits serving into separate pools of
+                                        replicas: a <strong>prefill</strong> pool that processes incoming
+                                        context and streams KV cache to a <strong>decode</strong> pool that
+                                        generates tokens. This sweep probes the split for a long-context
+                                        agentic workload: decode-heavy wins on nearly every metric (P90 TTFT
+                                        is the lone exception — 3:5 edges 2:6, likely tail smoothing from a
+                                        third prefill replica). Per-replica rates show why: decode replicas
+                                        run saturated (~42–49 output tok/s each) at <em>every</em> tested
+                                        ratio, so throughput scales with decode count while extra prefill
+                                        replicas sit increasingly idle. The sweep stops at 2:6 — the balance
+                                        point was not reached, and decode-heavier splits may do better still.
+                                    </p>
+                                </div>
+
+                                {/* Col 2: Selectable ratios (toggles filter the charts) */}
+                                <div className="space-y-2">
+                                    <SectionLabel tone="cyan" className="mb-1">Selectable ratios</SectionLabel>
+                                    <div className="grid grid-cols-2 gap-1.5">
+                                        {(runs || []).map(r => {
+                                            const isActive = !hiddenRatios.includes(r.ratio);
+                                            return (
+                                                <button
+                                                    key={r.ratio}
+                                                    onClick={() => setHiddenRatios(prev => isActive ? [...prev, r.ratio] : prev.filter(x => x !== r.ratio))}
+                                                    className={cn(
+                                                        'w-full text-left border rounded-lg p-2 flex items-center justify-between gap-2 transition-all cursor-pointer',
+                                                        isActive ? 'border-violet-500/30 bg-slate-900/60' : 'border-slate-800/50 bg-slate-900/20 opacity-60'
+                                                    )}
+                                                >
+                                                    <div className="min-w-0">
+                                                        <div className="text-xs font-semibold text-slate-200 font-mono">{r.ratio}</div>
+                                                        <p className="text-[10px] text-slate-500 truncate">{r.prefill}P · {r.decode}D</p>
+                                                    </div>
+                                                    <span className={cn(
+                                                        'w-1.5 h-1.5 rounded-full shrink-0',
+                                                        isActive ? 'bg-violet-400 shadow-[0_0_6px_rgba(139,92,246,0.8)]' : 'bg-slate-700'
+                                                    )} aria-hidden="true" />
+                                                </button>
+                                            );
+                                        })}
+                                    </div>
+                                    <p className="text-[10px] text-slate-500">Toggle ratios to include in the charts below.</p>
+                                </div>
+
+                                {/* Col 3: Roadmap */}
+                                <div>
+                                    <SectionLabel tone="slate">Upcoming & roadmap</SectionLabel>
+                                    <div className="border border-slate-800/50 rounded-lg bg-slate-900/30 p-2 flex items-center justify-between">
+                                        <div>
+                                            <div className="text-xs font-semibold text-slate-400">Aggregated baseline comparison</div>
+                                            <p className="text-[10px] text-slate-500">Same workload on co-located (non-disaggregated) replicas</p>
+                                        </div>
+                                        <Badge tone="warning" size="xs">Coming soon</Badge>
+                                    </div>
+                                    <div className="border border-slate-800/50 rounded-lg bg-slate-900/30 p-2 mt-2 flex items-center justify-between">
+                                        <div>
+                                            <div className="text-xs font-semibold text-slate-400">Decode-heavy extension</div>
+                                            <p className="text-[10px] text-slate-500">Sweep beyond 2:6 (e.g. 1:7) to find the balance point</p>
+                                        </div>
+                                        <Badge tone="warning" size="xs">Coming soon</Badge>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+
+                        {/* ROW 2: Benchmark scenario, Primary outcomes & Action */}
+                        {outcomes && (
+                            <div className="grid grid-cols-1 lg:grid-cols-12 gap-4">
+                                {/* Benchmark scenario (col-span-6) */}
+                                <div className="lg:col-span-8 border border-slate-800/80 rounded-xl bg-gradient-to-br from-slate-900 to-slate-950 p-4 flex flex-col justify-between shadow-lg relative overflow-hidden">
+                                    <div className="absolute -top-12 -left-12 w-32 h-32 bg-sky-500/5 rounded-full blur-2xl pointer-events-none" />
+                                    <SectionLabel tone="sky" className="text-[11px]">Benchmark scenario</SectionLabel>
+                                    <div className="grid grid-cols-12 gap-2">
+                                        {/* Column 1: Infra layer */}
+                                        <div className="flex flex-col gap-3 col-span-4 border-r border-slate-800/60 pr-2">
+                                            <div className="text-[10px] text-slate-400 font-semibold uppercase tracking-wider truncate">Infra layer</div>
+                                            <div className="flex flex-col gap-2 text-xs">
+                                                <FactCell label="Accelerator" value={<>TPU v7x (Ironwood)</>} />
+                                                <FactCell label="Replicas" value={<>{scenario?.totalReplicas ?? 8} x 8 chips, TP={scenario?.tp ?? 8}</>} />
+                                                <FactCell label="Sweep" value={<>P:D ratio 2:6 → 7:1</>} />
+                                            </div>
+                                        </div>
+
+                                        {/* Column 2: Model serving */}
+                                        <div className="flex flex-col gap-3 col-span-4 border-r border-slate-800/60 pr-2">
+                                            <div className="text-[10px] text-slate-400 font-semibold uppercase tracking-wider truncate">Model serving</div>
+                                            <div className="flex flex-col gap-2 text-xs">
+                                                <FactCell label="Model name" title={scenario?.model} value={<>Qwen3-Coder-480B-FP8</>} />
+                                                <FactCell label="Engine" value={<>vLLM — TPUConnector</>} />
+                                                <FactCell label="KV cache" value={<>fp8, prefix caching off</>} />
+                                            </div>
+                                        </div>
+
+                                        {/* Column 3: Workload */}
+                                        <div className="flex flex-col gap-3 col-span-4">
+                                            <div className="text-[10px] text-slate-400 font-semibold uppercase tracking-wider truncate">Workload</div>
+                                            <div className="flex flex-col gap-2 text-xs">
+                                                <FactCell label="Type" value={<>Agentic multi-turn</>} />
+                                                <FactCell label="Load" value={<>800 req @ conc. 40</>} />
+                                                <FactCell label="Context" value={<>160k sys + 1.5k/turn</>} />
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {/* Primary outcomes (col-span-3) */}
+                                <Panel padding="sm" className="lg:col-span-4 flex flex-col relative overflow-hidden group hover:border-violet-500/30 transition-all">
+                                    <SectionLabel tone="emerald" className="text-[11px]">Primary outcomes</SectionLabel>
+                                    <div className="grid grid-cols-1 gap-2 font-sans text-xs">
+                                        <div className="bg-slate-800/40 border border-slate-700/50 rounded-lg p-2.5 flex justify-between items-center transition-all hover:border-violet-500/40">
+                                            <div className="min-w-0 pr-2">
+                                                <h3 className="text-xs font-extrabold text-slate-400 uppercase tracking-wider mb-0.5 truncate">Best ratio</h3>
+                                                <div className="text-[10px] text-slate-500 font-normal uppercase truncate">(prefill : decode)</div>
+                                            </div>
+                                            <h4 className="text-base font-black font-mono text-violet-400 shrink-0">{outcomes.bestConfig.ratio}</h4>
+                                        </div>
+                                        <div className="bg-slate-800/40 border border-slate-700/50 rounded-lg p-2.5 flex justify-between items-center transition-all hover:border-emerald-500/40">
+                                            <div className="min-w-0 pr-2">
+                                                <h3 className="text-xs font-extrabold text-slate-400 uppercase tracking-wider mb-0.5 truncate">Peak throughput</h3>
+                                                <div className="text-[10px] text-slate-500 font-normal uppercase truncate">(total tok/s)</div>
+                                            </div>
+                                            <h4 className="text-base font-black font-mono text-emerald-400 shrink-0">{fmtTok(outcomes.bestTotal.throughput.total)}</h4>
+                                        </div>
+                                        <div className="bg-slate-800/40 border border-slate-700/50 rounded-lg p-2.5 flex justify-between items-center transition-all hover:border-sky-500/40">
+                                            <div className="min-w-0 pr-2">
+                                                <h3 className="text-xs font-extrabold text-slate-400 uppercase tracking-wider mb-0.5 truncate">Best TTFT</h3>
+                                                <div className="text-[10px] text-slate-500 font-normal uppercase truncate">(mean, s)</div>
+                                            </div>
+                                            <h4 className="text-base font-black font-mono text-sky-400 shrink-0">{fmtSec(outcomes.bestMeanTtft.ttft.mean)} s</h4>
+                                        </div>
+                                    </div>
+                                </Panel>
+                            </div>
+                        )}
+
+                        {/* Throughput chart */}
+                        <ChartContainer
+                            title="Throughput vs. P:D ratio"
+                            subtitle="Higher is better. Mean token rate per prefill:decode replica split (tokens/s)."
+                            actions={
+                                <ToggleGroup
+                                    options={[
+                                        { value: 'output', label: 'Output' },
+                                        { value: 'input', label: 'Input' },
+                                        { value: 'total', label: 'Total' },
+                                    ]}
+                                    value={thruMetric}
+                                    onChange={setThruMetric}
+                                />
+                            }
+                        >
+                            <div className="relative w-full h-[300px]">
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <BarChart data={throughputChartData} margin={{ top: 10, right: 20, left: 10, bottom: 10 }} barCategoryGap="25%">
+                                        <CartesianGrid {...gridProps()} vertical={false} />
+                                        <ChartXAxis dataKey="ratio" tickLine={false} interval={0} />
+                                        <ChartYAxis tickLine={false} width={70} />
+                                        <Tooltip
+                                            {...tooltipProps()}
+                                            content={<ThroughputTooltip />}
+                                        />
+                                        <Bar dataKey="value" fill={seriesColor(0)} radius={[6, 6, 0, 0]} maxBarSize={80} isAnimationActive={false} />
+                                    </BarChart>
+                                </ResponsiveContainer>
+                            </div>
+                            <p className="text-[10px] text-slate-500 mt-2">{THROUGHPUT_LABELS[thruMetric]}, by prefill:decode replica ratio (8 replicas total).</p>
+                        </ChartContainer>
+
+                        {/* Latency chart */}
+                        <ChartContainer
+                            title="Latency vs. P:D ratio"
+                            subtitle="Lower is better. TTFT/E2E in seconds; ITL in ms/token. ITL plateaus at prefill-heavy ratios (≥ 5:3) — the decode-saturation ceiling."
+                            actions={
+                                <Button variant="secondary" size="sm" onClick={() => setShowChartFilters(!showChartFilters)}>
+                                    Filters
+                                    {showChartFilters ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
+                                </Button>
+                            }
+                        >
+                            {showChartFilters && (
+                                <div className="flex flex-wrap items-center gap-x-6 gap-y-2 border border-slate-800/60 bg-slate-900/40 rounded-lg px-4 py-2.5 mb-4">
+                                    <div className="flex items-center gap-3">
+                                        <span className="text-[10px] text-slate-400 font-extrabold uppercase tracking-widest shrink-0">Latency:</span>
+                                        <ToggleGroup
+                                            options={[
+                                                { value: 'ttft', label: 'TTFT' },
+                                                { value: 'itl', label: 'ITL' },
+                                                { value: 'e2e', label: 'E2E' },
+                                            ]}
+                                            value={latMetric}
+                                            onChange={setLatMetric}
+                                        />
+                                    </div>
+                                    {latMetric !== 'itl' && (
+                                        <div className="flex items-center gap-2 ml-auto">
+                                            <span className="text-[10px] text-slate-400 font-extrabold uppercase tracking-widest shrink-0">Stats:</span>
+                                            <StatPills
+                                                options={['Mean', 'P90']}
+                                                active={visibleStats}
+                                                onToggle={(p) => setVisibleStats(prev => prev.includes(p) ? prev.filter(x => x !== p) : [...prev, p])}
+                                            />
+                                        </div>
+                                    )}
+                                </div>
+                            )}
+                            <div className="relative w-full h-[300px]">
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <BarChart data={latencyChartData} margin={{ top: 10, right: 20, left: 10, bottom: 10 }} barCategoryGap="25%">
+                                        <CartesianGrid {...gridProps()} vertical={false} />
+                                        <ChartXAxis dataKey="ratio" tickLine={false} interval={0} />
+                                        <ChartYAxis tickLine={false} width={70} unit={latMetric === 'itl' ? ' ms' : ' s'} />
+                                        <Tooltip
+                                            {...tooltipProps()}
+                                            content={<LatencyTooltip />}
+                                        />
+                                        <Bar dataKey="mean" name="Mean" radius={[6, 6, 0, 0]} maxBarSize={50} isAnimationActive={false} hide={!visibleStats.includes('Mean')}>
+                                            {latencyChartData.map((entry, index) => (
+                                                <Cell key={index} fill={entry.fill} fillOpacity={1} />
+                                            ))}
+                                        </Bar>
+                                        <Bar dataKey="p90" name="P90" radius={[6, 6, 0, 0]} maxBarSize={50} isAnimationActive={false} hide={latMetric === 'itl' || !visibleStats.includes('P90')}>
+                                            {latencyChartData.map((entry, index) => (
+                                                <Cell key={index} fill={entry.fill} fillOpacity={0.6} />
+                                            ))}
+                                        </Bar>
+                                    </BarChart>
+                                </ResponsiveContainer>
+                            </div>
+                            <p className="text-[10px] text-slate-500 mt-2">
+                                {LATENCY_LABELS[latMetric]}{latMetric === 'itl' ? ', mean' : ' — Mean (solid), P90 (translucent)'}, by prefill:decode replica ratio (8 replicas total).
+                            </p>
+                        </ChartContainer>
+
+                        {/* Results table */}
+                        {columnBests && (
+                            <ChartContainer
+                                title="Full results — all runs, all reported metrics"
+                                subtitle="TTFT/E2E in seconds; ITL in ms/token; throughput in tokens/s. Best value per column highlighted; lower is better for latency, higher for throughput."
+                            >
+                                <div className="overflow-x-auto">
+                                    <table className="w-full text-left border-collapse text-xs">
+                                        <thead>
+                                            <tr className="bg-slate-950 text-slate-400 font-mono uppercase tracking-wider text-[10px]">
+                                                <th className="p-3">P:D ratio</th>
+                                                <th className="p-3">Prefill</th>
+                                                <th className="p-3">Decode</th>
+                                                <th className="p-3">TTFT mean (s)</th>
+                                                <th className="p-3">TTFT P90 (s)</th>
+                                                <th className="p-3">E2E mean (s)</th>
+                                                <th className="p-3">E2E P90 (s)</th>
+                                                <th className="p-3">ITL mean (ms/tok)</th>
+                                                <th className="p-3">Output tok/s</th>
+                                                <th className="p-3">Input tok/s</th>
+                                                <th className="p-3">Total tok/s</th>
+                                                <th className="p-3">Requests</th>
+                                            </tr>
+                                        </thead>
+                                        <tbody className="divide-y divide-slate-800/60 font-mono">
+                                            {runs.map(r => {
+                                                const isWinner = outcomes && r.ratio === outcomes.bestConfig.ratio;
+                                                return (
+                                                    <tr key={r.ratio} className={cn(isWinner && 'bg-emerald-900/20')}>
+                                                        <td className="p-3 text-white font-sans font-bold">
+                                                            <span className="flex items-center gap-2">
+                                                                {r.ratio}
+                                                                {isWinner && <Badge tone="success" size="xs">Best observed</Badge>}
+                                                            </span>
+                                                        </td>
+                                                        <td className="p-3 text-slate-300">{r.prefill}</td>
+                                                        <td className="p-3 text-slate-300">{r.decode}</td>
+                                                        <td className={cn('p-3', r.ttft.mean === columnBests.ttftMean ? 'text-emerald-300 font-bold' : 'text-slate-300')}>{fmtSec(r.ttft.mean)}</td>
+                                                        <td className={cn('p-3', r.ttft.p90 === columnBests.ttftP90 ? 'text-emerald-300 font-bold' : 'text-slate-300')}>{fmtSec(r.ttft.p90)}</td>
+                                                        <td className={cn('p-3', r.e2e.mean === columnBests.e2eMean ? 'text-emerald-300 font-bold' : 'text-slate-300')}>{fmtSec(r.e2e.mean)}</td>
+                                                        <td className={cn('p-3', r.e2e.p90 === columnBests.e2eP90 ? 'text-emerald-300 font-bold' : 'text-slate-300')}>{fmtSec(r.e2e.p90)}</td>
+                                                        <td className={cn('p-3', r.itl.mean === columnBests.itlMean ? 'text-emerald-300 font-bold' : 'text-slate-300')}>{r.itl.mean.toLocaleString(undefined, { maximumFractionDigits: 1 })}</td>
+                                                        <td className={cn('p-3', r.throughput.output === columnBests.output ? 'text-emerald-300 font-bold' : 'text-slate-300')}>{fmtTok(r.throughput.output)}</td>
+                                                        <td className={cn('p-3', r.throughput.input === columnBests.input ? 'text-emerald-300 font-bold' : 'text-slate-300')}>{fmtTok(r.throughput.input)}</td>
+                                                        <td className={cn('p-3', r.throughput.total === columnBests.total ? 'text-emerald-300 font-bold' : 'text-slate-300')}>{fmtTok(r.throughput.total)}</td>
+                                                        <td className="p-3 text-slate-300">{r.requests.toLocaleString()}</td>
+                                                    </tr>
+                                                );
+                                            })}
+                                        </tbody>
+                                    </table>
+                                </div>
+                            </ChartContainer>
+                        )}
+                    </>
+                )}
+            </main>
+        </div>
+    );
+}

--- a/src/components/PrismHome.jsx
+++ b/src/components/PrismHome.jsx
@@ -2,11 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Activity, Zap, BarChart2, ArrowRight, Server, Cpu, CheckCircle, Shield, TrendingUp, HelpCircle, FileCode, Link, Database, Sliders, Layers, ChevronDown, ChevronUp, Lightbulb, ChevronLeft, ChevronRight } from 'lucide-react';
 import { cn } from '../utils/cn';
 
-const PrismHome = ({ onNavigate }) => {
-    const [currentRoadmapIndex, setCurrentRoadmapIndex] = useState(0);
-    const [isHoveringRoadmap, setIsHoveringRoadmap] = useState(false);
-
-    const roadmapItems = [
+const roadmapItems = [
         {
             title: "Prefix Cache Offloading",
             description: "Tiered KV cache offloading to host CPU memory, expanding accelerator context capacity bounds.",
@@ -15,15 +11,6 @@ const PrismHome = ({ onNavigate }) => {
             bgClass: "bg-emerald-500/10",
             borderClass: "border-emerald-500/20",
             badge: "KV-cache"
-        },
-        {
-            title: "Prefill/Decode Disagg",
-            description: "Separating prefill and decode nodes to eliminate queue interference for multi-tenant pipelines.",
-            icon: Activity,
-            colorClass: "text-purple-400",
-            bgClass: "bg-purple-500/10",
-            borderClass: "border-purple-500/20",
-            badge: "Large models"
         },
         {
             title: "Wide Expert Parallelism",
@@ -43,12 +30,16 @@ const PrismHome = ({ onNavigate }) => {
             borderClass: "border-cyan-500/20",
             badge: "Cost/TCO"
         }
-    ];
+];
+
+const PrismHome = ({ onNavigate }) => {
+    const [currentRoadmapIndex, setCurrentRoadmapIndex] = useState(0);
+    const [isHoveringRoadmap, setIsHoveringRoadmap] = useState(false);
 
     useEffect(() => {
         if (isHoveringRoadmap) return;
         const timer = setInterval(() => {
-            setCurrentRoadmapIndex((prev) => (prev + 1) % 4);
+            setCurrentRoadmapIndex((prev) => (prev + 1) % roadmapItems.length);
         }, 3500);
         return () => clearInterval(timer);
     }, [isHoveringRoadmap]);
@@ -79,7 +70,7 @@ const PrismHome = ({ onNavigate }) => {
                 </header>
 
                 {/* Well-lit paths */}
-                <section className="mb-10 w-full max-w-5xl bg-slate-900/15 border border-slate-900 rounded-2xl relative overflow-hidden backdrop-blur-xl shadow-2xl">
+                <section className="mb-10 w-full max-w-6xl bg-slate-900/15 border border-slate-900 rounded-2xl relative overflow-hidden backdrop-blur-xl shadow-2xl">
                     {/* Grid mesh backdrop decorative lines */}
                     <div className="absolute inset-0 bg-[linear-gradient(to_right,#1e293b_1.5px,transparent_1.5px),linear-gradient(to_bottom,#1e293b_1.5px,transparent_1.5px)] bg-[size:4rem_4rem] [mask-image:radial-gradient(ellipse_60%_50%_at_50%_0%,#000_70%,transparent_100%)] opacity-25 pointer-events-none" />
                     <div className="absolute top-0 right-0 w-80 h-80 bg-blue-500/5 rounded-full blur-3xl pointer-events-none" />
@@ -98,7 +89,7 @@ const PrismHome = ({ onNavigate }) => {
                         {/* Path 1: Intelligent routing */}
                         <div 
                             onClick={() => onNavigate('inference-scheduling')}
-                            className="group relative bg-slate-900/95 backdrop-blur-xl shadow-lg hover:shadow-2xl rounded-xl p-4 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(34,211,238,0.25)] transition-all duration-300 cursor-pointer flex flex-col justify-between border border-slate-800/80 hover:border-cyan-500/50 w-[290px] shrink-0 min-h-[320px] overflow-hidden"
+                            className="group relative bg-slate-900/95 backdrop-blur-xl shadow-lg hover:shadow-2xl rounded-xl p-4 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(34,211,238,0.25)] transition-all duration-300 cursor-pointer flex flex-col justify-between border border-slate-800/80 hover:border-cyan-500/50 w-[246px] shrink-0 min-h-[320px] overflow-hidden"
                         >
                             <div>
                                 <h3 className="text-base font-bold text-slate-200 tracking-wide mb-2 transition-colors group-hover:text-cyan-400">
@@ -143,7 +134,7 @@ const PrismHome = ({ onNavigate }) => {
                         {/* Path 2: Prefix cache offloading */}
                         <div
                             onClick={() => onNavigate('prefix-cache-offloading')}
-                            className="group relative bg-slate-900/95 backdrop-blur-xl shadow-lg hover:shadow-2xl rounded-xl p-4 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(16,185,129,0.25)] transition-all duration-300 cursor-pointer flex flex-col justify-between border border-slate-800/80 hover:border-emerald-500/50 w-[290px] shrink-0 min-h-[320px] overflow-hidden"
+                            className="group relative bg-slate-900/95 backdrop-blur-xl shadow-lg hover:shadow-2xl rounded-xl p-4 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(16,185,129,0.25)] transition-all duration-300 cursor-pointer flex flex-col justify-between border border-slate-800/80 hover:border-emerald-500/50 w-[246px] shrink-0 min-h-[320px] overflow-hidden"
                         >
                             <div>
                                 <h3 className="text-base font-bold text-slate-200 tracking-wide mb-2 transition-colors group-hover:text-emerald-400">
@@ -186,7 +177,7 @@ const PrismHome = ({ onNavigate }) => {
                         {/* Path 3: Agentic serving */}
                         <div 
                             onClick={() => onNavigate('agentic-serving')}
-                            className="group relative bg-slate-900/95 backdrop-blur-xl shadow-lg hover:shadow-2xl rounded-xl p-4 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(168,85,247,0.25)] transition-all duration-300 cursor-pointer flex flex-col justify-between border border-slate-800/80 hover:border-purple-500/50 w-[290px] shrink-0 min-h-[320px] overflow-hidden"
+                            className="group relative bg-slate-900/95 backdrop-blur-xl shadow-lg hover:shadow-2xl rounded-xl p-4 hover:-translate-y-1 hover:shadow-[0_0_30px_rgba(168,85,247,0.25)] transition-all duration-300 cursor-pointer flex flex-col justify-between border border-slate-800/80 hover:border-purple-500/50 w-[246px] shrink-0 min-h-[320px] overflow-hidden"
                         >
                             <div>
                                 <h3 className="text-base font-bold text-slate-200 tracking-wide mb-2 transition-colors group-hover:text-purple-400">
@@ -239,7 +230,7 @@ const PrismHome = ({ onNavigate }) => {
                         <div 
                             onMouseEnter={() => setIsHoveringRoadmap(true)}
                             onMouseLeave={() => setIsHoveringRoadmap(false)}
-                            className="group relative bg-gradient-to-br from-purple-950/20 via-slate-950/80 to-slate-950 backdrop-blur-xl border border-dashed border-purple-900/40 hover:border-purple-500/40 rounded-xl p-4 transition-all duration-300 flex flex-col justify-between w-[290px] shrink-0 min-h-[320px] overflow-hidden hover:shadow-[0_0_20px_rgba(168,85,247,0.15)]"
+                            className="group relative bg-gradient-to-br from-purple-950/20 via-slate-950/80 to-slate-950 backdrop-blur-xl border border-dashed border-purple-900/40 hover:border-purple-500/40 rounded-xl p-4 transition-all duration-300 flex flex-col justify-between w-[246px] shrink-0 min-h-[320px] overflow-hidden hover:shadow-[0_0_20px_rgba(168,85,247,0.15)]"
                         >
                             <div>
                                 <h3 className="text-base font-bold text-slate-300 tracking-wide mb-2 transition-colors group-hover:text-purple-400">
@@ -258,7 +249,7 @@ const PrismHome = ({ onNavigate }) => {
                                     <button 
                                         onClick={(e) => {
                                             e.stopPropagation();
-                                            setCurrentRoadmapIndex((prev) => (prev - 1 + 4) % 4);
+                                            setCurrentRoadmapIndex((prev) => (prev - 1 + roadmapItems.length) % roadmapItems.length);
                                         }}
                                         className="absolute left-1 top-1/2 -translate-y-1/2 p-1.5 rounded-full bg-slate-900 border border-slate-800/60 text-slate-400 hover:text-white hover:bg-slate-800 opacity-0 group-hover/item:opacity-100 transition-opacity z-10 cursor-pointer"
                                     >
@@ -268,7 +259,7 @@ const PrismHome = ({ onNavigate }) => {
                                     <button 
                                         onClick={(e) => {
                                             e.stopPropagation();
-                                            setCurrentRoadmapIndex((prev) => (prev + 1) % 4);
+                                            setCurrentRoadmapIndex((prev) => (prev + 1) % roadmapItems.length);
                                         }}
                                         className="absolute right-1 top-1/2 -translate-y-1/2 p-1.5 rounded-full bg-slate-900 border border-slate-800/60 text-slate-400 hover:text-white hover:bg-slate-800 opacity-0 group-hover/item:opacity-100 transition-opacity z-10 cursor-pointer"
                                     >
@@ -283,7 +274,7 @@ const PrismHome = ({ onNavigate }) => {
                                                 <div className="flex-1 min-w-0 pr-1.5">
                                                     <div className="flex items-center justify-between gap-1">
                                                         <h4 className="text-xs font-bold text-slate-200 truncate">{item.title}</h4>
-                                                        <span className="text-[8px] font-mono text-slate-500 shrink-0">{currentRoadmapIndex + 1}/4</span>
+                                                        <span className="text-[8px] font-mono text-slate-500 shrink-0">{currentRoadmapIndex + 1}/{roadmapItems.length}</span>
                                                     </div>
                                                     <p className="text-[11px] text-slate-400 leading-normal mt-1 line-clamp-3">{item.description}</p>
                                                 </div>

--- a/src/components/ui/FactCell.jsx
+++ b/src/components/ui/FactCell.jsx
@@ -1,0 +1,27 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+// The tiny label + mono value cell used throughout Benchmark scenario cards
+// and hero configuration columns on well-lit path dashboards.
+export function FactCell({ label, value, title, className }) {
+    return (
+        <div className={cn('min-w-0', className)}>
+            <span className="block text-[10px] text-slate-500 font-semibold mb-0.5 truncate">{label}</span>
+            <span className="font-mono font-bold text-white truncate block" title={title}>{value}</span>
+        </div>
+    );
+}

--- a/src/components/ui/Spinner.jsx
+++ b/src/components/ui/Spinner.jsx
@@ -32,12 +32,19 @@ export function Spinner({ size = 'sm', className }) {
     );
 }
 
-// Centered spinner + label for section/page level loading.
-export function LoadingState({ label = 'Loading…', size = 'lg', className }) {
-    return (
+// Centered spinner + label for section/page level loading. fullPage renders
+// the well-lit dark full-viewport shell around it (pre-data dashboard state).
+export function LoadingState({ label = 'Loading…', size = 'lg', fullPage = false, className }) {
+    const body = (
         <div className={cn('flex-1 flex flex-col items-center justify-center gap-4 py-16', className)}>
             <Spinner size={size} />
             {label && <div className="text-sm font-semibold text-theme-muted">{label}</div>}
+        </div>
+    );
+    if (!fullPage) return body;
+    return (
+        <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col justify-center items-center w-full">
+            {body}
         </div>
     );
 }

--- a/src/components/ui/StatPills.jsx
+++ b/src/components/ui/StatPills.jsx
@@ -1,0 +1,40 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import React from 'react';
+import { cn } from '../../utils/cn';
+
+// Multi-select pill group for chart stat/percentile visibility
+// ("Stats: Mean P90", "Percentiles: P50 P90 P99"). Unlike ToggleGroup
+// (single-select), every pill toggles independently. options: string[].
+export function StatPills({ options, active, onToggle, className }) {
+    return (
+        <div className={cn('flex items-center gap-0.5 bg-slate-900/50 border border-slate-700/50 rounded-lg p-0.5 shrink-0', className)}>
+            {options.map((p) => (
+                <button
+                    key={p}
+                    type="button"
+                    aria-pressed={active.includes(p)}
+                    onClick={() => onToggle(p)}
+                    className={cn(
+                        'px-2.5 py-1 text-[10px] font-medium rounded-md transition-all cursor-pointer',
+                        active.includes(p) ? 'bg-indigo-600 text-white shadow' : 'text-slate-400 hover:text-white'
+                    )}
+                >
+                    {p}
+                </button>
+            ))}
+        </div>
+    );
+}

--- a/src/components/ui/charts/ChartTooltip.jsx
+++ b/src/components/ui/charts/ChartTooltip.jsx
@@ -43,11 +43,13 @@ export function ChartTooltip({ title, className, children }) {
     );
 }
 
-export function ChartTooltipRow({ color, label, value, unit = '' }) {
+// `opacity` lets stat rows (Mean/P50/P90/P99) keep the series color at the
+// stat's bar opacity — see the stat-bars rule in skills/style.md.
+export function ChartTooltipRow({ color, opacity = 1, label, value, unit = '' }) {
     return (
         <div className="flex items-center justify-between gap-4 text-[11px]">
             <div className="flex items-center gap-1.5 min-w-0">
-                {color && <span className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: color }} aria-hidden="true" />}
+                {color && <span className="w-3 h-3 rounded-sm shrink-0" style={{ backgroundColor: color, opacity }} aria-hidden="true" />}
                 <span className="text-theme-muted font-medium truncate">{label}</span>
             </div>
             <span className="font-mono font-bold text-theme-text whitespace-nowrap">

--- a/src/components/ui/charts/theme.js
+++ b/src/components/ui/charts/theme.js
@@ -43,3 +43,14 @@ export function getChartTheme() {
 export function gridProps() {
     return { stroke: getChartTheme().grid, strokeDasharray: '3 3' };
 }
+
+// Spread into recharts <Tooltip {...tooltipProps()} content={<... />} />:
+// the standard hover cursor wash, no animation, and a wrapper that beats
+// the chart chrome's stacking context.
+export function tooltipProps() {
+    return {
+        isAnimationActive: false,
+        wrapperStyle: { outline: 'none', zIndex: 100 },
+        cursor: { fill: 'rgba(148, 163, 184, 0.08)' },
+    };
+}

--- a/src/components/ui/index.js
+++ b/src/components/ui/index.js
@@ -26,11 +26,13 @@ export { EmptyState } from './EmptyState';
 export { PageHeader, ShareLinkButton } from './PageHeader';
 export { WellLitHeader } from './WellLitHeader';
 export { ToggleGroup } from './ToggleGroup';
+export { StatPills } from './StatPills';
 export { SectionLabel } from './SectionLabel';
+export { FactCell } from './FactCell';
 
 export { ChartContainer } from './charts/ChartContainer';
 export { ChartTooltip, ChartTooltipRow } from './charts/ChartTooltip';
 export { ChartLegend } from './charts/ChartLegend';
 export { ChartXAxis, ChartYAxis } from './charts/Axis';
 export { CHART_SERIES, seriesColor, CHART_STATUS } from './charts/palette';
-export { getChartTheme, gridProps } from './charts/theme';
+export { getChartTheme, gridProps, tooltipProps } from './charts/theme';


### PR DESCRIPTION
First production run of the dashboard pipeline documented in `specs/main/dashboard-pipeline.md` — this PR is the **Gate B** review. Gate A (design spec) was approved by @jjk-g and is recorded in `specs/changes/pd-disaggregation-dashboard/proposal.md`.

## What this adds

The **Prefill/Decode Disaggregation** well-lit path dashboard, built from six published benchmark runs (llm-d-benchmark v0.2.1) sweeping the prefill:decode replica ratio (2:6 → 7:1) at a fixed 8 replicas — Qwen3-Coder-480B-FP8 on TPU v7x, agentic multi-turn workload. Headline: decode-heavy wins 5 of 6 tracked metrics (P90 TTFT is the lone exception), with a 7.0× total-throughput spread across the sweep.

- **Data**: `GET /api/pd-disaggregation/data` reads live from `gs://llm-d-benchmarks/pd-disaggregation/` (same server-side GCS pattern as `/api/prefix-cache/data`; the latest `reports-<timestamp>` dir per ratio supersedes older uploads; replica counts parsed from report content, not paths).
- **Dashboard** (`PdDisaggregationDashboard.jsx`): full well-lit anatomy per `skills/style.md` — `WellLitHeader`, canonical page shell, hero with an interactive **Selectable ratios** column that filters the charts, scenario/outcomes row (8/4), throughput chart (`Output|Input|Total`), latency chart with **Mean/P90 opacity-encoded stat bars** and pill toggles, and the full results table with per-column winners.
- **Registration**: view registered in `App.jsx`. The nav item and PrismHome card are intentionally **not** enabled in this PR (deep-link only via `?view=pd-disaggregation`) pending launch timing; the home rail was also tightened (`246px` cards, `max-w-6xl` rail).

## Library and contract additions (CODEOWNERS will request @seanhorgan/@Raji14)

Per the extract-on-second-use rule, patterns this work hit for the 2nd+ time graduated into `src/components/ui/`: `StatPills` (stat/percentile multi-toggles — previously copy-pasted in 6 files), `FactCell` (scenario label+value cells — ~37 instances across 4 dashboards), `tooltipProps()` (recharts tooltip plumbing, kills inline rgba cursors), `ChartTooltipRow opacity`, and `LoadingState fullPage`. Existing dashboards migrate opportunistically.

`skills/style.md` gains the rules this dashboard exercised: opacity-encoded stat bars (P50/Mean=1, P90=0.6, P99=0.35), hidden stat controls for single-stat metrics, bar-mark conventions, the scenario/outcomes row spans (6/3/3 with an Action card, 8/4 without), interactive hero "Selectable" columns, and the home-rail card sizing.

## Relationship to the new PD spec (`022d213`)

This dashboard is the first concrete slice of the rewritten `specs/changes/disagg-benchmarks-proposal.md` — the Benchmark Analysis pillar for a fixed-fleet ratio sweep. The guided suitability path, Pareto-frontier visualization, and parallelism recommendations remain future work (this sweep has no Pareto frontier to show: 2:6 dominates, which the copy states honestly as "best observed", with decode-heavier splits flagged as untested roadmap).

## Verification

- Lint: zero new errors on all touched files (repo baseline unchanged); `vite build` green.
- Style ratchet clean (the dotted-grid `#334155` named exemption is the only hex hit).
- Endpoint verified returning all six runs from GCS via ADC locally, and via the runtime service account on a Cloud Run deployment.
- Data published at `gs://llm-d-benchmarks/pd-disaggregation/` mirrors the existing bucket layout; reports carry no internal links.
