### PR TITLE
chore: replace huaxig with diamondburned in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,10 +2,10 @@
 
 reviewers:
   - seanhorgan
-  - huaxig
+  - diamondburned
   - jjk-g
 
 approvers:
   - seanhorgan
-  - huaxig
+  - diamondburned
   - jjk-g


### PR DESCRIPTION
Updates the OWNERS file: replaces `huaxig` with `diamondburned` as reviewer and approver, reflecting current active maintainership (diamondburned authored and maintains the Results Store and recent Prism work).