### PR TITLE
fix GITHUB_ prefix in secret names for Results Store

### DIFF
--- a/.github/workflows/deploy-cloud-run.yaml
+++ b/.github/workflows/deploy-cloud-run.yaml
@@ -34,8 +34,8 @@ jobs:
           ./deploy.sh --config deploy/prod.env
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
-          GITHUB_CLIENT_ID: ${{ secrets.GITHUB_CLIENT_ID }}
-          GITHUB_CLIENT_SECRET: ${{ secrets.GITHUB_CLIENT_SECRET }}
+          GITHUB_CLIENT_ID: ${{ secrets.PRISM_GITHUB_CLIENT_ID }}
+          GITHUB_CLIENT_SECRET: ${{ secrets.PRISM_GITHUB_CLIENT_SECRET }}
 
       - name: Verify deployment
         run: |


### PR DESCRIPTION
Rename the GitHub OAuth client secret names to:

- `PRISM_GITHUB_CLIENT_ID`
- `PRISM_GITHUB_CLIENT_SECRET`

See: https://github.com/github/docs/issues/34107
