### PR TITLE
support 0.2.x version strings in benchmark report v0.2 parser

### DIFF
--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -232,7 +232,8 @@ export function parseReportV02(yamlText, filename) {
     if (!parseResult.success) return null;
 
     const doc = parseResult.data;
-    if (doc.version !== '0.2') return null;
+    const ver = String(doc.version || '').trim();
+    if (ver !== '0.2' && !ver.startsWith('0.2.') && ver !== 'v0.2' && !ver.startsWith('v0.2.')) return null;
 
     // --- Scenario ---
     const stack = doc.scenario?.stack || [];

--- a/src/utils/benchmarkValidator.js
+++ b/src/utils/benchmarkValidator.js
@@ -20,7 +20,8 @@ export function validateFormat(fileContent, filename) {
         return { format: false, error: "Empty document" };
     }
 
-    if (parsedDoc.version === "0.2" || parsedDoc.schema === "v0.2" || (parsedDoc.run && parsedDoc.scenario && (parsedDoc.metrics || parsedDoc.results))) {
+    const ver = String(parsedDoc.version || '').trim();
+    if (ver === "0.2" || ver.startsWith("0.2.") || ver === "v0.2" || ver.startsWith("v0.2.") || parsedDoc.schema === "v0.2" || (parsedDoc.run && parsedDoc.scenario && (parsedDoc.metrics || parsedDoc.results))) {
         return { format: "brv02", parsedData: parsedDoc };
     }
 


### PR DESCRIPTION
Reports emitted by newer uBench benchmark runs specify patch versions such as "0.2.1". Previously, the parser strictly required exact equality with "0.2", causing parseReportV02 to fail.

Allow version strings matching 0.2._ and v0.2._ so these runs are parsed correctly.
