### PR TITLE
Support loading benchmark reports from a local/PVC directory

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -27,6 +27,11 @@ import { storage } from './results/gcs.ts';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+// Local benchmark reports dir (e.g. a mounted PVC). Falls back to the dev path.
+const LOCAL_DIR = path.resolve(
+    process.env.PRISM_LOCAL_DIR || path.join(__dirname, '../private/benchmarks')
+);
+
 const app = express();
 const port = process.env.PORT || 3000;
 
@@ -65,7 +70,8 @@ app.get('/api/config', (req, res) => {
         hostProject: process.env.GOOGLE_CLOUD_PROJECT || null,
         siteName: process.env.SITE_NAME || null,
         gaTrackingId: process.env.GA_TRACKING_ID || null,
-        contactUrl: process.env.CONTACT_US_URL || null
+        contactUrl: process.env.CONTACT_US_URL || null,
+        localDir: !!process.env.PRISM_LOCAL_DIR
     });
 });
 
@@ -159,7 +165,7 @@ app.all('/api/giq/*', async (req, res) => {
 // --- API: Local Benchmarks (Dev Mode) ---
 app.get('/api/local/list', async (req, res) => {
     const fs = await import('fs');
-    const dir = path.join(__dirname, '../private/benchmarks');
+    const dir = LOCAL_DIR;
     if (!fs.existsSync(dir)) {
         return res.json({ items: [] });
     }
@@ -191,10 +197,11 @@ app.get('/api/local/file/*', async (req, res) => {
     const fs = await import('fs');
     const relPath = req.params[0];
 
-    const baseDir = path.resolve(__dirname, '../private/benchmarks');
+    const baseDir = LOCAL_DIR;
     const filepath = path.resolve(baseDir, relPath);
 
-    if (!filepath.startsWith(baseDir)) {
+    const rel = path.relative(baseDir, filepath);
+    if (rel.startsWith('..') || path.isAbsolute(rel)) {
         return res.status(403).send('Forbidden');
     }
 
@@ -509,7 +516,7 @@ app.post('/api/local/submit', async (req, res) => {
         return res.status(400).json({ error: 'Missing runId' });
     }
     
-    const baseDir = path.resolve(__dirname, '../private/benchmarks');
+    const baseDir = LOCAL_DIR;
     const runDir = path.join(baseDir, payload.runId);
     
     try {

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -18,6 +18,7 @@ import { QualityParser } from '../utils/qualityParser';
 import { normalizeHardware, normalizeModelName } from '../utils/dataParser';
 import { parseJsonEntry, parseLogFile, parseLpgManifest, parseLpgConfig } from '../utils/dataParser';
 import { parseReportV02, groupStagesIntoRuns, stageToEntry } from '../utils/benchmarkReportV02Parser';
+import { scanLocalBenchmarks } from '../utils/gcsScanner';
 import { useGCS } from './useGCS';
 import { useGIQ } from './useGIQ';
 import { useLLMD } from './useLLMD';
@@ -1335,6 +1336,19 @@ export const useDashboardData = (initialState, dashboardState) => {
             } catch (e) {
                 console.error("Failed to load local data", e);
                 failedSources.push(`Sample Data (${e.message})`);
+            }
+
+            // 1b. Fetch local/PVC benchmark reports (no-op unless PRISM_LOCAL_DIR is set)
+            try {
+                const localBench = await scanLocalBenchmarks();
+                if (localBench.length > 0) {
+                    const sourceKey = 'local:benchmarks';
+                    allData = [...allData, ...localBench.map(e => ({ ...e, source: sourceKey }))];
+                    setAvailableSources(prev => new Set([...prev, sourceKey]));
+                    setSelectedSources(prev => new Set([...prev, sourceKey]));
+                }
+            } catch (e) {
+                console.warn("Failed to load local/PVC benchmarks", e);
             }
 
             // 1c. Fetch Archived Drive Data

--- a/src/utils/gcsScanner.js
+++ b/src/utils/gcsScanner.js
@@ -1,5 +1,6 @@
 import yaml from 'js-yaml';
 import { v4 as uuidv4 } from 'uuid';
+import { parseReportV02, stageToEntry } from './benchmarkReportV02Parser';
 
 const generateUUID = () => {
     return uuidv4();
@@ -297,6 +298,46 @@ export const parseInferenceSchedulingReport = (content, filePath) => {
     } catch (e) {
         console.warn(`YAML Parsing failed for ${filePath}:`, e);
         return null;
+    }
+};
+
+/**
+ * Scans a local directory (served by /api/local/*) for v0.2 benchmark
+ * reports and normalizes them through the shared brv02 pipeline.
+ */
+export const scanLocalBenchmarks = async () => {
+    try {
+        const response = await fetch('/api/local/list');
+        if (!response.ok) {
+            throw new Error(`Failed to list local benchmarks: ${response.status}`);
+        }
+
+        const data = await response.json();
+        if (!data.items) return [];
+
+        const entries = [];
+
+        await Promise.all(data.items.map(async (item) => {
+            if (!item.name.endsWith('.yaml')) return;
+            if (!item.name.includes('benchmark_report_v0.2')) return;
+
+            try {
+                const fileRes = await fetch(item.mediaLink);
+                if (!fileRes.ok) return;
+
+                const content = await fileRes.text();
+                const stage = parseReportV02(content, item.name);
+                if (stage) entries.push(stageToEntry(stage));
+            } catch (e) {
+                console.warn(`Failed to parse local report ${item.name}:`, e);
+            }
+        }));
+
+        return entries;
+
+    } catch (e) {
+        console.error('Local benchmarks scan error:', e);
+        return [];
     }
 };
 


### PR DESCRIPTION
## Summary

Adds support for loading v0.2 benchmark reports from a local directory (e.g. a mounted PVC in-cluster), gated behind the `PRISM_LOCAL_DIR` env var.

- **`server/server.js`** — Hoist the local benchmarks dir into a `LOCAL_DIR` constant driven by `PRISM_LOCAL_DIR` (falling back to the dev path), reuse it across the `/api/local/*` routes, and expose a `localDir` boolean in `/api/config`.
- **`src/utils/gcsScanner.js`** — New `scanLocalBenchmarks()` that lists `/api/local/list`, filters to `benchmark_report_v0.2` `.yaml` files, and normalizes them through the shared brv02 pipeline.
- **`src/hooks/useDashboardData.jsx`** — Append local benchmarks as a `local:benchmarks` source during `loadAllData`. No-op unless `PRISM_LOCAL_DIR` is set.

## Security

Hardens the `/api/local/file/*` traversal check to use `path.relative` instead of `startsWith`, which could false-match a sibling directory (e.g. `benchmarks-evil` alongside `benchmarks`).

cc @mengmeiye

🤖 Generated with [Claude Code](https://claude.com/claude-code)