### PR TITLE
feat: Add unlisted benchmark submission state

### DIFF
--- a/server/results/api.ts
+++ b/server/results/api.ts
@@ -37,6 +37,7 @@ export const PrismStageEntrySchema = z.object({
 export const PrismSubmissionStateSchema = z.enum([
     'staged',
     'submitted_pending_processing',
+    'unlisted',
     'submitted_pending_review',
     'public',
     'promoted',

--- a/server/results/gcs.ts
+++ b/server/results/gcs.ts
@@ -89,21 +89,27 @@ export async function listResults(options: ListResultsOptions): Promise<ListResu
     // eslint-disable-next-line no-unused-vars
     const filters: ((state: PrismSubmissionState, user: string) => boolean)[] = [];
 
-    // 1. Permission check (non-admins can only see their own results or public/promoted results)
+    // 1. Permission check (non-admins can see public/promoted, explicit status=unlisted, or their own results)
     if (permission !== 'admin') {
         filters.push((state, user) => {
             const isApproved = state === 'public' || state === 'promoted';
+            const isExplicitUnlisted = state === 'unlisted' && statusFilter === 'unlisted';
             const isOwn = !!(username && user.toLowerCase() === username.toLowerCase());
-            return isApproved || isOwn;
+            return isApproved || isExplicitUnlisted || isOwn;
         });
     }
 
-    // 2. Status Filter
+    // 2. Default Grid Filtering (general list queries without status or own filter exclude unlisted)
+    if (!statusFilter && !ownFilter) {
+        filters.push((state) => state !== 'unlisted');
+    }
+
+    // 3. Status Filter
     if (statusFilter) {
         filters.push((state) => state === statusFilter);
     }
 
-    // 3. Ownership Filter
+    // 4. Ownership Filter
     if (ownFilter) {
         filters.push((_, user) => !!(username && user.toLowerCase() === username.toLowerCase()));
     }

--- a/server/results/processing.ts
+++ b/server/results/processing.ts
@@ -30,7 +30,10 @@ export interface ProcessSubmissionResult {
  * If validation fails, the item is dropped completely (deleted from GCS storage).
  * If validation passes, the item is promoted to `submitted_pending_review`.
  */
-export async function processSubmission(runId: string): Promise<ProcessSubmissionResult> {
+export async function processSubmission(
+    runId: string,
+    targetState: PrismSubmissionState = 'submitted_pending_review'
+): Promise<ProcessSubmissionResult> {
     try {
         const payload = await readResultPayload(runId);
         
@@ -50,7 +53,7 @@ export async function processSubmission(runId: string): Promise<ProcessSubmissio
             };
         }
 
-        const newState: PrismSubmissionState = 'submitted_pending_review';
+        const newState: PrismSubmissionState = targetState;
 
         // Write back the processed result with updated GCS custom metadata context state
         await writeResult(runId, payload, newState, username);

--- a/server/results/routes/delete.ts
+++ b/server/results/routes/delete.ts
@@ -53,41 +53,47 @@ export async function deleteResultsHandler(
         return res.status(401).json({ error: 'Authentication required. Missing session token.' });
     }
 
+    let username = '';
     let permission = 'none';
 
     try {
         const authResult = await validateGitHubToken(token);
+        username = authResult.username;
         permission = authResult.permission;
     } catch (error: unknown) {
         const msg = error instanceof Error ? error.message : String(error);
         return res.status(401).json({ error: 'Invalid or expired session token.', details: msg });
     }
 
-    // 2. IAM Check: Only administrators are allowed to delete benchmarks
-    if (permission !== 'admin') {
-        return res.status(403).json({ error: 'Access denied. Only administrators can delete rejected benchmarks.' });
-    }
-
     try {
-        // 3. Fetch GCS metadata context to check submission status/state
+        // 2. Fetch GCS metadata context to check submission status/state & author
         const metadata = await readResultMetadata(runId);
         if (!metadata) {
             return res.status(404).json({ error: 'Result not found.' });
         }
 
-        // 4. Benchmark Check: Only rejected benchmarks can be deleted off GCS
-        if (metadata.state !== 'rejected') {
+        const { user: itemUser, state: itemState } = metadata;
+        const isOwner = !!(username && itemUser.toLowerCase() === username.toLowerCase());
+
+        let allowed = false;
+        if (isOwner && itemState === 'unlisted') {
+            allowed = true;
+        } else if (permission === 'admin' && (itemState === 'unlisted' || itemState === 'rejected')) {
+            allowed = true;
+        }
+
+        if (!allowed) {
             return res.status(403).json({
-                error: 'Forbidden. Only rejected benchmarks can be deleted from the Results Store.'
+                error: 'Forbidden. Benchmark can only be deleted if it is unlisted (by owner or admin) or rejected (by admin).'
             });
         }
 
-        // 5. Delete object from GCS Results Store
+        // 3. Delete object from GCS Results Store
         await deleteResult(runId);
 
         return res.json({
             success: true,
-            message: `Rejected benchmark ${runId} successfully deleted.`
+            message: `Benchmark ${runId} successfully deleted.`
         });
     } catch (error: unknown) {
         console.error('[Results Delete API Error]', error);

--- a/server/results/routes/get.ts
+++ b/server/results/routes/get.ts
@@ -71,7 +71,7 @@ export async function getResultsHandler(req: Request, res: Response<ResultsGetRe
         if (permission === 'admin') {
             allowed = true;
         } else {
-            if (itemState === 'public' || itemState === 'promoted') {
+            if (itemState === 'public' || itemState === 'promoted' || itemState === 'unlisted') {
                 allowed = true;
             } else if (username && itemUser.toLowerCase() === username.toLowerCase()) {
                 allowed = true;

--- a/server/results/routes/review.ts
+++ b/server/results/routes/review.ts
@@ -85,26 +85,39 @@ export async function reviewResultsHandler(
             return res.status(404).json({ error: 'Result not found' });
         }
 
-        const { user: itemUser } = metadata;
+        const { user: itemUser, state: currentState } = metadata;
 
         // 3. Permission and authorization checks
-        let allowed = false;
-        if (permission === 'admin') {
-            allowed = true;
+        if (currentState === 'unlisted') {
+            if (status !== 'submitted_pending_review') {
+                return res.status(403).json({ error: 'Forbidden. Unlisted benchmarks can only be promoted to submitted_pending_review.' });
+            }
+            const isOwner = username && itemUser.toLowerCase() === username.toLowerCase();
+            if (!isOwner) {
+                return res.status(403).json({ error: 'Forbidden. Only the owner of an unlisted benchmark can promote it.' });
+            }
+            if (feedback !== undefined || reviewer !== undefined) {
+                return res.status(400).json({ error: 'Feedback and reviewer fields are forbidden when promoting from unlisted to submitted_pending_review.' });
+            }
         } else {
-            // Check if the current user is the owner/author of the submission
-            if (username && itemUser.toLowerCase() === username.toLowerCase()) {
-                // Owners can only transition their own runs to 'submitted_pending_processing' or 'submitted_pending_review' (resubmission/promotion)
-                if (status === 'submitted_pending_processing' || status === 'submitted_pending_review') {
-                    allowed = true;
-                } else {
-                    return res.status(403).json({ error: 'Forbidden. Non-admin users cannot approve, reject, or promote benchmarks of other status values.' });
+            let allowed = false;
+            if (permission === 'admin') {
+                allowed = true;
+            } else {
+                // Check if the current user is the owner/author of the submission
+                if (username && itemUser.toLowerCase() === username.toLowerCase()) {
+                    // Owners can only transition their own runs to 'submitted_pending_processing' or 'submitted_pending_review' (resubmission/promotion)
+                    if (status === 'submitted_pending_processing' || status === 'submitted_pending_review') {
+                        allowed = true;
+                    } else {
+                        return res.status(403).json({ error: 'Forbidden. Non-admin users cannot approve, reject, or promote benchmarks of other status values.' });
+                    }
                 }
             }
-        }
 
-        if (!allowed) {
-            return res.status(403).json({ error: 'Access denied. You do not have permissions to modify this result.' });
+            if (!allowed) {
+                return res.status(403).json({ error: 'Access denied. You do not have permissions to modify this result.' });
+            }
         }
 
         // 4. Fetch actual file content from GCS to edit the fields

--- a/server/results/routes/submit.ts
+++ b/server/results/routes/submit.ts
@@ -82,6 +82,10 @@ export async function submitResultsHandler(
     }
 
     // 4. Enrich payload with author & time metadata
+    // Determine target visibility state ('unlisted' vs default 'submitted_pending_review')
+    const rawTargetState = (req.query.targetState as string) || (uploadData as any).targetState;
+    const targetState: PrismSubmissionState = rawTargetState === 'unlisted' ? 'unlisted' : 'submitted_pending_review';
+
     uploadData.github_author = { username };
     uploadData.submitted_at = new Date().toISOString();
 
@@ -91,7 +95,7 @@ export async function submitResultsHandler(
         await writeResult(serverRunId, uploadData, initialState, username);
 
         // 5. Run automated validation and promotion processing synchronously for now
-        const processingResult = await processSubmission(serverRunId);
+        const processingResult = await processSubmission(serverRunId, targetState);
 
         if (!processingResult.success) {
             return res.status(400).json({
@@ -101,12 +105,16 @@ export async function submitResultsHandler(
             });
         }
 
+        const successMessage = processingResult.state === 'unlisted'
+            ? 'Benchmark result successfully processed and saved as unlisted.'
+            : 'Benchmark result successfully submitted and promoted to review.';
+
         res.status(201).json({
             success: true,
             runId: serverRunId,
             oldRunId: clientRunId,
             state: processingResult.state,
-            message: 'Benchmark result successfully submitted and promoted to review.'
+            message: successMessage
         });
 
     } catch (error: any) {

--- a/specs/changes/unlisted-benchmarks-spec.md
+++ b/specs/changes/unlisted-benchmarks-spec.md
@@ -1,0 +1,145 @@
+# Spec: Unlisted Status for Prism Results Store Benchmarks
+
+- **Status**: Draft
+- **Author**: diamondburned, Jetski
+- **Date**: July 31, 2026
+
+## Objective
+
+This proposal introduces an **Unlisted** benchmark submission state (`unlisted`)
+for the Prism Results Store.
+
+Currently, benchmark runs uploaded to Prism Cloud move directly from automated
+validation into the human review queue (`submitted_pending_review`), where they
+await administrator approval to become `public`. There is no cloud-backed middle
+ground for storing preliminary, unverified, or experimental benchmark data
+without submitting it for formal public review.
+
+The goals of this feature are:
+
+1. Provide a cloud-backed storage state (`unlisted`) in Google Cloud Storage
+   (GCS) that skips human review.
+2. Serve as a data playground for bad, unverified, or preliminary benchmark data
+   without cluttering the main public benchmark catalog.
+3. Allow contributors to generate and copy direct share links
+   (`/results/:runId`) for unlisted benchmarks to collaborate with team members.
+4. Allow the submitting user (owner) to promote their unlisted benchmark to
+   `submitted_pending_review` whenever they verify the data quality and are
+   ready for public review.
+
+Non-goals:
+
+- Making unlisted benchmarks secret or private (unlisted data is accessible to
+  anyone holding a direct link or explicitly querying `status=unlisted`, but is
+  hidden by default from the general public explore grid).
+- Allowing administrators to manage or promote unlisted benchmarks (owner
+  self-promotion governs unlisted transitions; admin review is reserved for
+  approving items in the review queue).
+
+---
+
+## Background
+
+The Results Store backend uses GCS to store run result bundles as JSON files
+(`prism-results-store/<benchmarkID>.v1.json`) and relies on GCS custom object
+metadata contexts (`submission_state`, `github_user`, `model_name`,
+`hardware_name`) for fast server-side filtering.
+
+Currently, the submission pipeline follows a strict two-stage path:
+
+- **`staged`**: Stored locally in the user's browser (IndexedDB). Cannot be
+  shared via URL.
+- **`submitted_pending_processing`** $\rightarrow$
+  **`submitted_pending_review`**: Uploaded to Prism Cloud, validated, and placed
+  in the admin review queue.
+
+This structure creates friction when contributors have benchmark runs that they
+want stored on the backend and shared with teammates, but aren't certain whether
+the data quality is solid enough for public review. Introducing `unlisted`
+resolves this gap.
+
+For related details, see the canonical
+[Prism Results Store Specification](../main/completed/results-api/README.md),
+[API Route Reference](../main/completed/results-api/routes.md),
+[Frontend Architecture Spec](../main/completed/results-api/frontend.md), and
+[Identity & Access Management Spec](../main/completed/results-api/iam.md).
+
+---
+
+## Lifecycle State Machine & Visibility Matrix
+
+### State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> staged : Local Browser Upload (IndexedDB)
+    staged --> submitted_pending_processing : Submit Payload (Requires GitHub Auth)
+    submitted_pending_processing --> unlisted : Auto-Validation Pass (Target: Unlisted)
+    submitted_pending_processing --> submitted_pending_review : Auto-Validation Pass (Target: Public Review)
+    submitted_pending_processing --> [*] : Auto-Validation Fail (Dropped)
+    unlisted --> submitted_pending_review : Submitting User (Owner) Promotes to Review
+    submitted_pending_review --> public : Admin Approved
+    submitted_pending_review --> rejected : Admin Rejected
+    public --> promoted : Selected for Well-Lit Path
+```
+
+### State & Visibility Matrix
+
+| Property                            | `staged`                       | `unlisted`                                             | `submitted_pending_review`                    | `public`                    |
+| :---------------------------------- | :----------------------------- | :----------------------------------------------------- | :-------------------------------------------- | :-------------------------- |
+| **Storage Location**                | Local Browser (IndexedDB)      | Prism Cloud GCS Bucket                                 | Prism Cloud GCS Bucket                        | Prism Cloud GCS Bucket      |
+| **Human Review**                    | None                           | **Skipped** (Automated processing only)                | Queued for Admin Review                       | Approved                    |
+| **Visible to Guest/User**           | Browser-local only             | **Yes** (Via share link or explicit `status=unlisted`) | **No** (Owner only)                           | **Yes** (Public)            |
+| **Visible to Admin**                | Browser-local only             | Yes                                                    | **Yes** (All review queue items)              | Yes                         |
+| **Hidden by Default in Main Grid?** | N/A                            | **Yes**                                                | Yes                                           | **No** (Visible by default) |
+| **Promoted By**                     | Owner $\rightarrow$ Processing | **Owner** $\rightarrow$ `submitted_pending_review`     | **Admin** $\rightarrow$ `public` / `rejected` | N/A                         |
+
+---
+
+## Behavioral & Functional Requirements
+
+### 1. Ingestion & Target Visibility Selection
+
+- During the submission process (in the submission wizard), authenticated
+  contributors select their desired target visibility:
+    - **Save as Unlisted**: Validates data and stores the benchmark directly as
+      `unlisted` in GCS, skipping human review.
+    - **Submit for Public Review**: Validates data and places the benchmark into
+      `submitted_pending_review`.
+- All uploads undergo automated format and metric integrity checks
+  (`validatePrismUploadStructure`). Submissions that fail validation are dropped
+  immediately, returning HTTP 400.
+
+### 2. Access Control & Direct Link Sharing
+
+- **Not Secret, Hidden by Default**: `unlisted` benchmarks are not secret.
+  Anyone with a direct link (`/results/:runId` or `GET /api/results/:runId`) or
+  who explicitly filters by `status=unlisted` can read the benchmark payload.
+- **Default Grid Filtering**: General list queries (such as the default public
+  exploration grid) exclude `unlisted` benchmarks to prevent unverified data
+  from cluttering public results.
+- **Review Queue Restrictions**: The pending review queue
+  (`submitted_pending_review`) remains restricted: only **Admins** can view all
+  items in pending review, while non-admin submitters can only view their own
+  items under review (`own=true`).
+
+### 3. Owner Self-Promotion & Management Workflow
+
+- The **submitting user (owner)** retains full control over their unlisted
+  benchmarks.
+- **Promotion**: When an owner verifies that their unlisted benchmark data is
+  accurate, they can promote it from `unlisted` $\rightarrow$
+  `submitted_pending_review` via a single promote action button ("Promote to
+  Review").
+    - **No Feedback or Reason Input**: Owner promotion is a single-click status
+      transition that requires no reasons or feedback text. In
+      `POST /api/results/:runId/status`, `feedback` and `reviewer` fields are
+      unused and forbidden for this transition.
+- **Deletion**: Submitting users (owners) can permanently delete their own
+  unlisted benchmarks via `DELETE /api/results/:runId`. Admins can also delete
+  unlisted benchmarks.
+- Promoting an unlisted benchmark places it into the administrator review queue.
+  Administrators then review and approve the run to `public` or reject it to
+  `rejected`.
+- Administrators do not manage or promote unlisted benchmarks directly; unlisted
+  management is entirely owner-driven.

--- a/specs/main/completed/results-api/README.md
+++ b/specs/main/completed/results-api/README.md
@@ -156,11 +156,30 @@ environment:
         - NOW: necessary for proper attribution enforcement.
         - FUTURE: necessary for input sanitization in the future.
 - **`submitted_pending_review`** (Submitted, Pending Final Review):
-    - User review, if necessary.
-        - Eventually this stage will be skipped straight to the next one once
-          validation pipeline is robust enough.
+    - User review queue.
+    - **Visibility:** Only visible to **Admins** (who can view all benchmarks in
+      pending review) and the **submitting user/owner** (who can view their own
+      benchmarks under review).
     - See
       [\[External\] llm-d Results Store Submission Policy](https://docs.google.com/document/u/0/d/1EZI-VYXdM9V3KnoWkFIXmihrgO2t7YZZhgeMuIlZDpI/edit?resourcekey=0-xQu9xYrRcroMn5yogcb_xg).
+- **`unlisted`** (Unlisted):
+    - **Benchmark is stored in Prism Cloud backend** (GCS results store).
+    - **Skips human review:** Transitions straight from automated processing to
+      `unlisted` upon upload.
+    - **Not secret, but hidden by default:** Visible to everyone (no manual
+      review required), but hidden by default from general benchmark exploration
+      lists unless explicitly filtered (`status=unlisted`) or accessed via
+      direct share link.
+    - **Data Quality Playground:** Serves as a playground for bad, unverified,
+      or uncertain data. Verified/reviewed data is expected to be public;
+      unlisted data allows sharing unverified runs without cluttering the public
+      store.
+    - **Owner Promotion:** The submitting user (owner) can choose to promote
+      their `unlisted` benchmark to `submitted_pending_review`, placing it into
+      the review queue for public approval. Admins do not manage or promote
+      unlisted benchmarks.
+    - Distinct from `staged`: `staged` is stored locally in the browser
+      (IndexedDB), whereas `unlisted` lives in Prism's cloud storage backend.
 - **`public`** (Public):
     - All reviews done, benchmark now public in the sea of benchmarks.
     - **UNCLEAR:** Clean way to show potentially thousands of benchmarks, Manage
@@ -170,9 +189,14 @@ environment:
       benchmark results have been included in said well-lit path’s results.
     - Implies additional visibility from just sea of benchmarks.
 - **`rejected`** (Rejected):
-    - Explicitly rejected by an administrator during human review (`submitted_pending_review` -> `rejected`), with optional rejection reason attached.
+    - Explicitly rejected by an administrator during human review
+      (`submitted_pending_review` -> `rejected`), with optional rejection reason
+      attached.
     - Deleted off cloud when purged by admin.
-    - **Note:** Automated validation failures on upload do NOT transition items to `rejected`. Instead, invalid uploads are completely dropped/deleted from cloud storage, returning an HTTP 400 validation error to the submitter without populating the rejected queue.
+    - **Note:** Automated validation failures on upload do NOT transition items
+      to `rejected`. Instead, invalid uploads are completely dropped/deleted
+      from cloud storage, returning an HTTP 400 validation error to the
+      submitter without populating the rejected queue.
 
 ### 6.2 State Transitions
 
@@ -180,8 +204,10 @@ environment:
 stateDiagram-v2
     [*] --> staged : Local Upload
     staged --> submitted_pending_processing : Submit (Requires GitHub Auth)
-    submitted_pending_processing --> submitted_pending_review : Auto-Validation Pass
+    submitted_pending_processing --> unlisted : Auto-Validation Pass (Target: Unlisted)
+    submitted_pending_processing --> submitted_pending_review : Auto-Validation Pass (Target: Public Review)
     submitted_pending_processing --> [*] : Auto-Validation Fail (Dropped)
+    unlisted --> submitted_pending_review : Submitting User (Owner) Promotes to Review
     submitted_pending_review --> public : Admin Approved
     submitted_pending_review --> rejected : Admin Rejected
     public --> promoted : Selected for Well-Lit Path
@@ -191,7 +217,16 @@ stateDiagram-v2
     - `staged`: Open to all (no login required).
     - `submitted_pending_processing`: Requires GitHub OAuth. Only allowlisted
       users can submit.
-    - `submitted_pending_review` -> `public`: Requires Admin privileges.
+    - `unlisted`: Skips human review. Readable by everyone (not secret), but
+      hidden by default from public explore unless queried explicitly or
+      accessed via share link. For full design details, see
+      [unlisted-benchmarks-spec.md](../../changes/unlisted-benchmarks-spec.md).
+    - `unlisted` -> `submitted_pending_review`: Performed exclusively by the
+      **submitting user (owner)** when ready to submit for public review.
+    - `submitted_pending_review`: Visible only to **Admins** (all pending runs)
+      and the **submitting owner** (their own pending runs).
+    - `submitted_pending_review` -> `public` / `rejected`: Requires Admin
+      privileges.
 
 ### 6.3 Synchronous vs. Asynchronous Validation
 
@@ -202,14 +237,17 @@ early beta:
 1. **Synchronous Execution**: The backend web server runs the validation logic
    synchronously inside the request lifecycle immediately after the raw upload
    is staged in GCS.
-2. **Immediate Promotion**: If validation passes, the run is directly promoted
-   to `submitted_pending_review`. If validation fails, the item is completely
-   dropped/deleted from cloud storage and an HTTP 400 error is returned to
-   the client. The `rejected` queue is reserved exclusively for manual admin rejections.
+2. **Immediate Promotion / Unlisting**: If validation passes, the run is
+   promoted to either `unlisted` or `submitted_pending_review` depending on the
+   submitter's selected visibility mode (`targetState`). If validation fails,
+   the item is completely dropped/deleted from cloud storage and an HTTP 400
+   error is returned to the client. The `rejected` queue is reserved exclusively
+   for manual admin rejections.
 3. **Future Decoupling**: The processing wrapper is fully decoupled. In the
    future, the synchronous invocation can be removed in favor of an asynchronous
    background worker (e.g., GCS Object Eventarc trigger or Pub/Sub pull worker
-   calling the same processing library).
+   calling the same processing library). background worker (e.g., GCS Object
+   Eventarc trigger or Pub/Sub pull worker calling the same processing library).
 
 ---
 
@@ -258,16 +296,16 @@ to allow listing and filtering without reading the file contents.
 - **Maximum Contexts:** 50 keys per object.
 - **Custom Metadata Contexts:**
 
-| GCS Context Key    | Required | Base64url Encoded? (Prefix `e`) | Description                                                                    |
-| :----------------- | :------- | :------------------------------ | :----------------------------------------------------------------------------- |
-| `submission_state` | Yes      | **No**                          | The submission status (e.g. `public`, `rejected`, `submitted_pending_review`). |
-| `github_user`      | Yes      | **No**                          | The GitHub username of the contributor (for attribution).                      |
-| `run_id`           | Yes      | **No**                          | The unique run identifier (UUIDv4).                                            |
-| `hardware_name`    | No       | **Yes**                         | Normalized accelerator name (e.g. `TPU v6e`).                                  |
-| `model_name`       | No       | **Yes**                         | Normalized model name (e.g. `meta-llama/Llama-3-8B-Instruct`).                 |
-| `run_label`        | No       | **Yes**                         | Human-friendly run description label.                                          |
-| `feedback`         | No       | **Yes**                         | Feedback reason for rejection/changes requested.                               |
-| `well_lit_path`    | No       | **Yes**                         | Selected "Well-Lit Path" optimization classification.                          |
+| GCS Context Key    | Required | Base64url Encoded? (Prefix `e`) | Description                                                                                |
+| :----------------- | :------- | :------------------------------ | :----------------------------------------------------------------------------------------- |
+| `submission_state` | Yes      | **No**                          | The submission status (e.g. `public`, `unlisted`, `rejected`, `submitted_pending_review`). |
+| `github_user`      | Yes      | **No**                          | The GitHub username of the contributor (for attribution).                                  |
+| `run_id`           | Yes      | **No**                          | The unique run identifier (UUIDv4).                                                        |
+| `hardware_name`    | No       | **Yes**                         | Normalized accelerator name (e.g. `TPU v6e`).                                              |
+| `model_name`       | No       | **Yes**                         | Normalized model name (e.g. `meta-llama/Llama-3-8B-Instruct`).                             |
+| `run_label`        | No       | **Yes**                         | Human-friendly run description label.                                                      |
+| `feedback`         | No       | **Yes**                         | Feedback reason for rejection/changes requested.                                           |
+| `well_lit_path`    | No       | **Yes**                         | Selected "Well-Lit Path" optimization classification.                                      |
 
 ### 7.4 GCS Listing & Pagination Strategy (Logical Operator Workaround)
 
@@ -281,11 +319,14 @@ constraint while keeping GCS-side filtering fast and optimized:
    `contexts."submission_state"="public"`), letting the GCS server perform the
    filtering.
 2. **Client-Side Split-Listing Strategy:** To display a unified dashboard with
-   both the user's own benchmarks (staged/pending/processing/etc.) and public
-   approved benchmarks:
+   both the user's own benchmarks (staged/unlisted/pending/processing/etc.) and
+   public approved benchmarks:
     - The frontend client fires two separate listing requests to the backend
       with separate query params and pagination strings (e.g. one for `own=true`
       and another for `status=public` / `status=promoted`).
+    - Unlisted benchmarks belonging to other users are excluded from standard
+      public listing requests (`status=public`), but can be retrieved directly
+      by their UUID via `GET /api/results/:runId`.
     - The frontend displays the user's own benchmarks on top. It lists the
       current user's benchmarks until exhausted, then paginates/transitions to
       listing the public ones.

--- a/specs/main/completed/results-api/frontend.md
+++ b/specs/main/completed/results-api/frontend.md
@@ -67,8 +67,11 @@ pipeline status:
   public runs, allowing advanced client-side filters (e.g., Model, Hardware, TP,
   Accelerator Count) to apply seamlessly. KPI cards at the top of the Results
   Store page allow users to quickly filter the table by submission state
-  (`Staged`, `Under Review` / `Processing`, `In Review`, `Approved` / `Public`,
-  `Action Required` / `Rejected`). The `Rejected` state is reserved for runs explicitly rejected by administrators during review; uploads failing automated validation are dropped directly without populating the rejected queue.
+  (`Staged`, `Unlisted`, `Under Review` / `Processing`, `In Review`, `Approved`
+  / `Public`, `Action Required` / `Rejected`). The `Rejected` state is reserved
+  for runs explicitly rejected by administrators during review; uploads failing
+  automated validation are dropped directly without populating the rejected
+  queue.
 
 ---
 
@@ -219,16 +222,20 @@ full-page wizard supporting two distinct intents (`stage-locally` or
     - Renders the **Developer Certificate of Origin (DCO) v1.1**.
     - Requires checking a checkbox to sign off and agree to public attribution
       and cloud storage.
+    - **Visibility Selection:** Allows selecting target visibility mode
+      (`Save as Unlisted` vs `Submit for Public Review`).
     - Allows comma-separated assignment of GitHub usernames as reviewers.
 4. **Submit & Confirm:**
-    - Shows a summary of valid runs, user attribution, and DCO confirmation.
+    - Shows a summary of valid runs, user attribution, selected visibility mode
+      (`unlisted` or `submitted_pending_review`), and DCO confirmation.
     - Displays a warning about pull-request style maintenance checks.
-    - Clicking **Submit to Review Queue** posts sequential runs to
-      `/api/results` via the client.
+    - Clicking **Submit** posts sequential runs to `/api/results` via the client
+      with the chosen `targetState`.
     - On completion, it re-keys staged run IDs to server-assigned UUIDs,
       triggers a success toast, sets the `submitted` status for the post-upload
-      guided actions dialog, and redirects to the Results Store with the
-      `my-submissions` KPI filter active.
+      guided actions dialog (providing direct share links for `unlisted` runs),
+      and redirects to the Results Store with the `my-submissions` KPI filter
+      active.
 
 ### 4.3 Post-Upload Guided Action Dialog
 

--- a/specs/main/completed/results-api/routes.md
+++ b/specs/main/completed/results-api/routes.md
@@ -82,44 +82,53 @@ Lists benchmark runs from the active Prism results store (defined in
     - `pageToken`: (Optional) Pagination token retrieved from the
       `nextPageToken` of a prior list response.
     - `status`: (Optional) Filter by submission status (`staged` |
-      `submitted_pending_processing` | `submitted_pending_review` | `public` |
-      `promoted` | `rejected`).
+      `submitted_pending_processing` | `unlisted` | `submitted_pending_review` |
+      `public` | `promoted` | `rejected`).
     - `own`: (Optional) Filter to retrieve only the logged-in user's submissions
       (`true` | `false`).
-- **Authorization Rules:**
-    - **Admin:** Can list all benchmarks in all statuses.
+- **Authorization & Default Visibility Rules:**
+    - **Admin:** Can list benchmarks in all statuses (including all
+      `submitted_pending_review` items in the review queue).
     - **Standard User/Guest:**
-        - Can list their own benchmarks in any status.
-        - Can only list approved (`public` or `promoted`) benchmarks of other
-          users.
-        - Pending or rejected benchmarks belonging to other users are filtered
-          out.
+        - Can list their own benchmarks in any status (including `unlisted` and
+          their own `submitted_pending_review` runs).
+        - Can list `public` or `promoted` benchmarks.
+        - Can list `unlisted` benchmarks when explicitly querying
+          `status=unlisted` (unlisted is not secret, but hidden by default from
+          general search calls).
+        - `submitted_pending_review` benchmarks belonging to _other_ users are
+          restricted to Admins only and are filtered out.
 
 ### `POST /api/results`
 
 Submits a benchmark result bundle to the active results store.
 
 - **Headers:** `X-Prism-Github-Token: <access_token>` (required)
+- **Query Parameters / Body Field:**
+    - `targetState`: (Optional) `"unlisted"` | `"submitted_pending_review"`
+      (defaults to `"submitted_pending_review"`).
+        - `"unlisted"`: Benchmarks skip human review and transition straight
+          from automated processing to `unlisted`. Useful for preliminary or
+          unverified data playgrounds.
+        - `"submitted_pending_review"`: Benchmarks pass automated processing and
+          are queued for Admin human review.
 - **Request Body:** A JSON object representing the benchmark run upload payload
   matching the `PrismResultPayload` schema.
 - **Authorization Rules:** Only allowlisted contributors (with role `user` or
   `admin`) can submit benchmark results.
-- **Server-Side ID Mutation:** All internal IDs (including the top-level `runId`
-  and nested entry `run_id`s) are regenerated on the server to prevent ID
-  collisions. The metadata is also enriched with the author's username and
-  submission timestamp.
+- **Server-Side ID Mutation:** All internal IDs (including top-level `runId` and
+  nested entry `run_id`s) are regenerated on the server to prevent ID
+  collisions.
 - **Validation Failures:** If automated validation fails during processing, the
-  endpoint returns `400 Bad Request` with error details and warnings. The
-  submission is dropped completely and is NOT placed in the `rejected` queue or
-  saved in cloud storage.
+  endpoint returns `400 Bad Request`.
 - **Response (201 Created):**
     ```json
     {
         "success": true,
         "runId": "<server_generated_run_id>",
         "oldRunId": "<client_supplied_run_id>",
-        "state": "submitted_pending_review",
-        "message": "Benchmark result successfully submitted and promoted to review."
+        "state": "unlisted" | "submitted_pending_review",
+        "message": "Benchmark result successfully processed and saved."
     }
     ```
 
@@ -129,21 +138,22 @@ Retrieves the complete payload of a single benchmark submission run bundle by
 its UUID.
 
 - **Headers:** `X-Prism-Github-Token: <access_token>` (optional)
-- **Path Validation:** `runId` must be a valid UUID regex format or it returns
-  `400 Bad Request` to prevent path traversal.
+- **Path Validation:** `runId` must be a valid UUID regex format.
 - **Authorization Rules:**
     - **Admin:** Full access to view any benchmark bundle.
     - **Standard User/Guest:**
         - Can view their own benchmark run bundle in any state.
-        - Can view other contributors' bundles only if its state is `public` or
-          `promoted`.
-        - Returns `403 Forbidden` (or `404 Not Found`) if the user lacks
-          permissions.
+        - Can view other contributors' bundles if state is `public`, `promoted`,
+          OR `unlisted` (unlisted runs are accessible via direct link/UUID
+          lookup).
+        - Returns `403 Forbidden` (or `404 Not Found`) for
+          `submitted_pending_processing`, `submitted_pending_review`, or
+          `rejected` items belonging to other users.
 
 ### `POST /api/results/:runId/status`
 
-Updates the review status and/or registers admin feedback for a staged or
-pending benchmark result submission.
+Updates the review status and/or registers admin feedback for a benchmark result
+submission.
 
 - **Headers:** `X-Prism-Github-Token: <access_token>` (required)
 - **Request Body:**
@@ -154,35 +164,44 @@ pending benchmark result submission.
         "reviewer": "<optional_username>"
     }
     ```
-- **Authorization Rules:**
-    - **Admin:** Full access. Can approve (`public` / `promoted`), reject
-      (`rejected`), or reset state.
-    - **Contributor (Owner):** Can only transition state to
-      `submitted_pending_processing` or `submitted_pending_review` to promote or
-      resubmit their own benchmark. Any attempt to set state to `public` or
-      `rejected` returns `403 Forbidden`. Rejections are reserved exclusively
-      for administrators.
+- **Authorization & State Machine Rules:**
+    - **Admin:** Can approve (`public` / `promoted`), reject (`rejected`), or
+      reset review queue state. Optional `feedback` and `reviewer` fields are
+      recorded in the review history. Admins do not manage or promote unlisted
+      benchmarks.
+    - **Submitting User (Owner):** Can promote their own benchmark from
+      `unlisted` $\rightarrow$ `submitted_pending_review` via a single-click
+      action ("Promote to Review").
+        - **Field Restrictions:** When promoting from `unlisted` $\rightarrow$
+          `submitted_pending_review`, `feedback` and `reviewer` fields are
+          **unused and forbidden**. Sending `feedback` or `reviewer` in the
+          request body returns `400 Bad Request`.
+        - Any attempt by non-admins to set state to `public` or `rejected`
+          returns `403 Forbidden`.
     - **Other users:** `403 Forbidden`.
 
 ### `DELETE /api/results/:runId`
 
-Permanently deletes a rejected benchmark result bundle from the GCS Results
-Store.
+Permanently deletes an unlisted or rejected benchmark result bundle from the GCS
+Results Store.
 
 - **Headers:** `X-Prism-Github-Token: <access_token>` (required)
 - **Path Validation:** `runId` must be a valid UUID regex format or it returns
   `400 Bad Request`.
 - **Authorization Rules:**
-    - **Admin:** Allowed ONLY if the benchmark's current submission state is
-      `rejected`. Any attempt to delete benchmarks in non-rejected states
-      (`staged`, `submitted_pending_processing`, `submitted_pending_review`,
-      `public`, `promoted`) returns `403 Forbidden`.
-    - **Non-Admin Users / Guests:** `403 Forbidden`.
+    - **Submitting User (Owner):** Can permanently delete their own benchmark if
+      its current state is `unlisted`. Attempts to delete items in non-unlisted
+      states return `403 Forbidden`.
+    - **Admin:** Can permanently delete any benchmark whose state is `unlisted`
+      or `rejected`. Any attempt to delete benchmarks in active public or review
+      states (`staged`, `submitted_pending_processing`,
+      `submitted_pending_review`, `public`, `promoted`) returns `403 Forbidden`.
+    - **Other users:** `403 Forbidden`.
 - **Response (200 OK):**
     ```json
     {
         "success": true,
-        "message": "Rejected benchmark <runId> successfully deleted."
+        "message": "Benchmark <runId> successfully deleted."
     }
     ```
 

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -126,6 +126,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
     const [dcoSigned, setDcoSigned] = useState(false);
     const [selectedReviewers, setSelectedReviewers] = useState([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
+    const [targetVisibility, setTargetVisibility] = useState('submitted_pending_review');
     const [comparingBundleId, setComparingBundleId] = useState(null);
 
     const [localModelFilter, setLocalModelFilter] = useState('all');
@@ -1327,7 +1328,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
         }
     };
 
-    const handleSubmit = async () => {
+    const handleSubmit = async (targetState = 'submitted_pending_review') => {
         const validBundles = stagedFiles.filter(b => !b.isSkipped && b.validation.format && b.validation.errors.length === 0);
         if (validBundles.length === 0) return;
         
@@ -1395,7 +1396,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     throw new Error(errorMsg);
                 }
 
-                const res = await fetch('/api/results', {
+                const res = await fetch(`/api/results?targetState=${encodeURIComponent(targetState)}`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
@@ -1418,22 +1419,29 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                 }
             }
 
-            if (addToast) addToast("Benchmark submissions submitted successfully for review!", "success");
+            if (addToast) {
+                addToast(
+                    targetState === 'unlisted'
+                        ? "Benchmark saved as unlisted!"
+                        : "Benchmark submissions submitted successfully for review!",
+                    "success"
+                );
+            }
             
             // Refresh submissions list in main dashboard
             if (loadSubmissions) {
-                loadSubmissions(true);
+                await loadSubmissions(true);
             }
 
-            // Force refetch database so newly submitted benchmarks in GCS are loaded immediately
+            // Refetch full database in the background without blocking navigation
             if (loadAllData) {
-                await loadAllData(null, true);
+                loadAllData(null, true).catch(err => console.error("Error refreshing background data:", err));
             }
 
             // Close and reset
             resetWizard();
             localStorage.setItem('prism_activate_my_submissions_filter', 'true');
-            localStorage.setItem('prism_show_post_upload_dialog', 'submitted');
+            localStorage.setItem('prism_show_post_upload_dialog', targetState === 'unlisted' ? 'unlisted' : 'submitted');
             if (onNavigate) {
                 onNavigate('results-store');
             } else if (onNavigateBack) {
@@ -1631,6 +1639,65 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                         <Check size={13} className="text-emerald-500" /> Signed and Verified
                                     </span>
                                 </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    {/* Visibility Selection Section */}
+                    <div className="bg-slate-950/40 rounded-2xl border border-slate-900/80 p-5 space-y-3 shadow-inner">
+                        <div>
+                            <h4 className="text-xs font-bold text-slate-200 uppercase tracking-wider">Benchmark Visibility</h4>
+                            <p className="text-[11px] text-slate-400 mt-0.5">Select the visibility and publishing workflow for this submission.</p>
+                        </div>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 pt-1">
+                            <div 
+                                onClick={() => setTargetVisibility('submitted_pending_review')}
+                                className={`p-3.5 rounded-xl border cursor-pointer transition-all ${
+                                    targetVisibility === 'submitted_pending_review'
+                                    ? 'bg-emerald-500/10 border-emerald-500/50 shadow-[0_0_15px_rgba(16,185,129,0.1)]'
+                                    : 'bg-slate-900/40 border-slate-800/80 hover:border-slate-700'
+                                }`}
+                            >
+                                <div className="flex items-center justify-between mb-1">
+                                    <span className="text-xs font-bold text-emerald-400">
+                                        Public Review
+                                    </span>
+                                    <input 
+                                        type="radio" 
+                                        name="visibility" 
+                                        checked={targetVisibility === 'submitted_pending_review'} 
+                                        onChange={() => setTargetVisibility('submitted_pending_review')}
+                                        className="accent-emerald-500 cursor-pointer"
+                                    />
+                                </div>
+                                <p className="text-[10px] text-slate-400 leading-normal">
+                                    Submits to the maintainer review queue for formal verification and publishing on the global grid.
+                                </p>
+                            </div>
+
+                            <div 
+                                onClick={() => setTargetVisibility('unlisted')}
+                                className={`p-3.5 rounded-xl border cursor-pointer transition-all ${
+                                    targetVisibility === 'unlisted'
+                                    ? 'bg-cyan-500/10 border-cyan-500/50 shadow-[0_0_15px_rgba(6,182,212,0.1)]'
+                                    : 'bg-slate-900/40 border-slate-800/80 hover:border-slate-700'
+                                }`}
+                            >
+                                <div className="flex items-center justify-between mb-1">
+                                    <span className="text-xs font-bold text-cyan-400">
+                                        Unlisted
+                                    </span>
+                                    <input 
+                                        type="radio" 
+                                        name="visibility" 
+                                        checked={targetVisibility === 'unlisted'} 
+                                        onChange={() => setTargetVisibility('unlisted')}
+                                        className="accent-cyan-500 cursor-pointer"
+                                    />
+                                </div>
+                                <p className="text-[10px] text-slate-400 leading-normal">
+                                    Experimental runs that haven't been reviewed yet.
+                                </p>
                             </div>
                         </div>
                     </div>
@@ -3040,15 +3107,24 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                     </span>
                                 )}
                                 <button 
-                                    onClick={handleSubmit}
+                                    onClick={() => handleSubmit(targetVisibility)}
                                     disabled={isSubmitting || user?.permission === 'none'}
                                     className={`px-5 py-2 text-xs font-bold rounded-xl flex items-center gap-1.5 transition-all ${
                                         isSubmitting || user?.permission === 'none'
                                         ? 'bg-slate-900/40 text-slate-500 border border-slate-900/50 cursor-not-allowed opacity-50 shadow-none'
+                                        : targetVisibility === 'unlisted'
+                                        ? 'bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-500 hover:to-blue-500 text-white shadow-md hover:shadow-cyan-500/10 cursor-pointer border border-cyan-500/20'
                                         : 'bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-500 hover:to-teal-500 text-white shadow-md hover:shadow-emerald-500/10 cursor-pointer border border-emerald-500/20'
                                     }`}
                                 >
-                                    {isSubmitting ? <Spinner size="xs" className="text-white dark:text-white" /> : <Check size={14} />} Submit to Review Queue
+                                    {isSubmitting ? (
+                                        <Spinner size="xs" className="text-white dark:text-white" />
+                                    ) : targetVisibility === 'unlisted' ? (
+                                        <UploadCloud size={14} />
+                                    ) : (
+                                        <Check size={14} />
+                                    )}
+                                    {targetVisibility === 'unlisted' ? 'Save as Unlisted' : 'Submit for Public Review'}
                                 </button>
                             </div>
                         )}

--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -62,6 +62,7 @@ const getKpiFilterLabel = (filter) => {
     switch (filter) {
         case 'my-submissions': return 'My Benchmarks';
         case 'staged': return 'Locally Staged';
+        case 'unlisted': return 'Unlisted';
         case 'processing': return 'Processing';
         case 'in_review': return 'Under Review';
         case 'approved': return 'Published';
@@ -98,6 +99,7 @@ export const FilterPanel = ({
     isLoadingSubmissions = false,
     loadSubmissions,
     searchTerm, setSearchTerm, kpiFilter, setKpiFilter,
+    includeUnlisted = false, setIncludeUnlisted,
     updateSubmissionStatus,
     bulkUpdateSubmissionStatus,
     deleteSubmission,
@@ -419,6 +421,7 @@ export const FilterPanel = ({
 
     const statusCounts = React.useMemo(() => {
         let staged = 0;
+        let unlisted = 0;
         let processing = 0;
         let inReview = 0;
         let approved = 0;
@@ -439,6 +442,7 @@ export const FilterPanel = ({
                 const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
                 
                 if (status === 'staged') staged++;
+                else if (status === 'unlisted') unlisted++;
                 else if (status === 'submitted_pending_processing' || status === 'processing') processing++;
                 else if (status === 'submitted_pending_review' || status === 'in_review') inReview++;
                 else if (status === 'public' || status === 'promoted' || status === 'approved') approved++;
@@ -446,7 +450,7 @@ export const FilterPanel = ({
             }
         });
 
-        return { staged, processing, inReview, approved, rejected };
+        return { staged, unlisted, processing, inReview, approved, rejected };
     }, [modelStats, submissionsMap, user]);
 
     const allRuns = React.useMemo(() => {
@@ -575,6 +579,7 @@ export const FilterPanel = ({
                 setSearchTerm={setSearchTerm}
                 kpiFilter={kpiFilter}
                 setKpiFilter={setKpiFilter}
+                includeUnlisted={includeUnlisted}
                 paretoKeys={paretoKeys}
                 submissionsMap={submissionsMap}
                 isLoadingSubmissions={isLoadingSubmissions}
@@ -594,7 +599,7 @@ export const FilterPanel = ({
         setActiveFilters, expandedModels, toggleBenchmark, toggleModelExpansion, baselineBenchmarkKey,
         setBaselineBenchmarkKey, hideShowSelectedOnly, renameClearToUnselectAll, brv02Runs, brv02CustomLabels,
         setBrv02CustomLabels, removeBrv02Run, setShowDataPanel, searchTerm, setSearchTerm, kpiFilter,
-        setKpiFilter, paretoKeys, submissionsMap, isLoadingSubmissions, updateSubmissionStatus,
+        setKpiFilter, includeUnlisted, paretoKeys, submissionsMap, isLoadingSubmissions, updateSubmissionStatus,
         bulkUpdateSubmissionStatus, deleteSubmission, onOpenSubmitDialog, hasFiltersToSave, loadAllData, loadingConnections,
         dashboardState, defaultSources
     ]);
@@ -681,7 +686,7 @@ export const FilterPanel = ({
                                     const isMySubmissionsActive = kpiFilter === 'my-submissions' || ['staged', 'processing', 'in_review', 'approved', 'action'].includes(kpiFilter);
                                     
                                     if (isMySubmissionsActive) {
-                                        const { staged, processing, inReview, approved, rejected } = statusCounts;
+                                        const { staged, unlisted, processing, inReview, approved, rejected } = statusCounts;
                                         
                                         return (
                                             <div className="flex-1 flex flex-col justify-between bg-slate-900/40 border border-slate-900/80 px-3 py-2 rounded-xl">
@@ -704,6 +709,25 @@ export const FilterPanel = ({
                                                         <div className="flex flex-col items-start leading-none text-left">
                                                             <span className="text-[8px] font-bold uppercase text-slate-400/90 tracking-wider">Staged</span>
                                                             <span className={cn('text-xs md:text-sm font-extrabold mt-0.5 transition-colors duration-200', kpiFilter === 'staged' ? 'text-amber-400 font-black' : 'text-slate-200')}>{staged}</span>
+                                                        </div>
+                                                    </button>
+
+                                                    <ArrowRight className="w-3 h-3 text-slate-800 shrink-0" />
+
+                                                    {/* Step 1b: Unlisted */}
+                                                    <button 
+                                                        onClick={() => setKpiFilter(kpiFilter === 'unlisted' ? 'my-submissions' : 'unlisted')}
+                                                        className={cn(
+                                                            'relative flex-1 flex items-center pl-3 pr-2 py-1 rounded-md border transition-all duration-300 cursor-pointer overflow-hidden',
+                                                            kpiFilter === 'unlisted'
+                                                            ? 'bg-cyan-500/5 border-cyan-500/35 shadow-[0_0_12px_rgba(6,182,212,0.08)] -translate-y-0.5'
+                                                            : 'bg-slate-900/25 border-transparent hover:border-slate-800/60 hover:bg-slate-900/40 hover:-translate-y-0.5'
+                                                        )}
+                                                    >
+                                                        <div className={cn('absolute left-0 top-1 bottom-1 w-0.5 rounded-r transition-all duration-300', kpiFilter === 'unlisted' ? 'bg-cyan-400 h-6' : 'bg-cyan-500/55')} />
+                                                        <div className="flex flex-col items-start leading-none text-left">
+                                                            <span className="text-[8px] font-bold uppercase text-slate-400/90 tracking-wider">Unlisted</span>
+                                                            <span className={cn('text-xs md:text-sm font-extrabold mt-0.5 transition-colors duration-200', kpiFilter === 'unlisted' ? 'text-cyan-400 font-black' : 'text-slate-200')}>{unlisted}</span>
                                                         </div>
                                                     </button>
 
@@ -790,46 +814,86 @@ export const FilterPanel = ({
                                     } else {
                                         // Public Store Selected
                                         return (
-                                            <div className="flex-1 flex flex-row items-center justify-between bg-slate-900/40 border border-slate-900/80 px-4 py-2 rounded-xl select-none">
-                                                <div className="flex flex-col justify-center">
-                                                    <span className="text-[10px] font-bold text-slate-400/95 uppercase tracking-wider leading-none">Public Store Analytics</span>
-                                                    <span className="text-[10px] text-slate-500 mt-1.5 leading-none">Submission activity (last 15 days)</span>
-                                                </div>
-                                                
-                                                <div className="flex items-center gap-4">
-                                                    {sparklinePath ? (
-                                                        <div className="flex flex-col items-end">
-                                                            <svg width="140" height="24" className="overflow-visible">
-                                                                <path
-                                                                    d={sparklinePath}
-                                                                    fill="none"
-                                                                    stroke="#06b6d4"
-                                                                    strokeWidth="1.5"
-                                                                    strokeLinecap="round"
-                                                                    strokeLinejoin="round"
-                                                                />
-                                                                <path
-                                                                    d={`${sparklinePath} L 140 24 L 0 24 Z`}
-                                                                    fill="url(#sparkline-grad)"
-                                                                    stroke="none"
-                                                                />
-                                                                <defs>
-                                                                    <linearGradient id="sparkline-grad" x1="0" y1="0" x2="0" y2="1">
-                                                                        <stop offset="0%" stopColor="#06b6d4" stopOpacity="0.15" />
-                                                                        <stop offset="100%" stopColor="#06b6d4" stopOpacity="0.0" />
-                                                                    </linearGradient>
-                                                                </defs>
-                                                            </svg>
-                                                        </div>
-                                                    ) : (
-                                                        <span className="text-[10px] text-slate-600">No recent activity</span>
-                                                    )}
+                                            <div className="flex-1 flex flex-row items-stretch gap-3 select-none">
+                                                {/* Pane 1: Public Store Analytics */}
+                                                <div className="flex-1 flex flex-row items-center justify-between bg-slate-900/40 border border-slate-900/80 px-4 py-2 rounded-xl">
+                                                    <div className="flex flex-col justify-center">
+                                                        <span className="text-[10px] font-bold text-slate-400/95 uppercase tracking-wider leading-none">Public Store Analytics</span>
+                                                        <span className="text-[10px] text-slate-500 mt-1.5 leading-none">Submission activity (last 15 days)</span>
+                                                    </div>
                                                     
-                                                    <div className="flex flex-col items-end border-l border-slate-800/80 pl-4 h-9 justify-center">
-                                                        <span className="text-[8px] font-bold text-slate-500 uppercase tracking-wider leading-none">Total Runs</span>
-                                                        <span className="text-base font-black text-cyan-400 mt-1 leading-none">{totalCount}</span>
+                                                    <div className="flex items-center gap-4">
+                                                        {sparklinePath ? (
+                                                            <div className="flex flex-col items-end">
+                                                                <svg width="140" height="24" className="overflow-visible">
+                                                                    <path
+                                                                        d={sparklinePath}
+                                                                        fill="none"
+                                                                        stroke="#06b6d4"
+                                                                        strokeWidth="1.5"
+                                                                        strokeLinecap="round"
+                                                                        strokeLinejoin="round"
+                                                                    />
+                                                                    <path
+                                                                        d={`${sparklinePath} L 140 24 L 0 24 Z`}
+                                                                        fill="url(#sparkline-grad)"
+                                                                        stroke="none"
+                                                                    />
+                                                                    <defs>
+                                                                        <linearGradient id="sparkline-grad" x1="0" y1="0" x2="0" y2="1">
+                                                                            <stop offset="0%" stopColor="#06b6d4" stopOpacity="0.15" />
+                                                                            <stop offset="100%" stopColor="#06b6d4" stopOpacity="0.0" />
+                                                                        </linearGradient>
+                                                                    </defs>
+                                                                </svg>
+                                                            </div>
+                                                        ) : (
+                                                            <span className="text-[10px] text-slate-600">No recent activity</span>
+                                                        )}
+                                                        
+                                                        <div className="flex flex-col items-end border-l border-slate-800/80 pl-4 h-9 justify-center">
+                                                            <span className="text-[8px] font-bold text-slate-500 uppercase tracking-wider leading-none">Total Runs</span>
+                                                            <span className="text-base font-black text-cyan-400 mt-1 leading-none">{totalCount}</span>
+                                                        </div>
                                                     </div>
                                                 </div>
+
+                                                {/* Pane 2: Standalone Unlisted Pane */}
+                                                <button
+                                                    onClick={() => setIncludeUnlisted ? setIncludeUnlisted(prev => !prev) : null}
+                                                    className={cn(
+                                                        "flex flex-col justify-between px-4 py-3 rounded-xl border text-left transition-all duration-300 cursor-pointer select-none min-w-[195px]",
+                                                        includeUnlisted
+                                                        ? "bg-slate-900 border-cyan-500/50 shadow-[0_0_12px_rgba(6,182,212,0.15)]"
+                                                        : "bg-slate-900/40 border-slate-900/80 hover:border-slate-800/80 hover:bg-slate-800/40"
+                                                    )}
+                                                    title="Toggle unlisted benchmarks inclusion"
+                                                >
+                                                    <div className="flex flex-col justify-center">
+                                                        <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400/95 leading-none">
+                                                            Show Unlisted
+                                                        </span>
+                                                        <span className="text-[10px] text-slate-500 mt-1.5 leading-none">
+                                                            Experimental runs not reviewed yet
+                                                        </span>
+                                                    </div>
+                                                    
+                                                    <div className="pt-2 flex items-center justify-between border-t border-slate-800/60 mt-2.5">
+                                                        <span className={cn("text-[9px] font-bold uppercase tracking-wider", includeUnlisted ? "text-cyan-400" : "text-slate-500")}>
+                                                            {includeUnlisted ? "Included" : "Hidden"}
+                                                        </span>
+                                                        
+                                                        <div className={cn(
+                                                            "w-7 h-4 rounded-full p-0.5 transition-colors duration-200 ease-in-out flex items-center",
+                                                            includeUnlisted ? "bg-cyan-500 shadow-[0_0_8px_rgba(6,182,212,0.4)]" : "bg-slate-800 border border-slate-700/60"
+                                                        )}>
+                                                            <div className={cn(
+                                                                "w-3 h-3 rounded-full shadow-md transform transition-transform duration-200 ease-in-out",
+                                                                includeUnlisted ? "translate-x-3 bg-slate-950" : "translate-x-0 bg-slate-400"
+                                                            )} />
+                                                        </div>
+                                                    </div>
+                                                </button>
                                             </div>
                                         );
                                     }

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -46,6 +46,14 @@ const getCardStatusAccent = (isBrv02, runId, submissionsMap, gcsStatus = null) =
             accentBar: <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-amber-500 z-10" />
         };
     }
+
+    if (status === 'unlisted') {
+        return {
+            borderClass: 'border-cyan-500/30 dark:border-cyan-500/20 hover:border-cyan-400/50',
+            bgClass: 'bg-cyan-500/[0.02]',
+            accentBar: <div className="absolute left-0 top-0 bottom-0 w-1.5 bg-cyan-500 z-10" />
+        };
+    }
     
     if (status === 'submitted_pending_processing' || status === 'submitted_pending_review' || status === 'in_review') {
         return {
@@ -82,6 +90,7 @@ const getKpiFilterLabel = (filter) => {
         case 'my-submissions': return 'My Benchmarks';
         case 'verified': return 'Production Ready';
         case 'staged': return 'Locally Staged';
+        case 'unlisted': return 'Unlisted';
         case 'processing': return 'Processing';
         case 'in_review': return 'Under Review';
         case 'approved': return 'Published';
@@ -94,7 +103,7 @@ const getKpiFilterLabel = (filter) => {
 };
 
 export const UnifiedDataTable = (props) => {
-    const { dashboardState } = props;
+    const { dashboardState, includeUnlisted = false } = props;
     const { user } = useGitHubAuth();
     const isAdmin = user?.permission === 'admin';
         const [rawYamlContent, setRawYamlContent] = useState(null);
@@ -725,6 +734,23 @@ export const UnifiedDataTable = (props) => {
             stats = stats.filter(stat => selectedBenchmarks.has(stat.benchmarkKey));
         }
 
+        // Default Public Store view (kpiFilter === null)
+        if (kpiFilter === null) {
+            if (!includeUnlisted) {
+                stats = stats.filter(stat => {
+                    const firstEntry = stat.data?.[0];
+                    if (!firstEntry) return true;
+                    const src = firstEntry.source || '';
+                    const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
+                    if (!isBrv02) return true;
+                    const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
+                    const sub = runId && submissionsMap ? submissionsMap[runId] : null;
+                    const status = sub?.status || firstEntry.source_info?.submission_state;
+                    return status !== 'unlisted';
+                });
+            }
+        }
+
         // Apply KPI Filter
         if (kpiFilter === 'my-submissions') {
             stats = stats.filter(stat => {
@@ -753,6 +779,20 @@ export const UnifiedDataTable = (props) => {
                 const sub = runId && submissionsMap ? submissionsMap[runId] : null;
                 const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
                 return isMine && status === 'staged';
+            });
+        } else if (kpiFilter === 'unlisted') {
+            // Filter inside My Benchmarks: filter user's submissions strictly for unlisted status
+            stats = stats.filter(stat => {
+                const firstEntry = stat.data?.[0];
+                if (!firstEntry) return false;
+                const src = firstEntry.source || '';
+                const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
+                if (!isBrv02) return false;
+                const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
+                const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
+                const sub = runId && submissionsMap ? submissionsMap[runId] : null;
+                const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
+                return isMine && status === 'unlisted';
             });
         } else if (kpiFilter === 'processing') {
             stats = stats.filter(stat => {
@@ -843,7 +883,7 @@ export const UnifiedDataTable = (props) => {
         }
 
         return stats;
-    }, [modelStats, showSelectedOnly, selectedBenchmarks, kpiFilter, searchTerm, paretoKeys, baselineBenchmarkKey, submissionsMap, user]);
+    }, [modelStats, showSelectedOnly, selectedBenchmarks, kpiFilter, includeUnlisted, searchTerm, paretoKeys, baselineBenchmarkKey, submissionsMap, user]);
 
     const sortedStats = React.useMemo(() => {
         return [...filteredStats].sort((a, b) => {
@@ -2330,6 +2370,55 @@ const BenchmarkRow = React.memo(({
                                                                                                     >
                                                                                                         <Send className="w-2.5 h-2.5" /> Submit for Review
                                                                                                     </button>
+                                                                                                );
+                                                                                            }
+                                                                                            if (status === 'unlisted') {
+                                                                                                const authorUsername = sub?.github_author?.username || benchmarkData[0]?.github_author?.username || benchmarkData[0]?.source_info?.github_user;
+                                                                                                const isOwner = !!(user?.username && authorUsername && authorUsername.toLowerCase() === user.username.toLowerCase());
+                                                                                                const canPromote = isOwner;
+                                                                                                const canDelete = isOwner || isAdmin;
+
+                                                                                                if (!canPromote && !canDelete) return null;
+
+                                                                                                return (
+                                                                                                    <div className="flex items-center gap-1.5">
+                                                                                                        {canPromote && (
+                                                                                                            <button
+                                                                                                                onClick={(e) => {
+                                                                                                                    e.stopPropagation();
+                                                                                                                    handleActionClick(async () => {
+                                                                                                                        if (updateSubmissionStatus) {
+                                                                                                                            await updateSubmissionStatus(runId, 'submitted_pending_review', '', stat.model, stat.hardware);
+                                                                                                                        }
+                                                                                                                    });
+                                                                                                                }}
+                                                                                                                disabled={isLoadingSubmissions || isLocalActionPending}
+                                                                                                                title="Promote unlisted benchmark to the admin review queue"
+                                                                                                                className="px-2.5 py-1 rounded-xl border border-purple-500/20 bg-purple-500/5 hover:bg-purple-500/10 disabled:opacity-50 disabled:cursor-not-allowed text-purple-400 text-[9px] font-bold uppercase tracking-wider transition-colors cursor-pointer select-none flex items-center gap-1 whitespace-nowrap"
+                                                                                                            >
+                                                                                                                <Play className="w-2.5 h-2.5 fill-current" /> Promote to Review
+                                                                                                            </button>
+                                                                                                        )}
+                                                                                                        {canDelete && (
+                                                                                                            <button
+                                                                                                                onClick={(e) => {
+                                                                                                                    e.stopPropagation();
+                                                                                                                    handleActionClick(async () => {
+                                                                                                                        if (window.confirm(`Are you sure you want to permanently delete unlisted benchmark ${runId} from the Results Store? This action cannot be undone.`)) {
+                                                                                                                            if (deleteSubmission) {
+                                                                                                                                await deleteSubmission(runId);
+                                                                                                                            }
+                                                                                                                        }
+                                                                                                                    });
+                                                                                                                }}
+                                                                                                                disabled={isLoadingSubmissions || isLocalActionPending}
+                                                                                                                title="Permanently delete this unlisted benchmark off GCS storage"
+                                                                                                                className="px-2.5 py-1 rounded-xl border border-red-500/30 bg-red-500/10 hover:bg-red-500/20 disabled:opacity-50 disabled:cursor-not-allowed text-red-400 text-[9px] font-bold uppercase tracking-wider transition-all cursor-pointer select-none flex items-center gap-1 whitespace-nowrap"
+                                                                                                            >
+                                                                                                                <Trash2 className="w-2.5 h-2.5" /> Delete
+                                                                                                            </button>
+                                                                                                        )}
+                                                                                                    </div>
                                                                                                 );
                                                                                             }
                                                                                             if (canResubmit && status === 'submitted_pending_processing') {

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -144,6 +144,15 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
     const [activeTab, setActiveTab] = React.useState('all'); // 'all' or 'submissions'
     const [searchTerm, setSearchTerm] = React.useState('');
 
+    const [includeUnlisted, setIncludeUnlisted] = React.useState(() => {
+        try {
+            const params = new URLSearchParams(window.location.search);
+            return params.get('includeUnlisted') === '1' || params.get('includeUnlisted') === 'true';
+        } catch {
+            return false;
+        }
+    });
+
     const [kpiFilter, setKpiFilter] = React.useState(() => {
         try {
             const params = new URLSearchParams(window.location.search);
@@ -171,7 +180,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
         const params = new URLSearchParams(window.location.search);
         if (kpiFilter) {
             params.set('kpiFilter', kpiFilter);
-            if (['my-submissions', 'staged', 'processing', 'in_review', 'approved', 'action'].includes(kpiFilter)) {
+            if (['my-submissions', 'staged', 'unlisted', 'processing', 'in_review', 'approved', 'action'].includes(kpiFilter)) {
                 params.set('own', 'true');
             } else {
                 params.delete('own');
@@ -180,12 +189,18 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
             params.delete('kpiFilter');
             params.delete('own');
         }
+
+        if (includeUnlisted) {
+            params.set('includeUnlisted', '1');
+        } else {
+            params.delete('includeUnlisted');
+        }
         
         const newUrl = `${window.location.pathname}?${params.toString()}`;
         if (window.location.search !== `?${params.toString()}`) {
             window.history.replaceState(null, '', newUrl);
         }
-    }, [kpiFilter]);
+    }, [kpiFilter, includeUnlisted]);
 
     React.useEffect(() => {
         const showSubmitFlow = sessionStorage.getItem('prism_show_submit_dialog_after_login');
@@ -793,6 +808,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                         renameClearToUnselectAll: true,
                         brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run,
                         searchTerm, setSearchTerm, kpiFilter, setKpiFilter,
+                        includeUnlisted, setIncludeUnlisted,
                         submissionsMap,
                         isLoadingSubmissions,
                         updateSubmissionStatus,
@@ -818,6 +834,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
         baselineBenchmarkKey, setBaselineBenchmarkKey,
         brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run,
         searchTerm, setSearchTerm, kpiFilter, setKpiFilter,
+        includeUnlisted,
         submissionsMap,
         isLoadingSubmissions,
         updateSubmissionStatus,
@@ -1194,16 +1211,26 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                             'w-10 h-10 rounded-2xl flex items-center justify-center shadow-lg',
                             postUploadType === 'staged'
                                 ? 'bg-amber-500/10 border border-amber-500/20 text-amber-400 shadow-amber-500/5'
+                                : postUploadType === 'unlisted'
+                                ? 'bg-cyan-500/10 border border-cyan-500/20 text-cyan-400 shadow-cyan-500/5'
                                 : 'bg-emerald-500/10 border border-emerald-500/20 text-emerald-400 shadow-emerald-500/5'
                         )}>
-                            {postUploadType === 'staged' ? <UploadCloud size={20} /> : <CheckCircle size={20} />}
+                            {postUploadType === 'staged' ? <UploadCloud size={20} /> : postUploadType === 'unlisted' ? <UploadCloud size={20} /> : <CheckCircle size={20} />}
                         </div>
                         <div>
                             <div className="text-lg font-bold text-white tracking-wide">
-                                {postUploadType === 'staged' ? 'Runs Staged Successfully!' : 'Benchmark Submitted for Review!'}
+                                {postUploadType === 'staged'
+                                    ? 'Runs Staged Successfully!'
+                                    : postUploadType === 'unlisted'
+                                    ? 'Benchmark Saved as Unlisted!'
+                                    : 'Benchmark Submitted for Review!'}
                             </div>
                             <span className="text-[10px] text-slate-500 font-normal">
-                                {postUploadType === 'staged' ? 'LOCAL SESSION STAGING' : 'SUBMISSION QUEUED'}
+                                {postUploadType === 'staged'
+                                    ? 'LOCAL SESSION STAGING'
+                                    : postUploadType === 'unlisted'
+                                    ? 'UNLISTED BENCHMARK'
+                                    : 'SUBMISSION QUEUED'}
                             </span>
                         </div>
                     </div>
@@ -1230,6 +1257,8 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                                 'px-4 py-2 rounded-xl text-xs font-bold transition-all cursor-pointer text-white shadow-md',
                                 postUploadType === 'staged'
                                     ? 'bg-amber-600 hover:bg-amber-500 shadow-amber-500/10'
+                                    : postUploadType === 'unlisted'
+                                    ? 'bg-cyan-600 hover:bg-cyan-500 shadow-cyan-500/10'
                                     : 'bg-emerald-600 hover:bg-emerald-500 shadow-emerald-500/10'
                             )}
                         >
@@ -1244,6 +1273,8 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                         'absolute top-0 inset-x-0 h-1.5 bg-gradient-to-r',
                         postUploadType === 'staged'
                             ? 'from-amber-500 via-orange-400 to-yellow-500'
+                            : postUploadType === 'unlisted'
+                            ? 'from-cyan-500 via-blue-400 to-indigo-500'
                             : 'from-emerald-500 via-cyan-400 to-blue-500'
                     )} />
 
@@ -1251,6 +1282,8 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                     <p className="text-xs text-slate-300 leading-relaxed pt-1">
                         {postUploadType === 'staged'
                             ? "Your benchmark files have been validated and staged locally in your browser session. They are currently visible only to you and ready for analysis."
+                            : postUploadType === 'unlisted'
+                            ? "Your benchmark run has been processed and saved as unlisted. It is accessible directly via URL link and visible in your personal submissions dashboard, but omitted from default explore listings."
                             : "Your runs have been successfully posted to the validation server and are currently in the maintainer review queue. A public preview is available in your catalog."
                         }
                     </p>
@@ -1287,6 +1320,27 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                                         <span className="text-xs font-bold text-slate-200">Publish Globally</span>
                                         <span className="text-[11px] text-slate-400 mt-0.5 leading-normal">
                                             When you're ready to share the benchmarks, select them in the table and click <span className="text-cyan-400 font-medium">Compare & Publish</span> in the action bar or bottom dock to submit them for review.
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        ) : postUploadType === 'unlisted' ? (
+                            <div className="space-y-3.5">
+                                <div className="flex items-start gap-2.5">
+                                    <span className="w-5 h-5 rounded-md bg-cyan-500/15 border border-cyan-500/30 text-cyan-400 text-xs font-bold flex items-center justify-center shrink-0 mt-0.5">1</span>
+                                    <div className="flex flex-col">
+                                        <span className="text-xs font-bold text-slate-200">Direct Link Sharing</span>
+                                        <span className="text-[11px] text-slate-400 mt-0.5 leading-normal">
+                                            Unlisted benchmarks can be shared directly with colleagues or collaborators via their direct run URL.
+                                        </span>
+                                    </div>
+                                </div>
+                                <div className="flex items-start gap-2.5">
+                                    <span className="w-5 h-5 rounded-md bg-cyan-500/15 border border-cyan-500/30 text-cyan-400 text-xs font-bold flex items-center justify-center shrink-0 mt-0.5">2</span>
+                                    <div className="flex flex-col">
+                                        <span className="text-xs font-bold text-slate-200">Promote Whenever Ready</span>
+                                        <span className="text-[11px] text-slate-400 mt-0.5 leading-normal">
+                                            When you are ready to publish this benchmark publicly, click <span className="text-purple-400 font-medium">Promote to Review</span> on the benchmark row in your submissions dashboard.
                                         </span>
                                     </div>
                                 </div>

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -2254,20 +2254,26 @@ export const useDashboardData = (initialState, dashboardState) => {
     const loadSubmissions = useCallback(async (isManual = false) => {
         setIsLoadingSubmissions(true);
         try {
-            const params = new URLSearchParams();
-            params.set('own', 'true');
-            params.set('limit', '50');
-
             const headers = {};
             if (accessToken) {
                 headers['X-Prism-Github-Token'] = accessToken;
             }
 
-            const res = await fetch(`/api/results?${params.toString()}`, { headers });
-            if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
-            const listData = await res.json();
+            // Fetch user's own submissions as well as global unlisted submissions
+            const [resOwn, resUnlisted] = await Promise.all([
+                fetch('/api/results?own=true&limit=50', { headers }).catch(() => null),
+                fetch('/api/results?status=unlisted&limit=50', { headers }).catch(() => null)
+            ]);
+
+            const ownData = resOwn && resOwn.ok ? await resOwn.json() : { items: [] };
+            const unlistedData = resUnlisted && resUnlisted.ok ? await resUnlisted.json() : { items: [] };
+
+            const itemsMap = new Map();
+            (ownData.items || []).forEach(item => itemsMap.set(item.runId, item));
+            (unlistedData.items || []).forEach(item => itemsMap.set(item.runId, item));
+            const listDataItems = Array.from(itemsMap.values());
             
-            const serverSubmissions = (listData.items || []).map(item => ({
+            const serverSubmissions = listDataItems.map(item => ({
                 id: item.runId,
                 runId: item.runId,
                 model: item.model_name || "Custom Model",
@@ -2326,14 +2332,14 @@ export const useDashboardData = (initialState, dashboardState) => {
                 headers['X-Prism-Github-Token'] = accessToken;
             }
 
+            const reqBody = status === 'submitted_pending_review' 
+                ? { status }
+                : { status, feedback, reviewer };
+
             const res = await fetch(`/api/results/${runId}/status`, {
                 method: 'POST',
                 headers,
-                body: JSON.stringify({
-                    status,
-                    feedback,
-                    reviewer
-                })
+                body: JSON.stringify(reqBody)
             });
             if (!res.ok) throw new Error(`HTTP error! status: ${res.status}`);
             const data = await res.json();

--- a/src/utils/dashboardHelpers.jsx
+++ b/src/utils/dashboardHelpers.jsx
@@ -357,6 +357,13 @@ export const getSubmissionStatusDetails = (state) => {
                 text: 'text-amber-700 dark:text-amber-400',
                 border: 'border-amber-200 dark:border-amber-900/50'
             };
+        case 'unlisted':
+            return {
+                label: 'Unlisted',
+                bg: 'bg-cyan-50 dark:bg-cyan-950/20',
+                text: 'text-cyan-700 dark:text-cyan-400',
+                border: 'border-cyan-200 dark:border-cyan-900/50'
+            };
         case 'submitted_pending_review':
             return {
                 label: 'Pending Review',


### PR DESCRIPTION
## What does this PR do?

Introduces an **Unlisted** benchmark submission state (`unlisted`) for the Prism Results Store per [unlisted-benchmarks-spec.md](specs/changes/unlisted-benchmarks-spec.md).

- **Backend API & Data Processing (`server/results/`)**:
  - Adds the `unlisted` status enum to `PrismSubmissionStateSchema` and submission processing pipelines.
  - Supports `targetState` query/body parameters in `/api/results/submit` (`targetState=unlisted`).
  - Grants direct link read access (`GET /api/results/:runId`) for unlisted runs without requiring authentication.
  - Excludes `unlisted` runs from default GCS explore queries unless explicitly requested via `status=unlisted` or `own=true`.
  - Restricts status transitions (`unlisted` -> `submitted_pending_review`) and deletion (`DELETE /api/results/:runId`) strictly to the submitting owner.

- **Frontend Submissions & Management (`src/components/`)**:
  - Replaces dual submit buttons with a single submit action button and a Step 4 visibility selector (Public Review vs. Unlisted) in `SubmitValidationPage.jsx`.
  - Presents a dedicated post-upload action modal for unlisted submissions providing direct share link copying and promotion guidance.
  - Adds an orthogonal **SHOW UNLISTED** inclusion toggle (`includeUnlisted=1`) in `FilterPanel.jsx` that overlays unlisted benchmarks alongside public runs in the Public Store grid.
  - Maintains the dedicated `unlisted` sub-stage status filter in `UnifiedDataTable.jsx` under **My Benchmarks**.

## Why is this change needed?

Previously, benchmark uploads moved directly into the human review queue (`submitted_pending_review`), awaiting admin approval to become `public`. There was no cloud-backed storage state for preliminary, unverified, or experimental benchmark data. `unlisted` provides a cloud-backed storage playground in GCS that skips human review, allows direct share link collaboration (`/results/:runId`), and enables owner self-promotion to public review whenever ready.

## How was this tested?

- [x] Manual testing performed
  - Verified targetState selection during Step 4 submission flow (Unlisted vs Public Review).
  - Tested **SHOW UNLISTED** inclusion toggle in Public Store view alongside public benchmarks.
  - Verified owner self-promotion transition from `unlisted` to `submitted_pending_review`.
- [x] Linters pass (`nix shell nixpkgs#nodejs -c npx eslint ...`)

## Checklist

- [x] Commits follow project guidelines
- [x] Linters pass
- [x] Documentation & specification updated (`specs/changes/unlisted-benchmarks-spec.md`)

## Related Issues

Related to specs/changes/unlisted-benchmarks-spec.md