### PR TITLE
Fix Results Store upload payload validation and chart rendering toggles

### DIFF
--- a/server/results/api.ts
+++ b/server/results/api.ts
@@ -77,19 +77,19 @@ export const PrismResultPayloadSchema = z.object({
     /** Selected "Well-Lit Path" optimization and deployment classification. Example: "optimized-baseline" */
     well_lit_path: z.string().nullable().optional(),
     /** Name of the primary backend inference execution engine. Example: "vllm" | "tgi" | "sglang" */
-    inference_tool: z.string().optional(),
+    inference_tool: z.string().nullable().optional(),
     /** Software version of the main inference execution tool. Example: "v0.4.2" */
-    inference_tool_version: z.string().optional(),
+    inference_tool_version: z.string().nullable().optional(),
     /** Flat key-value record mapping secondary software dependencies/tools to their versions. Example: { "guidellm": "v0.1.0" } */
-    other_tools: z.record(z.string(), z.string()).optional(),
+    other_tools: z.record(z.string(), z.string()).nullable().optional(),
     /** Flat key-value record mapping deployment configuration manifest files to their hosted URLs. Example: { "vllm_service": "https://github.com/.../vllm.yaml" } */
-    manifests: z.record(z.string(), z.string()).optional(),
+    manifests: z.record(z.string(), z.string()).nullable().optional(),
     /** Flat key-value record mapping verification run logs/evidence to their storage bucket URLs. Example: { "run_log": "gs://llm-d-benchmarks/regressions/gemma2_9b/run.log" } */
-    evidence: z.record(z.string(), z.string()).optional(),
+    evidence: z.record(z.string(), z.string()).nullable().optional(),
     /** Raw parsed YAML content dictionary harvested from run_metadata.yaml if found. */
-    run_metadata: z.record(z.string(), z.unknown()).optional(),
+    run_metadata: z.record(z.string(), z.unknown()).nullable().optional(),
     /** User custom JSON metadata dictionary editable dynamically within the dashboard inline editor. */
-    metadata: z.record(z.string(), z.unknown()).optional(),
+    metadata: z.record(z.string(), z.unknown()).nullable().optional(),
     /** Feedback reason for rejection or change requests, if any. */
     feedback: z.string().nullable().optional(),
     /** Optional review metadata including reviewer and review status change history. */

--- a/server/results/gcs.ts
+++ b/server/results/gcs.ts
@@ -295,3 +295,20 @@ export async function writeResult(
         throw new Error(`GCS upload failed: ${message}`);
     }
 }
+
+/**
+ * Deletes a benchmark result bundle from Google Cloud Storage by its runId.
+ */
+export async function deleteResult(runId: string): Promise<void> {
+    const bucketName = getPrismResultsBucket();
+    const objectName = `prism-results-store/${runId}.v1.json`;
+    const file = storage.bucket(bucketName).file(objectName);
+    try {
+        await file.delete();
+    } catch (e: unknown) {
+        if (e && typeof e === 'object' && 'code' in e && (e as { code?: number }).code === 404) return;
+        const message = e instanceof Error ? e.message : String(e);
+        throw new Error(`Failed to delete result from GCS: ${message}`);
+    }
+}
+

--- a/server/results/processing.ts
+++ b/server/results/processing.ts
@@ -12,13 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { readResultPayload, writeResult } from './gcs.ts';
+import { readResultPayload, writeResult, deleteResult } from './gcs.ts';
 import { validatePrismUploadStructure } from '../../src/utils/benchmarkValidator.js';
 import { PrismSubmissionState } from './api.ts';
 
 export interface ProcessSubmissionResult {
     success: boolean;
-    state: PrismSubmissionState;
+    state?: PrismSubmissionState;
     errors: string[];
     warnings: string[];
 }
@@ -26,8 +26,9 @@ export interface ProcessSubmissionResult {
 /**
  * Validates and processes a benchmark submission by its runId.
  * Decoupled so it can run synchronously inside the API server, or inside a background worker.
- * Reads the raw staged result payload, performs consistency and metric validation,
- * and updates the submission state in Google Cloud Storage.
+ * Reads the raw staged result payload and performs consistency and metric validation.
+ * If validation fails, the item is dropped completely (deleted from GCS storage).
+ * If validation passes, the item is promoted to `submitted_pending_review`.
  */
 export async function processSubmission(runId: string): Promise<ProcessSubmissionResult> {
     const payload = await readResultPayload(runId);
@@ -38,25 +39,25 @@ export async function processSubmission(runId: string): Promise<ProcessSubmissio
     // Perform validation checks
     const validation = validatePrismUploadStructure(payload, { isUpload: true });
 
-    const newState: PrismSubmissionState = validation.isValid
-        ? 'submitted_pending_review'
-        : 'rejected';
-
-    // If validation fails, store validation errors in the payload's metadata for audit
+    // If validation fails, drop the submission completely from GCS storage
     if (!validation.isValid) {
-        payload.metadata = {
-            ...(payload.metadata || {}),
-            validation_errors: validation.errors
+        await deleteResult(runId);
+        return {
+            success: false,
+            errors: validation.errors || [],
+            warnings: validation.warnings || []
         };
     }
+
+    const newState: PrismSubmissionState = 'submitted_pending_review';
 
     // Write back the processed result with updated GCS custom metadata context state
     await writeResult(runId, payload, newState, username);
 
     return {
-        success: validation.isValid,
+        success: true,
         state: newState,
-        errors: validation.errors || [],
+        errors: [],
         warnings: validation.warnings || []
     };
 }

--- a/server/results/routes/review.ts
+++ b/server/results/routes/review.ts
@@ -140,9 +140,8 @@ export async function reviewResultsHandler(
             const processingResult = await processSubmission(runId);
             if (!processingResult.success) {
                 return res.status(400).json({
-                    error: 'Validation failed during resubmission.',
-                    details: processingResult.errors,
-                    state: processingResult.state
+                    error: 'Validation failed during resubmission. Submission dropped.',
+                    details: processingResult.errors
                 });
             }
             return res.json({

--- a/server/results/routes/submit.ts
+++ b/server/results/routes/submit.ts
@@ -95,10 +95,9 @@ export async function submitResultsHandler(
 
         if (!processingResult.success) {
             return res.status(400).json({
-                error: 'Validation failed during processing.',
+                error: 'Validation failed during processing. Upload dropped.',
                 details: processingResult.errors,
-                warnings: processingResult.warnings,
-                state: processingResult.state
+                warnings: processingResult.warnings
             });
         }
 

--- a/specs/changes/chart-cap-scaling-spec.md
+++ b/specs/changes/chart-cap-scaling-spec.md
@@ -1,0 +1,89 @@
+# Spec: Explicit Auto Mode & Scaled Cap Controls for Prism Charts
+
+- **Status**: Implemented
+- **Author**: diamondburned@google.com, Jetski
+- **Date**: July 24, 2026
+
+## 1. Executive Summary & Rationale
+
+This document outlines the architectural decisions, scaling behavior, and performance optimizations for the "CAP" slider and X-axis domain controls across Prism's Results Store and Well-Lit Path dashboards.
+
+Previously, adjusting the CAP slider filtered out data points exceeding the cap value. However, because charts were configured with dynamic auto-scaling domains (`domain=['auto', 'auto']` or `getAxisConfig`), the X-axis bounds automatically shrank to fit the remaining datapoints rather than remaining locked at the slider's specified numerical cap. Additionally, switching between different X/Y axis metrics (e.g., TPOT vs. TTFT) retained stale numerical cap values, cutting off valid data points in the new metric scale.
+
+### 1.1 Core UX & Engineering Challenges
+
+- **Auto-Scaling Domain Conflicts**: Setting a cap filtered data points above the cap, but Recharts auto-scaled the axis down to the maximum remaining datapoint. If a user set a cap of 400 ms and the highest remaining datapoint was 320 ms, the axis right edge jumped down to 320 ms instead of staying pinned at 400 ms.
+- **Cross-Metric Scale Mismatches**: Retaining a manual cap value across different metrics (e.g., 50 ms for TPOT) caused 100% of data points to be hidden when switching to higher-scale metrics like TTFT (which may span up to 5,000 ms).
+- **Synchronous Rendering Stutter**: Dragging the Cap range input fired synchronous React state updates on every `mousemove` event (60–120 times/sec), triggering unmemoized array filtering and full component tree re-renders across data tables and scatter charts.
+
+---
+
+## 2. Technical Architecture & Design Decisions
+
+### 2.1 Explicit Auto Mode vs. Locked Manual Cap
+
+Prism introduces an explicit **Auto** mode state alongside the numerical Cap slider control across all chart toolbars ([ThroughputCostChart.jsx](src/components/Dashboard/ThroughputCostChart.jsx), [AgenticWorkloadsDashboard.jsx](src/components/AgenticWorkloadsDashboard.jsx), and [IntelligentRoutingChart.jsx](src/components/IntelligentRoutingChart.jsx)):
+
+1.  **Auto Mode (Default)**:
+    - Active on initial page load or when clicking the "Auto" toggle button (`xAxisMax === Infinity` / `zoomXMax === null`).
+    - The X-axis domain automatically scales to fit active benchmark dataset bounds using clean tick distributions (`getAxisConfig`).
+    - Range slider and text inputs display an "Auto" placeholder and dimmed UI styling.
+2.  **Locked Manual Cap Mode**:
+    - Engaged when unchecking "Auto", dragging the range slider, or entering a custom number.
+    - Pins the upper boundary of the X-axis domain strictly to `[minX, customCap]` with `allowDataOverflow` enabled.
+    - Data points above `customCap` are hidden or visually clipped, but the right boundary of the X-axis stays pinned at `customCap` without shrinking under the user's feet.
+
+### 2.2 120% Maximum Bound Padding
+
+To prevent data points on the far right edge of a dataset from clipping against the container boundary, upper axis calculations (`dataMax`) incorporate a 20% right margin (`Math.ceil(rawDataMax * 1.2)`):
+
+- **Data Max Calculation**: `const dataMax = Math.ceil(rawDataMax * 1.2);`
+- Provides comfortable visual padding when viewing scatter plots and Pareto frontiers.
+
+### 2.3 Automatic Cap Reset on Metric View Switch
+
+When a user switches the active X-axis or Y-axis metric (e.g., switching from TPOT to TTFT or NTPOT), `xAxisMax` / `zoomXMax` automatically resets to Auto mode (`Infinity` / `null`). This prevents stale numerical caps from masking data in the new unit scale.
+
+---
+
+## 3. Performance Optimizations & 60 FPS Responsiveness
+
+To eliminate Main Thread layout thrashing during mouse drag operations on the Cap range input:
+
+1.  **React 19 `useDeferredValue` Integration**:
+    - Wrap the cap filter state in `React.useDeferredValue(xAxisMax)` / `React.useDeferredValue(zoomXMax)` in [Dashboard.jsx](src/components/Dashboard.jsx), [AgenticWorkloadsDashboard.jsx](src/components/AgenticWorkloadsDashboard.jsx), and [IntelligentRoutingChart.jsx](src/components/IntelligentRoutingChart.jsx).
+    - Slider knob movement and text input updates remain responsive at 60 FPS while heavy SVG chart re-renders and table filtering are scheduled as non-blocking background transitions.
+2.  **Memoized Filter Pipelines**:
+    - In [Dashboard.jsx](src/components/Dashboard.jsx), `filteredData` is wrapped in `useMemo` to prevent array re-allocation on unrelated renders.
+    - In [ThroughputCostChart.jsx](src/components/Dashboard/ThroughputCostChart.jsx), `visibleDataPoints`, `uniqueBenchmarks`, `baselineSeries`, `paretoData`, and axis domain calculations are wrapped in `useMemo`.
+
+---
+
+## 4. Trade-offs: Pros vs. Cons
+
+### 4.1 Pros
+
+- **Predictable Boundary Controls**: Lock-in manual caps allow users to compare datasets side-by-side or against fixed latency SLO boundaries.
+- **Zero-Stutter Dragging**: `useDeferredValue` and `useMemo` eliminate frame drops during range slider interaction.
+- **Safe Metric Transitions**: Automatic cap resetting prevents empty graphs when switching axis dimensions.
+
+### 4.2 Cons
+
+- **State Complexity**: Manually managed `useDeferredValue` and Auto state flags require careful sync when building shareable URLs (`useDashboardState.js`).
+
+---
+
+## 5. Relevant Git Commit History
+
+The following commits introduced the automated chart axis scaling, scaling synchronization, and layout fixes:
+
+- **`1597944`** — *Fix agentic serving guide chart axes and labels (#106)* (Author: Sean Horgan)  
+  Introduced `getAxisConfig` in [utils.js](src/components/ui/charts/utils.js) and replaced hardcoded axis domain arrays with dynamic `chartAxesConfig` auto-scaling domain calculations.
+- **`25e9a5e`** — *fix: synchronize agentic chart scaling controls (#75) (#101)* (Author: diamondburned)  
+  Synchronized `zoomXMax` and `effectiveXMax` scaling bounds across agentic workload chart lines.
+- **`6d3db5b`** — *fix: scale comparison drawer chart axes to selected benchmarks only* (Author: Sean Horgan)  
+  Scoped drawer dataset filtering (`drawerFilteredData`) to align comparison chart axis scaling with active benchmark selections.
+- **`70462ad`** — *Match popup charts to the same format as guide charts; remove incorrect data normalization in popup charts.* (Author: Sean Horgan)  
+  Standardized popup chart formatting and removed legacy normalization routines overriding axis bounds.
+- **`0e6e73a`** — *Refactor Inference Scheduling charts to new scatter layout* (Author: Sean Horgan)  
+  Refactored scheduling chart layout to scatter plot formats using dynamic dataset bounds.

--- a/specs/main/results-api/README.md
+++ b/specs/main/results-api/README.md
@@ -170,8 +170,9 @@ environment:
       benchmark results have been included in said well-lit path’s results.
     - Implies additional visibility from just sea of benchmarks.
 - **`rejected`** (Rejected):
-    - Failed any of the above checks (or include reason otherwise).
-    - Deleted off cloud.
+    - Explicitly rejected by an administrator during human review (`submitted_pending_review` -> `rejected`), with optional rejection reason attached.
+    - Deleted off cloud when purged by admin.
+    - **Note:** Automated validation failures on upload do NOT transition items to `rejected`. Instead, invalid uploads are completely dropped/deleted from cloud storage, returning an HTTP 400 validation error to the submitter without populating the rejected queue.
 
 ### 6.2 State Transitions
 
@@ -180,7 +181,7 @@ stateDiagram-v2
     [*] --> staged : Local Upload
     staged --> submitted_pending_processing : Submit (Requires GitHub Auth)
     submitted_pending_processing --> submitted_pending_review : Auto-Validation Pass
-    submitted_pending_processing --> rejected : Auto-Validation Fail
+    submitted_pending_processing --> [*] : Auto-Validation Fail (Dropped)
     submitted_pending_review --> public : Admin Approved
     submitted_pending_review --> rejected : Admin Rejected
     public --> promoted : Selected for Well-Lit Path
@@ -202,8 +203,9 @@ early beta:
    synchronously inside the request lifecycle immediately after the raw upload
    is staged in GCS.
 2. **Immediate Promotion**: If validation passes, the run is directly promoted
-   to `submitted_pending_review` (and if it fails, it is marked as `rejected`).
-   The client receives the final status response immediately.
+   to `submitted_pending_review`. If validation fails, the item is completely
+   dropped/deleted from cloud storage and an HTTP 400 error is returned to
+   the client. The `rejected` queue is reserved exclusively for manual admin rejections.
 3. **Future Decoupling**: The processing wrapper is fully decoupled. In the
    future, the synchronous invocation can be removed in favor of an asynchronous
    background worker (e.g., GCS Object Eventarc trigger or Pub/Sub pull worker

--- a/specs/main/results-api/frontend.md
+++ b/specs/main/results-api/frontend.md
@@ -68,7 +68,7 @@ pipeline status:
   Accelerator Count) to apply seamlessly. KPI cards at the top of the Results
   Store page allow users to quickly filter the table by submission state
   (`Staged`, `Under Review` / `Processing`, `In Review`, `Approved` / `Public`,
-  `Action Required` / `Rejected`).
+  `Action Required` / `Rejected`). The `Rejected` state is reserved for runs explicitly rejected by administrators during review; uploads failing automated validation are dropped directly without populating the rejected queue.
 
 ---
 

--- a/specs/main/results-api/routes.md
+++ b/specs/main/results-api/routes.md
@@ -108,6 +108,7 @@ Submits a benchmark result bundle to the active results store.
   and nested entry `run_id`s) are regenerated on the server to prevent ID
   collisions. The metadata is also enriched with the author's username and
   submission timestamp.
+- **Validation Failures:** If automated validation fails during processing, the endpoint returns `400 Bad Request` with error details and warnings. The submission is dropped completely and is NOT placed in the `rejected` queue or saved in cloud storage.
 - **Response (201 Created):**
     ```json
     {
@@ -156,7 +157,7 @@ pending benchmark result submission.
     - **Contributor (Owner):** Can only transition state to
       `submitted_pending_processing` or `submitted_pending_review` to promote or
       resubmit their own benchmark. Any attempt to set state to `public` or
-      `rejected` returns `403 Forbidden`.
+      `rejected` returns `403 Forbidden`. Rejections are reserved exclusively for administrators.
     - **Other users:** `403 Forbidden`.
 
 ---

--- a/src/components/AgenticWorkloadsDashboard.jsx
+++ b/src/components/AgenticWorkloadsDashboard.jsx
@@ -287,7 +287,8 @@ export default function AgenticWorkloadsDashboard({ onNavigateBack, onNavigate, 
 
     const chartDataMax = useMemo(() => {
         const values = buildChartLines.flatMap(line => line.data.map(point => point.x));
-        return values.length ? Math.max(...values) : 100;
+        const rawMax = values.length ? Math.max(...values) : 100;
+        return Math.ceil(rawMax * 1.2);
     }, [buildChartLines]);
 
     const chartDataMin = useMemo(() => {
@@ -298,9 +299,10 @@ export default function AgenticWorkloadsDashboard({ onNavigateBack, onNavigate, 
     }, [buildChartLines]);
 
     const capStep = Math.max(1, Math.ceil(chartDataMax / 1000));
-    const effectiveXMax = zoomXMax === null
+    const deferredZoomXMax = React.useDeferredValue(zoomXMax);
+    const effectiveXMax = deferredZoomXMax === null
         ? chartDataMax
-        : Math.max(chartDataMin, Math.min(zoomXMax, chartDataMax));
+        : Math.max(chartDataMin, Math.min(deferredZoomXMax, chartDataMax));
 
     const visibleChartLines = useMemo(() => buildChartLines.map(line => ({
         ...line,
@@ -470,7 +472,10 @@ export default function AgenticWorkloadsDashboard({ onNavigateBack, onNavigate, 
                                 size="xs"
                                 options={[['output', 'Output'], ['input', 'Input'], ['total', 'Total'], ['qps', 'QPS']].map(([value, label]) => ({ value, label }))}
                                 value={zoomYAxis}
-                                onChange={setZoomYAxis}
+                                onChange={(value) => {
+                                    setZoomYAxis(value);
+                                    setZoomXMax(null);
+                                }}
                             />
                         </div>
                     </div>
@@ -491,8 +496,20 @@ export default function AgenticWorkloadsDashboard({ onNavigateBack, onNavigate, 
 
                             <div className="flex items-center gap-2 bg-slate-900/50 border border-slate-700/50 px-3 py-1 rounded-lg">
                                 <span className="text-[10px] text-slate-400 font-extrabold uppercase tracking-widest">Cap:</span>
-                                <input type="range" min={chartDataMin} max={chartDataMax} step={capStep} value={effectiveXMax} onChange={(e) => setZoomXMax(Number(e.target.value))} className="w-28 h-1 bg-slate-700 rounded-lg appearance-none cursor-pointer accent-cyan-400" />
-                                <input type="number" min={chartDataMin} max={chartDataMax} value={effectiveXMax} onChange={(e) => setZoomXMax(e.target.value === '' ? null : Math.max(chartDataMin, Number(e.target.value)))} className="w-16 bg-transparent text-[10px] text-slate-200 focus:outline-none focus:ring-1 focus:ring-cyan-500/50 rounded px-1 text-right font-mono font-bold transition-all" />
+                                <button 
+                                    type="button"
+                                    onClick={() => setZoomXMax(zoomXMax === null ? Math.round(chartDataMax * 0.8) : null)}
+                                    className={cn(
+                                        'px-2 py-0.5 text-[9.5px] font-extrabold uppercase tracking-wider rounded transition-all cursor-pointer',
+                                        zoomXMax === null 
+                                            ? 'bg-cyan-600 text-white shadow' 
+                                            : 'bg-slate-800 text-slate-400 hover:text-white'
+                                    )}
+                                >
+                                    Auto
+                                </button>
+                                <input type="range" min={chartDataMin} max={chartDataMax} step={capStep} value={effectiveXMax} onChange={(e) => setZoomXMax(Number(e.target.value))} className={cn("w-28 h-1 rounded-lg appearance-none cursor-pointer accent-cyan-400", zoomXMax === null ? "bg-slate-800/40 opacity-40" : "bg-slate-700")} />
+                                <input type="number" min={chartDataMin} max={chartDataMax} value={zoomXMax === null ? '' : effectiveXMax} placeholder={zoomXMax === null ? 'Auto' : effectiveXMax.toString()} onChange={(e) => setZoomXMax(e.target.value === '' ? null : Math.max(chartDataMin, Number(e.target.value)))} className={cn("w-16 bg-transparent text-[10px] focus:outline-none focus:ring-1 focus:ring-cyan-500/50 rounded px-1 text-right font-mono font-bold transition-all", zoomXMax === null ? "text-slate-500" : "text-slate-200")} />
                                 <span className="text-[9px] text-slate-500 font-mono font-bold">ms</span>
                             </div>
                         </div>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1233,18 +1233,22 @@ const Dashboard = ({ mode = 'browser', onNavigateBack, onNavigate, dashboardStat
         return models;
     }, [selectedBenchmarks, filteredBySource]);
 
+    const deferredXAxisMax = React.useDeferredValue(xAxisMax);
+
     // Filter data based on selected sources, models (via benchmarks), and x-axis filter
-    let filteredData = filteredBySource
-        .filter(d => selectedBenchmarks.has(getBenchmarkKey(d)))
-        .filter(d => {
-            if (xAxisMax === Infinity) return true;
-            if (chartMode === 'tpot') return d.time_per_output_token <= xAxisMax;
-            if (chartMode === 'qps') return (d.qps || d.metrics?.request_rate || 0) <= xAxisMax;
-            if (chartMode === 'ntpot') return (d.metrics?.ntpot || 0) <= xAxisMax;
-            if (chartMode === 'ttft') return (d.metrics?.ttft?.mean || 0) <= xAxisMax;
-            if (chartMode === 'itl') return (d.metrics?.itl || 0) <= xAxisMax;
-            return (d.latency?.mean || 0) <= xAxisMax;
-        });
+    const filteredData = React.useMemo(() => {
+        return filteredBySource
+            .filter(d => selectedBenchmarks.has(getBenchmarkKey(d)))
+            .filter(d => {
+                if (deferredXAxisMax === Infinity) return true;
+                if (chartMode === 'tpot') return d.time_per_output_token <= deferredXAxisMax;
+                if (chartMode === 'qps') return (d.qps || d.metrics?.request_rate || 0) <= deferredXAxisMax;
+                if (chartMode === 'ntpot') return (d.metrics?.ntpot || 0) <= deferredXAxisMax;
+                if (chartMode === 'ttft') return (d.metrics?.ttft?.mean || 0) <= deferredXAxisMax;
+                if (chartMode === 'itl') return (d.metrics?.itl || 0) <= deferredXAxisMax;
+                return (d.latency?.mean || 0) <= deferredXAxisMax;
+            });
+    }, [filteredBySource, selectedBenchmarks, getBenchmarkKey, deferredXAxisMax, chartMode]);
 
     const toggleBenchmark = (key) => {
         console.log("[toggleBenchmark] Toggling key:", key);

--- a/src/components/Dashboard/ThroughputCostChart.jsx
+++ b/src/components/Dashboard/ThroughputCostChart.jsx
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import React from 'react';
+import React, { useMemo } from 'react';
 import { ResponsiveContainer, LineChart, CartesianGrid, Tooltip, Line } from 'recharts';
 import { RotateCcw, Maximize, Minimize, ChevronUp, ChevronDown } from 'lucide-react';
 import { CustomLabel, CustomChartTooltip } from '../common';
@@ -179,80 +179,62 @@ export const ThroughputCostChart = (props) => {
             };
 
             // 1. Calculate Data Bounds (getVal already defined above)
-            
-            let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
-            const visibleDataPoints = []; // Flattened
-            
-            // Directly iterate filteredData (already filtered by selectedBenchmarks)
-            // This avoids the brittle allModels × filteredData double-loop where
-            // d.model === model matching could fail due to normalization differences.
-            filteredData.forEach(d => {
-                if (config.filterFn(d)) {
-                    const vx = Number(getVal(d, config.xKey));
-                    const vy = Number(getVal(d, config.yKey));
-                    if (!isNaN(vx) && !isNaN(vy)) {
-                        const benchmarkKey = getBenchmarkKey(d);
-                        const model = d.model_name || d.model || 'Unknown';
-                        visibleDataPoints.push({ ...d, vx, vy, model, benchmarkKey });
-                        if (vx < minX) minX = vx;
-                        if (vx > maxX) maxX = vx;
-                        if (vy < minY) minY = vy;
-                        if (vy > maxY) maxY = vy;
+            const { visibleDataPoints, uniqueBenchmarks, baselineSeries, paretoData, autoX, autoY } = useMemo(() => {
+                let minX = Infinity, maxX = -Infinity, minY = Infinity, maxY = -Infinity;
+                const visibleDataPoints = []; // Flattened
+                
+                filteredData.forEach(d => {
+                    if (config.filterFn(d)) {
+                        const vx = Number(getVal(d, config.xKey));
+                        const vy = Number(getVal(d, config.yKey));
+                        if (!isNaN(vx) && !isNaN(vy)) {
+                            const benchmarkKey = getBenchmarkKey(d);
+                            const model = d.model_name || d.model || 'Unknown';
+                            visibleDataPoints.push({ ...d, vx, vy, model, benchmarkKey });
+                            if (vx < minX) minX = vx;
+                            if (vx > maxX) maxX = vx;
+                            if (vy < minY) minY = vy;
+                            if (vy > maxY) maxY = vy;
+                        }
                     }
+                });
+                
+                const uniqueBenchmarks = [...new Set(visibleDataPoints.map(d => d.benchmarkKey))];
+
+                const baselineSeries = (baselineBenchmarkKey
+                    ? visibleDataPoints
+                          .filter(d => d.benchmarkKey === baselineBenchmarkKey)
+                          .map(d => ({ vx: d.vx, vy: d.vy }))
+                          .sort((a, b) => a.vx - b.vx)
+                    : []);
+
+                let paretoData = [];
+                if (showPareto && visibleDataPoints.length > 0) {
+                     const maximizeY = tputType !== 'cost';
+                     const minimizeX = true;
+                     paretoData = getParetoFrontier(visibleDataPoints, minimizeX, maximizeY);
                 }
-            });
-            
-            // Get unique benchmark keys (each upload becomes a distinct line)
-            const uniqueBenchmarks = [...new Set(visibleDataPoints.map(d => d.benchmarkKey))];
 
-            // Baseline series — used to compute %diff in the tooltip. Built only
-            // when a baseline is set and that benchmark is currently visible.
-            const baselineSeries = (baselineBenchmarkKey
-                ? visibleDataPoints
-                      .filter(d => d.benchmarkKey === baselineBenchmarkKey)
-                      .map(d => ({ vx: d.vx, vy: d.vy }))
-                      .sort((a, b) => a.vx - b.vx)
-                : []);
+                if (minX === Infinity) { minX=0; maxX=100; minY=0; maxY=100; }
+                
+                const xPad = (maxX - minX) * 0.05 || (isLogScaleX ? minX*0.1 : 1);
+                const yPad = (maxY - minY) * 0.05 || 1;
+                
+                let minXBound = Math.max(0, minX - xPad);
+                let maxXBound = maxX + xPad;
 
-            // Calculate Pareto Frontier if enabled
-            let paretoData = [];
-            if (showPareto && visibleDataPoints.length > 0) {
-                 // Determine optimization directions
-                 // Y-Axis:
-                 // Tput/QPS -> Maximize
-                 // Cost -> Minimize
-                 const maximizeY = tputType !== 'cost';
-                 
-                 // X-Axis:
-                 // Time/Latency -> Minimize
-                 // (Currently all X modes are time-based)
-                 const minimizeX = true;
+                if (isLogScaleX) {
+                      const logMin = Math.floor(Math.log10(minX > 0 ? minX : 0.1));
+                      const logMax = Math.ceil(Math.log10(maxX > 0 ? maxX : 100));
+                      minXBound = Math.pow(10, logMin);
+                      maxXBound = Math.pow(10, logMax);
+                }
+                const upperX = xAxisMax !== Infinity ? xAxisMax : maxXBound;
+                const autoX = [minXBound, upperX]; 
+                const autoY = [Math.max(0, minY - yPad), maxY + yPad];
 
-                 paretoData = getParetoFrontier(visibleDataPoints, minimizeX, maximizeY);
-            }
-
-            // Handle empty data case
-            if (minX === Infinity) { minX=0; maxX=100; minY=0; maxY=100; }
-            
-            // Add padding if using auto-bounds
-            // Add padding if using auto-bounds
-            const xPad = (maxX - minX) * 0.05 || (isLogScaleX ? minX*0.1 : 1);
-            const yPad = (maxY - minY) * 0.05 || 1;
-            
-            let minXBound = Math.max(0, minX - xPad);
-            let maxXBound = maxX + xPad;
-
-            if (isLogScaleX) {
-                  // Snap to powers of 10 for cleaner log scale
-                  // Example: 12 -> 10, 856 -> 1000
-                  const logMin = Math.floor(Math.log10(minX > 0 ? minX : 0.1));
-                  const logMax = Math.ceil(Math.log10(maxX > 0 ? maxX : 100));
-                  
-                  minXBound = Math.pow(10, logMin);
-                  maxXBound = Math.pow(10, logMax);
-            }
-            const autoX = [minXBound, maxXBound]; 
-            const autoY = [Math.max(0, minY - yPad), maxY + yPad];
+                return { visibleDataPoints, uniqueBenchmarks, baselineSeries, paretoData, autoX, autoY };
+            }, [filteredData, config, getBenchmarkKey, baselineBenchmarkKey, showPareto, tputType, isLogScaleX, xAxisMax]);
 
             const curX = zoomDomain?.x || autoX;
             const curY = zoomDomain?.y || autoY;
@@ -681,9 +663,20 @@ export const ThroughputCostChart = (props) => {
             }
 
             if (theme === 'dark') {
-                const dataMax = validData.length > 0 ? Math.max(...validData.map(d => Number(getVal(d, xKey)) || 0)) : (Math.max(...filteredBySource.map(d => Number(getVal(d, xKey)) || 0)) || 100);
+                const rawDataMax = validData.length > 0 ? Math.max(...validData.map(d => Number(getVal(d, xKey)) || 0)) : (Math.max(...filteredBySource.map(d => Number(getVal(d, xKey)) || 0)) || 100);
+                const dataMax = Math.ceil(rawDataMax * 1.2);
                 const step = Math.max(0.01, dataMax / 100);
                 const currentMax = xAxisMax === Infinity ? dataMax : xAxisMax;
+
+                const switchMode = (mode) => {
+                    setChartMode(mode);
+                    setXAxisMax(Infinity);
+                };
+
+                const switchTput = (type) => {
+                    setTputType(type);
+                    setXAxisMax(Infinity);
+                };
 
                 return (
                     <div className="bg-slate-900/80 border border-slate-700/60 rounded-2xl shadow-2xl flex flex-col w-full min-h-[550px] overflow-visible backdrop-blur-sm relative">
@@ -715,11 +708,11 @@ export const ThroughputCostChart = (props) => {
                                         <div className="flex items-center gap-3">
                                              <span className="text-[10px] text-slate-450 font-extrabold uppercase tracking-wider w-16">X-Axis:</span>
                                              <div className="flex flex-wrap bg-slate-950/60 border border-slate-800/80 rounded-lg p-0.5 gap-0.5">
-                                                 <button onClick={() => setChartMode('tpot')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'tpot' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>TPOT</button>
-                                                 <button onClick={() => setChartMode('ntpot')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'ntpot' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>NTPOT</button>
-                                                 <button onClick={() => setChartMode('ttft')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'ttft' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>TTFT</button>
-                                                 <button onClick={() => setChartMode('itl')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'itl' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>ITL</button>
-                                                 <button onClick={() => setChartMode('lat')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'lat' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>E2E Latency</button>
+                                                 <button onClick={() => switchMode('tpot')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'tpot' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>TPOT</button>
+                                                 <button onClick={() => switchMode('ntpot')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'ntpot' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>NTPOT</button>
+                                                 <button onClick={() => switchMode('ttft')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'ttft' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>TTFT</button>
+                                                 <button onClick={() => switchMode('itl')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'itl' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>ITL</button>
+                                                 <button onClick={() => switchMode('lat')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', chartMode === 'lat' ? 'bg-indigo-650 text-white shadow' : 'text-slate-400 hover:text-white')}>E2E Latency</button>
                                              </div>
                                          </div>
 
@@ -727,11 +720,11 @@ export const ThroughputCostChart = (props) => {
                                         <div className="flex items-center gap-3">
                                              <span className="text-[10px] text-slate-450 font-extrabold uppercase tracking-wider w-16">Y-Axis:</span>
                                              <div className="flex flex-wrap bg-slate-950/60 border border-slate-800/80 rounded-lg p-0.5 gap-0.5">
-                                                 <button onClick={() => setTputType('output')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', tputType === 'output' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>Output</button>
-                                                 <button onClick={() => metricAvailability.input && setTputType('input')} disabled={!metricAvailability.input} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', !metricAvailability.input ? 'text-slate-700 cursor-not-allowed opacity-40' : tputType === 'input' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>Input</button>
-                                                 <button onClick={() => metricAvailability.total && setTputType('total')} disabled={!metricAvailability.total} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', !metricAvailability.total ? 'text-slate-700 cursor-not-allowed opacity-40' : tputType === 'total' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>Total</button>
-                                                 <button onClick={() => metricAvailability.qps && setTputType('qps')} disabled={!metricAvailability.qps} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', !metricAvailability.qps ? 'text-slate-700 cursor-not-allowed opacity-40' : tputType === 'qps' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>QPS</button>
-                                                 <button onClick={() => metricAvailability.cost && setTputType('cost')} disabled={!metricAvailability.cost} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', !metricAvailability.cost ? 'text-slate-700 cursor-not-allowed opacity-40' : tputType === 'cost' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>Cost</button>
+                                                 <button onClick={() => switchTput('output')} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', tputType === 'output' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>Output</button>
+                                                 <button onClick={() => metricAvailability.input && switchTput('input')} disabled={!metricAvailability.input} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', !metricAvailability.input ? 'text-slate-700 cursor-not-allowed opacity-40' : tputType === 'input' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>Input</button>
+                                                 <button onClick={() => metricAvailability.total && switchTput('total')} disabled={!metricAvailability.total} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', !metricAvailability.total ? 'text-slate-700 cursor-not-allowed opacity-40' : tputType === 'total' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>Total</button>
+                                                 <button onClick={() => metricAvailability.qps && switchTput('qps')} disabled={!metricAvailability.qps} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', !metricAvailability.qps ? 'text-slate-700 cursor-not-allowed opacity-40' : tputType === 'qps' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>QPS</button>
+                                                 <button onClick={() => metricAvailability.cost && switchTput('cost')} disabled={!metricAvailability.cost} className={cn('px-2.5 py-1 text-[9.5px] font-extrabold uppercase tracking-wider rounded-md transition-all', !metricAvailability.cost ? 'text-slate-700 cursor-not-allowed opacity-40' : tputType === 'cost' ? 'bg-emerald-600 text-white shadow' : 'text-slate-400 hover:text-white')}>Cost</button>
                                              </div>
                                              {tputType === 'cost' && (
                                                  <select 
@@ -767,6 +760,18 @@ export const ThroughputCostChart = (props) => {
                                              {/* Cap Input */}
                                              <div className="flex items-center gap-2 bg-slate-950/60 border border-slate-800/80 px-3 py-1 rounded-lg">
                                                  <span className="text-[10px] text-slate-450 font-extrabold uppercase tracking-wider">Cap:</span>
+                                                 <button 
+                                                     type="button"
+                                                     onClick={() => setXAxisMax(xAxisMax === Infinity ? Math.round(dataMax * 0.8) : Infinity)}
+                                                     className={cn(
+                                                         'px-2 py-0.5 text-[9.5px] font-extrabold uppercase tracking-wider rounded transition-all cursor-pointer',
+                                                         xAxisMax === Infinity 
+                                                             ? 'bg-cyan-600 text-white shadow' 
+                                                             : 'bg-slate-800 text-slate-400 hover:text-white'
+                                                     )}
+                                                 >
+                                                     Auto
+                                                 </button>
                                                  <input 
                                                      type="range" 
                                                      min={0} 
@@ -775,21 +780,26 @@ export const ThroughputCostChart = (props) => {
                                                      value={currentMax} 
                                                      onChange={(e) => {
                                                          const val = parseFloat(e.target.value);
-                                                         if (val >= dataMax * 0.99) setXAxisMax(Infinity);
-                                                         else setXAxisMax(val);
+                                                         setXAxisMax(val);
                                                      }} 
-                                                     className="w-24 h-1 bg-slate-800 rounded-lg appearance-none cursor-pointer accent-cyan-400" 
+                                                     className={cn(
+                                                         "w-24 h-1 rounded-lg appearance-none cursor-pointer accent-cyan-400",
+                                                         xAxisMax === Infinity ? "bg-slate-850 opacity-40" : "bg-slate-800"
+                                                     )} 
                                                  />
                                                  <input 
                                                      type="number" 
                                                      value={xAxisMax === Infinity ? '' : xAxisMax} 
-                                                     placeholder={dataMax.toFixed(0)} 
+                                                     placeholder={xAxisMax === Infinity ? 'Auto' : dataMax.toFixed(0)} 
                                                      onChange={(e) => {
                                                          const val = parseFloat(e.target.value);
                                                          if (!val || isNaN(val)) setXAxisMax(Infinity);
                                                          else setXAxisMax(val);
                                                      }} 
-                                                     className="w-14 bg-transparent text-[10px] text-slate-200 focus:outline-none focus:ring-1 focus:ring-cyan-500/50 rounded px-1 text-right font-mono font-extrabold transition-all" 
+                                                     className={cn(
+                                                         "w-14 bg-transparent text-[10px] focus:outline-none focus:ring-1 focus:ring-cyan-500/50 rounded px-1 text-right font-mono font-extrabold transition-all",
+                                                         xAxisMax === Infinity ? "text-slate-500" : "text-slate-200"
+                                                     )} 
                                                  />
                                                  <span className="text-[9px] text-slate-500 font-mono font-bold">ms</span>
                                              </div>
@@ -909,10 +919,25 @@ export const ThroughputCostChart = (props) => {
                                                          strokeWidth={isBaseline ? 2.5 : 2} 
                                                          strokeDasharray={isBaseline ? "4 4" : "0"}
                                                          dot={showDataLabels ? { r: 3, fill: color, strokeWidth: 0 } : false} 
+                                                         label={(props) => <CustomLabel {...props} lastIndex={lineData.length - 1} text={smartLabels[benchmarkKey] || displayName} stroke={color} showLineLabel={showLabels} showDataLabels={showDataLabels} dataPoint={lineData[props.index]} />}
                                                          isAnimationActive={false}
-                                                    />
+                                                     />
                                                 );
                                             })}
+
+                                            {showPareto && paretoData.length > 1 && (
+                                                <Line 
+                                                    data={paretoData}
+                                                    type="monotone"
+                                                    dataKey="vy"
+                                                    stroke="#f59e0b"
+                                                    strokeWidth={2}
+                                                    strokeDasharray="5 5"
+                                                    dot={{ r: 4, fill: '#f59e0b', strokeWidth: 0 }}
+                                                    name="Pareto Frontier"
+                                                    isAnimationActive={false}
+                                                />
+                                            )}
                                         </LineChart>
                                     </ResponsiveContainer>
                                 </div>

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -1343,13 +1343,13 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     model_name: bundle.payload.model_name || "Custom Model",
                     hardware: {
                         hardware_name: bundle.payload.hardware?.hardware_name || "Unknown Hardware",
-                        accelerator_count: bundle.payload.hardware?.accelerator_count || null
+                        accelerator_count: bundle.payload.hardware?.accelerator_count
                     },
-                    well_lit_path: bundle.payload.well_lit_path || null,
-                    inference_tool: bundle.payload.inference_tool || null,
-                    inference_tool_version: bundle.payload.inference_tool_version || null,
-                    run_metadata: bundle.payload.run_metadata || null,
-                    metadata: bundle.payload.metadata || null,
+                    well_lit_path: bundle.payload.well_lit_path,
+                    inference_tool: bundle.payload.inference_tool,
+                    inference_tool_version: bundle.payload.inference_tool_version,
+                    run_metadata: bundle.payload.run_metadata,
+                    metadata: bundle.payload.metadata,
                     manifests: {
                         ...(bundle.payload.manifests || {}),
                         ...(bundle.attachedManifests ? Object.fromEntries(
@@ -1387,6 +1387,13 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     }))
                 };
 
+                const preflight = validatePrismUploadStructure(payload, { isUpload: true });
+                if (!preflight.isValid) {
+                    const errorMsg = `Pre-flight validation failed for "${payload.runLabel}": ${preflight.errors.join('; ')}`;
+                    if (addToast) addToast(errorMsg, "error");
+                    throw new Error(errorMsg);
+                }
+
                 const res = await fetch('/api/results', {
                     method: 'POST',
                     headers: {
@@ -1398,7 +1405,8 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                 
                 if (!res.ok) {
                     const errorData = await res.json().catch(() => ({}));
-                    throw new Error(errorData.error || `Submit failed with HTTP ${res.status}`);
+                    const detailsStr = Array.isArray(errorData.details) ? `: ${errorData.details.join('; ')}` : (errorData.details ? `: ${errorData.details}` : '');
+                    throw new Error((errorData.error || `Submit failed with HTTP ${res.status}`) + detailsStr);
                 }
 
                 const responseData = await res.json();

--- a/src/components/IntelligentRoutingChart.jsx
+++ b/src/components/IntelligentRoutingChart.jsx
@@ -224,10 +224,12 @@ const IntelligentRoutingChart = ({ data, initialXAxis, initialYAxis, initialLogS
         .filter(d => !isNaN(d.dynamic_x) && !isNaN(d.dynamic_y))
         .sort((a, b) => a.dynamic_x - b.dynamic_x);
 
-    const dataMax = derivedZoomData.length > 0 ? Math.max(...derivedZoomData.map(d => d.dynamic_x)) : 100;
+    const rawDataMax = derivedZoomData.length > 0 ? Math.max(...derivedZoomData.map(d => d.dynamic_x)) : 100;
+    const dataMax = Math.ceil(rawDataMax * 1.2);
     const dataMin = derivedZoomData.length > 0 ? Math.min(...derivedZoomData.filter(d => d.dynamic_x > 0).map(d => d.dynamic_x)) : 1;
     const step = Math.max(0.01, dataMax / 100);
-    const currentMax = zoomXMax === Infinity ? dataMax : zoomXMax;
+    const deferredZoomXMax = React.useDeferredValue(zoomXMax);
+    const currentMax = deferredZoomXMax === Infinity ? dataMax : deferredZoomXMax;
     const isPercentileAxis = ['ttft', 'tpot', 'itl', 'ntpot', 'e2e'].includes(zoomXAxis);
     const visibleZoomData = derivedZoomData.filter(d => d.dynamic_x <= currentMax && (!isPercentileAxis || visiblePercentiles.includes(d.percentile)));
 
@@ -340,7 +342,10 @@ const IntelligentRoutingChart = ({ data, initialXAxis, initialYAxis, initialLogS
                                     { value: 'e2e', label: 'E2E Latency' },
                                 ]}
                                 value={zoomXAxis}
-                                onChange={setZoomXAxis}
+                                onChange={(val) => {
+                                    setZoomXAxis(val);
+                                    setZoomXMax(Infinity);
+                                }}
                             />
                         </div>
 
@@ -356,7 +361,10 @@ const IntelligentRoutingChart = ({ data, initialXAxis, initialYAxis, initialLogS
                                         { value: 'qps', label: 'QPS' },
                                     ]}
                                     value={zoomYAxis}
-                                    onChange={setZoomYAxis}
+                                    onChange={(val) => {
+                                        setZoomYAxis(val);
+                                        setZoomXMax(Infinity);
+                                    }}
                                 />
                             </div>
                         </div>
@@ -378,8 +386,20 @@ const IntelligentRoutingChart = ({ data, initialXAxis, initialYAxis, initialLogS
 
                             <div className="flex items-center gap-2 bg-slate-900/50 border border-slate-700/50 px-3 py-1 rounded-lg">
                                 <span className="text-[10px] text-slate-400 font-extrabold uppercase tracking-widest">Cap:</span>
-                                <input type="range" min={0} max={dataMax} step={step} value={currentMax} onChange={(e) => { const val = parseFloat(e.target.value); if (val >= dataMax * 0.99) setZoomXMax(Infinity); else setZoomXMax(val); }} className="w-28 h-1 bg-slate-700 rounded-lg appearance-none cursor-pointer accent-cyan-400" />
-                                <input type="number" value={zoomXMax === Infinity ? '' : zoomXMax} placeholder={dataMax.toFixed(1)} onChange={(e) => { const val = parseFloat(e.target.value); if (!val || isNaN(val)) setZoomXMax(Infinity); else setZoomXMax(val); }} className="w-16 bg-transparent text-[10px] text-slate-200 focus:outline-none focus:ring-1 focus:ring-cyan-500/50 rounded px-1 text-right font-mono font-bold transition-all" />
+                                <button 
+                                    type="button"
+                                    onClick={() => setZoomXMax(zoomXMax === Infinity ? Math.round(dataMax * 0.8) : Infinity)}
+                                    className={cn(
+                                        'px-2 py-0.5 text-[9.5px] font-extrabold uppercase tracking-wider rounded transition-all cursor-pointer',
+                                        zoomXMax === Infinity 
+                                            ? 'bg-cyan-600 text-white shadow' 
+                                            : 'bg-slate-800 text-slate-400 hover:text-white'
+                                    )}
+                                >
+                                    Auto
+                                </button>
+                                <input type="range" min={0} max={dataMax} step={step} value={currentMax} onChange={(e) => setZoomXMax(parseFloat(e.target.value))} className={cn("w-28 h-1 rounded-lg appearance-none cursor-pointer accent-cyan-400", zoomXMax === Infinity ? "bg-slate-800/40 opacity-40" : "bg-slate-700")} />
+                                <input type="number" value={zoomXMax === Infinity ? '' : zoomXMax} placeholder={zoomXMax === Infinity ? 'Auto' : dataMax.toFixed(1)} onChange={(e) => { const val = parseFloat(e.target.value); if (!val || isNaN(val)) setZoomXMax(Infinity); else setZoomXMax(val); }} className={cn("w-16 bg-transparent text-[10px] focus:outline-none focus:ring-1 focus:ring-cyan-500/50 rounded px-1 text-right font-mono font-bold transition-all", zoomXMax === Infinity ? "text-slate-500" : "text-slate-200")} />
                                 <span className="text-[9px] text-slate-500 font-mono font-bold">ms</span>
                             </div>
                         </div>
@@ -398,9 +418,10 @@ const IntelligentRoutingChart = ({ data, initialXAxis, initialYAxis, initialLogS
                                     type="number"
                                     dataKey="dynamic_x"
                                     label={xLabels[zoomXAxis] || 'Queries Per Second'}
-                                    domain={zoomLogScale ? [logTicks[0] || 1, 'auto'] : ['auto', 'auto']}
+                                    domain={zoomLogScale ? [logTicks[0] || 1, zoomXMax === Infinity ? 'auto' : zoomXMax] : [0, zoomXMax === Infinity ? 'auto' : zoomXMax]}
                                     scale={zoomLogScale ? 'log' : 'auto'}
                                     ticks={zoomLogScale ? logTicks : undefined}
+                                    allowDataOverflow
                                 />
                                 <ChartYAxis
                                     label={yLabels[zoomYAxis] || 'Tokens/sec'}

--- a/src/components/common/CustomLabel.jsx
+++ b/src/components/common/CustomLabel.jsx
@@ -22,7 +22,7 @@ export const CustomLabel = (props) => {
 
     // 1. Data Point Label (TP)
     if (showDataLabels && item) {
-        let tp = item.tp || item.metadata?.tensor_parallelism || item.tensor_parallelism || '1';
+        let tp = item.tp || item.metadata?.tensor_parallelism || item.tensor_parallelism || item.metadata?.tp || '1';
         if (tp) {
              if (!String(tp).startsWith('TP')) tp = `TP${tp}`;
              content.push(


### PR DESCRIPTION
## What does this PR do?

This PR includes two fixes for the Results Store and Dashboard components:

1. **Results Store Upload Validation**:
   - Updates `PrismResultPayloadSchema` to accept `null` values for optional payload fields (`inference_tool`, `inference_tool_version`, `run_metadata`, `metadata`, `other_tools`, `manifests`, `evidence`).
   - Adds pre-flight validation to `SubmitValidationPage` before submission and improves server validation error formatting.
   - Restricts the rejected submission state strictly to admin review rejections. Automated validation failures now trigger immediate storage cleanup and return an HTTP 400 error response without queuing malformed runs.
   - Updates specifications in `specs/main/results-api/`.

2. **Chart Cap Scaling and Rendering Toggles**:
   - Fixes dark theme chart rendering in `ThroughputCostChart` where `CustomLabel` and Pareto frontier lines were omitted, restoring Labels, Points, and Pareto toggles across Results Store and Compare & Promote views.
   - Adds explicit Auto scaling state, deferred slider updates, and spec in `specs/changes/chart-cap-scaling-spec.md`.

## Why is this change needed?

- Upload payloads containing `null` for optional metadata fields failed Zod schema validation on `/api/results` or queued malformed runs into the rejected state rather than handling validation error cleanup cleanly.
- Dark theme rendering in `ThroughputCostChart` omitted custom labels and Pareto frontier lines, disabling rendering toggles across dashboard views.

## How was this tested?

- [x] Manual testing performed
- [x] Tested upload API payload validation with null optional metadata fields
- [x] Verified chart toggle rendering and Auto scaling behavior in dark/light themes

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)
