### PR TITLE
feat: add benchmark sharing and UI refinements

### DIFF
--- a/specs/changes/share-benchmarks-spec.md
+++ b/specs/changes/share-benchmarks-spec.md
@@ -1,0 +1,226 @@
+# Spec: Multi-Benchmark Compact Share Links & Automated Comparison
+
+- **Status**: Draft
+- **Author**: diamondburned, Jetski
+- **Date**: July 31, 2026
+
+## Objective
+
+This proposal introduces a multi-benchmark sharing mechanism for the Prism Results Store.
+
+Users can select multiple benchmark runs in the Results Store table, generate a compact share link containing binary Base64-encoded benchmark UUIDs, and share it with collaborators. When a recipient opens the link, Prism automatically navigates to the Results Store, fetches and selects the specified benchmarks, and opens the Compare sidebar for immediate side-by-side analysis.
+
+The key goals of this feature are:
+
+1. **Multi-Benchmark URL Sharing**: Allow users to share combinations of public and unlisted benchmark runs via a single URL.
+4. **Automated Compare Sidebar Activation**: Automatically select the shared runs and launch the Compare sidebar upon link navigation.
+
+Non-goals:
+
+- Supporting share links for browser-local `staged` benchmark runs (staged data resides only in the submitter's browser IndexedDB).
+- Supporting share links for runs in the administrator review queue (`submitted_pending_review`) or rejected queue (`rejected`).
+- Creating a separate database table or short-URL alias redirect backend service (compact binary encoding keeps URLs small without requiring server-side link resolution storage).
+
+---
+
+## Background
+
+Currently, users in the Prism Results Store can select multiple benchmarks from the table to perform side-by-side analysis using the Compare & Inspect drawer (`setShowComparisonDrawer(true)`). However, there is no direct mechanism to copy a shareable link that preserves this selection state for collaborators.
+
+While individual unlisted runs can be accessed via `/results/:runId` direct links (as specified in [unlisted-benchmarks-spec.md](unlisted-benchmarks-spec.md)), comparing multiple benchmark runs requires manual re-selection by each team member.
+
+Providing a share button on the selection toolbar with compact binary Base64 UUID encoding solves this gap while keeping URLs concise and URL-bar friendly.
+
+For related context, see:
+- [Prism Results Store Specification](../main/completed/results-api/README.md)
+- [Frontend Architecture Specification](../main/completed/results-api/frontend.md)
+- [API Route Reference](../main/completed/results-api/routes.md)
+- [Unlisted Benchmarks Specification](unlisted-benchmarks-spec.md)
+
+---
+
+## Visibility & Authorization Constraints Matrix
+
+Sharing is governed by strict visibility rules to prevent leaking preliminary, browser-local, or review-queue benchmark runs.
+
+### Visibility Rules
+
+| Submission State | Share Link Allowed? | Enforcement Strategy |
+| :--- | :--- | :--- |
+| `public` | **Yes** | Fully shareable across all users. |
+| `unlisted` | **Yes** | Fully shareable via direct link (unlisted benchmarks are cloud-backed and accessible to anyone with the UUID). |
+| `staged` | **No (Forbidden)** | Blocked. Staged data exists only in local IndexedDB. |
+| `submitted_pending_processing` | **No (Forbidden)** | Blocked. Upload is in transient processing state. |
+| `submitted_pending_review` | **No (Forbidden)** | Blocked. Run is in admin review queue; restricted to owner and admins. |
+| `rejected` | **No (Forbidden)** | Blocked. Run was rejected during review. |
+
+### Validation Rule
+
+When a user selects benchmarks in the UI and attempts to generate a share link, the client evaluates the submission state of every selected run:
+
+```typescript
+function canShareBenchmarks(selectedRuns: BenchmarkRun[]): boolean {
+  if (selectedRuns.length === 0) return false;
+
+  return selectedRuns.every(run => {
+    const status = getSubmissionStatus(run);
+    return status === 'public' || status === 'unlisted';
+  });
+}
+```
+
+If `canShareBenchmarks(selectedRuns)` returns `false`:
+- The "Share Selected" action is **disabled** with an explanatory tooltip, OR
+- Clicking the action triggers a warning alert/toast: *"Sharing is forbidden: Selection contains staged, pending review, or rejected runs. Only public and unlisted benchmarks can be shared."*
+
+---
+
+## Compact Binary Base64 Encoding Specification
+
+Standard UUID v4 strings consume 36 ASCII characters (e.g. `123e4567-e89b-12d3-a456-426614174000`), representing 128 bits (16 bytes) of binary data. Passing comma-separated raw UUID text strings in URL query parameters scales poorly as the number of selected benchmarks increases.
+
+To minimize URL length, benchmark UUIDs are serialized directly into binary byte arrays before Base64 encoding.
+
+### Target URL Format
+
+```
+/?view=results-store&benchmarks=<Base64String>
+```
+
+Example:
+`/?view=results-store&benchmarks=EJ5FZ-i7EdOkVkJmFBdAABE-hX7ruxF2pFiC`
+
+### Encoding Algorithm (Client Link Generation)
+
+Given an array of selected benchmark UUID strings `[uuid_1, uuid_2, ..., uuid_N]`:
+
+1. **UUID to Bytes**: Convert each 36-character UUID string (format `8-4-4-4-12`) into a 16-byte `Uint8Array`:
+   - Remove hyphens `-` to obtain a 32-character hexadecimal string.
+   - Parse hexadecimal pairs into 16 raw byte values.
+2. **Concatenation**: Combine all `N` 16-byte arrays into a single contiguous `Uint8Array` of total length `16 * N` bytes.
+3. **Base64 Encoding**: Encode the concatenated byte array into a Base64 URL-safe string (padding characters `=` may be retained or standard URL encoding applied).
+
+```mermaid
+graph LR
+    A[Selected UUIDs<br/>36 chars each] --> B[Strip Hyphens<br/>32 hex chars each]
+    B --> C[Convert to Bytes<br/>16 bytes per UUID]
+    C --> D[Concatenate Bytes<br/>N x 16 bytes]
+    D --> E[Base64 Encode]
+    E --> F["URL Query Param<br/>?view=results-store&benchmarks=..."]
+```
+
+### Decoding Algorithm (Client Navigation Handler)
+
+When opening a link containing `?view=results-store&benchmarks=<Base64String>`:
+
+1. **Extract Parameter**: Read the `benchmarks` parameter from `window.location.search`.
+2. **Base64 Decoding**: Decode the Base64 string into a `Uint8Array`.
+3. **Byte Alignment Validation**:
+   - Check if `bytes.length > 0` and `bytes.length % 16 === 0`.
+   - If validation fails (corrupted string or invalid length), log an error, trigger an error toast (*"Invalid benchmark share link"*), and fall back to the default Results Store view.
+4. **Byte Splitting & UUID Reconstruction**:
+   - Iterate over the byte array in 16-byte chunks (`i = 0, 16, 32, ...`).
+   - Convert each 16-byte slice into a 32-character hexadecimal string.
+   - Format into canonical UUID string representation (`8-4-4-4-12`):
+     `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`
+5. **Output**: An array of canonical UUID strings `[uuid_1, uuid_2, ..., uuid_N]`.
+
+### Compact Size Comparison
+
+| Number of Benchmarks (`N`) | Raw ASCII Comma-Separated | Compact Binary Base64 | Reduction |
+| :---: | :---: | :---: | :---: |
+| 1 | 36 chars | 24 chars | 33% smaller |
+| 3 | 110 chars | 64 chars | 42% smaller |
+| 5 | 184 chars | 108 chars | 41% smaller |
+| 10 | 369 chars | 216 chars | 41% smaller |
+
+---
+
+## User Experience & Workflow
+
+### Link Generation Workflow
+
+1. **Selection**: User navigates to `/?view=results-store` and checks $N$ rows in `UnifiedDataTable.jsx`.
+2. **Toolbar Update**: The selection action bar displays the total selected count and available bulk actions.
+3. **Validation Check**:
+   - If all selected benchmarks have state `public` or `unlisted`, the **Share Link** button is enabled.
+   - If any selected benchmark is `staged`, `submitted_pending_review`, or `rejected`, the **Share Link** button displays a disabled state with a descriptive tooltip or warning icon.
+4. **Copy Action**:
+   - Clicking **Share Link** executes the binary Base64 encoding algorithm.
+   - Constructs the full URL: `https://<domain>/?view=results-store&benchmarks=<encoded_string>`.
+   - Copies the URL to the user's clipboard and displays a success toast notification (*"Share link copied to clipboard"*).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User
+    participant Table as UnifiedDataTable
+    participant Encoder as ShareLinkEncoder
+    participant Clipboard as Browser Clipboard
+
+    User->>Table: Select benchmark checkboxes
+    Table->>Table: Validate all selected runs (public / unlisted)
+    alt Any run is staged, pending, or rejected
+        Table-->>User: Disable Share button with warning tooltip
+    else All runs are public or unlisted
+        User->>Table: Click "Share Selected" button
+        Table->>Encoder: Pass selected run UUIDs
+        Encoder->>Encoder: Convert UUIDs to 16-byte binary & Base64
+        Encoder-->>Table: Return ?view=results-store&benchmarks=...
+        Table->>Clipboard: Write URL to clipboard
+        Table-->>User: Show toast ("Share link copied to clipboard")
+    end
+```
+
+### Link Consumption & Automated Compare Sidebar Workflow
+
+1. **Navigation**: Recipient opens `https://<domain>/?view=results-store&benchmarks=<encoded_string>`.
+2. **State Hydration**:
+   - Prism initializes and detects `view=results-store` and `benchmarks` query parameters on mount.
+   - Calls the decoder to extract the array of target run UUIDs.
+3. **Data Resolving**:
+   - Prism checks existing in-memory / IndexedDB cached runs for matching UUID keys.
+   - For any target UUID not currently present in the client catalog (such as `unlisted` runs hidden from default grid lists), Prism fetches the run bundle via `GET /api/results/:runId`.
+4. **Selection & Compare Activation**:
+   - Prism populates `selectedBenchmarks` with the retrieved benchmark keys.
+   - Prism automatically opens the Compare sidebar (`setShowComparisonDrawer(true)`).
+   - Displays an informational toast (*"Loaded N shared benchmarks into Compare view"*).
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Recipient
+    participant App as Prism App Mount
+    participant Decoder as ShareLinkDecoder
+    participant API as Results API / GCS
+    participant UI as Results Store & Compare Sidebar
+
+    Recipient->>App: Open URL (?view=results-store&benchmarks=...)
+    App->>Decoder: Decode Base64 benchmarks parameter
+    Decoder-->>App: Return list of run UUIDs
+    loop For each decoded run UUID
+        alt Benchmark already loaded in memory
+            App->>App: Use cached benchmark item
+        else Benchmark missing (e.g. unlisted run)
+            App->>API: GET /api/results/:runId
+            API-->>App: Return run bundle JSON payload
+        end
+    end
+    App->>UI: Set selectedBenchmarks state
+    App->>UI: Set showComparisonDrawer(true)
+    UI-->>Recipient: Display table with selected benchmarks & open Compare sidebar
+```
+
+---
+
+## Edge Cases & Error Handling
+
+1. **Malformed Base64 Parameter**:
+   - If `benchmarks` parameter is corrupted or byte length is not a multiple of 16, Prism displays an error notification: *"Invalid share link format"*.
+   - Navigation gracefully defaults to the normal Results Store view without crashing.
+2. **Deleted or Non-Existent Benchmark UUID**:
+   - If one of the decoded UUIDs returns 404 Not Found (e.g. an unlisted benchmark deleted by its owner), Prism skips the missing run, loads the remaining valid runs into the Compare sidebar, and displays a warning toast: *"1 shared benchmark could not be found or was deleted"*.
+3. **Access Restricted Benchmark**:
+   - If a share link contained a run ID that transitioned to pending review or private access and returns HTTP 403, it is safely excluded from selection with an appropriate notice.
+4. **Empty Selection**:
+   - Navigating to `?view=results-store&benchmarks=` with an empty string triggers standard Results Store view without opening the Compare sidebar.

--- a/specs/main/completed/results-api/frontend.md
+++ b/specs/main/completed/results-api/frontend.md
@@ -246,3 +246,69 @@ returning from a successful wizard session:
   Inspect curves, add manifests, or Publish).
 - **Submission Queued:** Explains how to track the status of queued runs in the
   review pipeline.
+
+---
+
+## 5. Multi-Benchmark Compact Share Links & Comparison Activation
+
+### 5.1 Overview & URL Parameter Format
+
+Users can select multiple benchmark runs in the Results Store table
+(`UnifiedDataTable.jsx`) and generate a shareable link. When a recipient opens
+the share link, Prism automatically loads and selects the benchmark runs and
+opens the Compare sidebar drawer (`setShowComparisonDrawer(true)`).
+
+The share link uses the following query parameter format:
+
+```
+/?view=results-store&benchmarks=<Base64String>
+```
+
+### 5.2 Visibility Restriction & Link Generation Validation Rules
+
+To prevent sharing browser-local data or restricted review queue items:
+
+1. **Allowed Submission States:** Benchmark runs MUST have a status of `public`
+   or `unlisted`.
+2. **Forbidden Submission States:** Benchmark runs in `staged` (IndexedDB),
+   `submitted_pending_processing`, `submitted_pending_review` (admin queue), or
+   `rejected` states **cannot** be shared via URL.
+3. **Enforcement:**
+    - When multiple benchmarks are selected, the client validates that every
+      selected benchmark is either `public` or `unlisted`.
+    - If any selected benchmark is in a forbidden state, link generation is
+      **forbidden**. The **Share Selected** button is disabled with an
+      explanatory tooltip, or an error notification is presented to the
+      submitter.
+
+### 5.3 Compact Binary Base64 Encoding & Decoding Scheme
+
+To prevent bloated URL strings when sharing multiple benchmarks:
+
+1. **Encoding (Generation):**
+    - Each selected benchmark UUID string (36 characters) is converted to its
+      16-byte binary representation (`Uint8Array`).
+    - The 16-byte arrays for all `N` selected benchmarks are concatenated into a
+      single byte array (`16 * N` bytes).
+    - The concatenated byte array is Base64 encoded.
+2. **Decoding (Consumption):**
+    - Upon reading `?view=results-store&benchmarks=<Base64String>`, the Base64
+      string is decoded into a byte array.
+    - The array length is validated (`bytes.length > 0` and
+      `bytes.length % 16 === 0`).
+    - The byte array is sliced into 16-byte chunks, and each chunk is formatted
+      back into standard UUID string format
+      (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`).
+
+### 5.4 Automated Navigation & Compare Sidebar Activation
+
+When navigating to a valid benchmark share URL:
+
+1. **Data Resolving:** Prism extracts the list of target UUIDs and checks
+   in-memory and cached runs. Any missing benchmark (e.g. `unlisted` runs hidden
+   from default grid lists) is fetched via `GET /api/results/:runId`.
+2. **Selection Hydration:** Prism populates `selectedBenchmarks` with the
+   decoded UUID keys.
+3. **Compare Activation:** Prism automatically opens the Compare drawer
+   (`setShowComparisonDrawer(true)`), rendering side-by-side performance curves
+   and telemetry charts immediately.

--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -107,7 +107,9 @@ export const FilterPanel = ({
     loadAllData,
     loadingConnections,
     dashboardState,
-    defaultSources
+    defaultSources,
+    addToast,
+    dashboardData
 }) => {
     const [isAdvancedExpanded, setIsAdvancedExpanded] = useState(false);
     const { user } = useGitHubAuth();
@@ -591,6 +593,8 @@ export const FilterPanel = ({
                 loadAllData={loadAllData}
                 loadingConnections={loadingConnections}
                 dashboardState={dashboardState}
+                addToast={addToast}
+                dashboardData={dashboardData}
             />
         );
     }, [
@@ -601,7 +605,7 @@ export const FilterPanel = ({
         setBrv02CustomLabels, removeBrv02Run, setShowDataPanel, searchTerm, setSearchTerm, kpiFilter,
         setKpiFilter, includeUnlisted, paretoKeys, submissionsMap, isLoadingSubmissions, updateSubmissionStatus,
         bulkUpdateSubmissionStatus, deleteSubmission, onOpenSubmitDialog, hasFiltersToSave, loadAllData, loadingConnections,
-        dashboardState, defaultSources
+        dashboardState, defaultSources, addToast, dashboardData
     ]);
 
     if (!showFilterPanel) return null;

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -14,7 +14,7 @@
 
 import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { RotateCcw, ChevronDown, ChevronUp, Star, Pin, CheckSquare, Square, Check, Pencil, Trash2, Code2, Copy, X, Database, Eye, ShieldCheck, AlertCircle, TrendingUp, AlertTriangle, Search, FileText, FileClock, Sliders, Activity, Send, Play, Loader } from 'lucide-react';
+import { RotateCcw, ChevronDown, ChevronUp, Star, Pin, CheckSquare, Square, Check, Pencil, Trash2, Code2, Copy, X, Database, Eye, EyeOff, ShieldCheck, AlertCircle, TrendingUp, AlertTriangle, Search, FileText, FileClock, Sliders, Activity, Send, Play, Loader } from 'lucide-react';
 import { RunComparisonChart } from '../Dashboard/RunComparisonChart';
 import { ThroughputCostChart } from '../Dashboard/ThroughputCostChart';
 import { Button, Badge, StatusChip, Modal, Textarea } from '../ui';
@@ -23,6 +23,7 @@ import { getSourceTag, getSourceType, getSourceTypeStyle, formatOriginLabel, get
 import yaml from 'js-yaml';
 import { useGitHubAuth } from '../../hooks/useGitHubAuth';
 import { validateBenchmark } from '../../utils/benchmarkValidator';
+import { encodeShareLink, isValidUuid } from '../../utils/shareLinkEncoder';
 import { v4 as uuidv4 } from 'uuid';
 
 const getCleanModelName = (name) => {
@@ -202,6 +203,15 @@ export const UnifiedDataTable = (props) => {
 
     const actionPendingRef = React.useRef(false);
     const [isLocalActionPending, setIsLocalActionPending] = React.useState(false);
+    const [showToast, setShowToast] = useState(false);
+    const [toastMessage, setToastMessage] = useState('');
+
+    React.useEffect(() => {
+        if (showToast) {
+            const timer = setTimeout(() => setShowToast(false), 2500);
+            return () => clearTimeout(timer);
+        }
+    }, [showToast]);
 
     const handleActionClick = React.useCallback(async (actionFn) => {
         if (actionPendingRef.current) return;
@@ -291,9 +301,100 @@ export const UnifiedDataTable = (props) => {
         return stagedList;
     }, [brv02Runs, selectedBenchmarks]);
 
+    const [hiddenBenchmarkKeys, setHiddenBenchmarkKeys] = React.useState(new Set());
+
+    React.useEffect(() => {
+        if (!showComparisonDrawer) {
+            setHiddenBenchmarkKeys(new Set());
+        }
+    }, [showComparisonDrawer]);
+
+    const handleToggleGraphVisibility = React.useCallback((key) => {
+        setHiddenBenchmarkKeys(prev => {
+            const next = new Set(prev);
+            if (next.has(key)) {
+                next.delete(key);
+            } else {
+                next.add(key);
+            }
+            return next;
+        });
+    }, []);
+
+    const allSelectedKeys = React.useMemo(() => {
+        return (modelStats || [])
+            .filter(s => selectedBenchmarks.has(s.benchmarkKey))
+            .map(s => s.benchmarkKey);
+    }, [modelStats, selectedBenchmarks]);
+
+    const handleSoloOrInvertGraphVisibility = React.useCallback((key) => {
+        setHiddenBenchmarkKeys(prev => {
+            const isOnlyThisVisible = !prev.has(key) && allSelectedKeys.every(k => k === key || prev.has(k));
+            if (isOnlyThisVisible) {
+                return new Set([key]);
+            } else {
+                const otherKeys = allSelectedKeys.filter(k => k !== key);
+                return new Set(otherKeys);
+            }
+        });
+    }, [allSelectedKeys]);
+
     const drawerFilteredData = React.useMemo(() => {
         return (filteredBySource || []).filter(d => selectedBenchmarks.has(getBenchmarkKey(d)));
     }, [filteredBySource, selectedBenchmarks]);
+
+    const drawerChartFilteredData = React.useMemo(() => {
+        return (filteredBySource || []).filter(d => {
+            const key = getBenchmarkKey(d);
+            return selectedBenchmarks.has(key) && !hiddenBenchmarkKeys.has(key);
+        });
+    }, [filteredBySource, selectedBenchmarks, hiddenBenchmarkKeys]);
+
+    const { canShare, shareableUuids, shareForbiddenReason } = React.useMemo(() => {
+        if (!selectedBenchmarks || selectedBenchmarks.size === 0) {
+            return { canShare: false, shareableUuids: [], shareForbiddenReason: null };
+        }
+
+        const selectedStatsList = (modelStats || []).filter(stat => selectedBenchmarks.has(stat.benchmarkKey));
+
+        if (selectedStatsList.length === 0 || selectedStatsList.length !== selectedBenchmarks.size) {
+            return {
+                canShare: false,
+                shareableUuids: [],
+                shareForbiddenReason: "Sharing is forbidden: Selection contains invalid or unknown runs."
+            };
+        }
+
+        const uuids = [];
+        for (const stat of selectedStatsList) {
+            const firstEntry = stat.data?.[0];
+            const sourceStr = firstEntry?.source || '';
+            const runId = firstEntry?.run_id || (sourceStr.startsWith('brv02:') ? sourceStr.replace('brv02:', '') : null);
+
+            if (!runId || !isValidUuid(runId)) {
+                return {
+                    canShare: false,
+                    shareableUuids: [],
+                    shareForbiddenReason: "Sharing is forbidden: Selection contains unsubmitted or local staged runs without public UUIDs."
+                };
+            }
+            uuids.push(runId);
+        }
+
+        return {
+            canShare: true,
+            shareableUuids: uuids,
+            shareForbiddenReason: null
+        };
+    }, [selectedBenchmarks, modelStats]);
+
+    const handleCopyShareLink = React.useCallback(() => {
+        if (!canShare || shareableUuids.length === 0) return;
+        const shareLink = encodeShareLink(shareableUuids);
+        navigator.clipboard.writeText(shareLink);
+        setToastMessage("Copied link to clipboard!");
+        setShowToast(true);
+    }, [canShare, shareableUuids]);
 
     const buildBundleForRun = React.useCallback((run) => {
         const stageFiles = run.stages.map(stage => {
@@ -1696,7 +1797,7 @@ export const UnifiedDataTable = (props) => {
                 )}>
                         <div className="absolute top-0 right-0 w-80 h-80 bg-cyan-500/10 rounded-full blur-3xl pointer-events-none" />
                         
-                        <div className="flex items-center justify-between pb-4 mb-6 border-b border-slate-805 flex-shrink-0">
+                        <div className="flex items-center justify-between pb-4 mb-6 border-b border-slate-900 flex-shrink-0">
                             <div className="flex flex-col gap-1">
                                 <div className="flex items-center gap-2">
                                     <span className="text-xs sm:text-sm font-bold uppercase tracking-wider text-cyan-400">
@@ -1743,7 +1844,7 @@ export const UnifiedDataTable = (props) => {
                                     qualityMetrics={qualityMetrics}
                                     allModels={modelStats.map(m => m.model)}
                                     selectedModels={selectedModels}
-                                    filteredData={drawerFilteredData}
+                                    filteredData={drawerChartFilteredData}
                                     getBenchmarkKey={getBenchmarkKey}
                                     theme="dark"
                                     isZoomEnabled={drawerIsZoomEnabled}
@@ -1757,7 +1858,7 @@ export const UnifiedDataTable = (props) => {
                                     chartColorMode={drawerChartColorMode}
                                     setChartColorMode={setDrawerChartColorMode}
                                     metricAvailability={drawerMetricAvailability}
-                                    filteredBySource={drawerFilteredData}
+                                    filteredBySource={drawerChartFilteredData}
                                     xAxisMax={drawerXAxisMax}
                                     setXAxisMax={setDrawerXAxisMax}
                                     isLogScaleX={drawerIsLogScaleX}
@@ -1768,86 +1869,109 @@ export const UnifiedDataTable = (props) => {
                                 />
                             </div>
 
-                            {/* Section 2: Active Submissions Actions */}
-                            <div className="space-y-4">
-
-                                {selectedStagedRuns.length > 0 && (
-                                    <div className="flex justify-end pt-1 select-none">
-                                        {user?.permission === 'none' ? (
-                                            <div className="relative group/tooltip inline-block">
-                                                <button
-                                                    disabled
-                                                    className="px-4 py-2 bg-slate-800 text-slate-500 text-xs font-bold uppercase tracking-wider rounded-xl border border-slate-700/50 cursor-not-allowed flex items-center gap-1.5 opacity-60"
-                                                >
-                                                    <Send size={12} />
-                                                    Publish Selected ({selectedStagedRuns.length})
-                                                </button>
-                                                <div className="absolute right-0 bottom-full mb-2 px-3 py-2 bg-slate-900 border border-slate-800 text-slate-350 text-xs font-medium rounded-xl opacity-0 invisible group-hover/tooltip:opacity-100 group-hover/tooltip:visible transition-all duration-200 shadow-2xl z-[9999] w-64 pointer-events-none leading-relaxed text-center normal-case tracking-normal animate-in fade-in slide-in-from-bottom-2 duration-150">
-                                                    You are not in the Results Store closed-beta. Check back later once the feature is released.
-                                                </div>
+                            <div className="space-y-4 pt-2 pb-6">
+                                <div className="flex items-center justify-between border-b border-slate-900 pb-2 select-none">
+                                    <div className="flex items-center gap-2">
+                                        <span className="text-xs font-black uppercase tracking-wider text-cyan-400/90">
+                                            Selected Benchmark Runs
+                                        </span>
+                                        <span className="text-[10px] text-slate-500">
+                                            ({modelStats.filter(s => selectedBenchmarks.has(s.benchmarkKey)).length})
+                                        </span>
+                                    </div>
+                                    <div className="relative group/share-link">
+                                        <Button
+                                            variant="secondary"
+                                            size="sm"
+                                            onClick={handleCopyShareLink}
+                                            disabled={!canShare}
+                                            className={cn("gap-1.5", !canShare && "opacity-50 cursor-not-allowed")}
+                                        >
+                                            <Copy size={12} />
+                                            <span>Share Link</span>
+                                        </Button>
+                                        {!canShare && shareForbiddenReason && (
+                                            <div className="absolute right-0 bottom-full mb-2 px-3 py-2 bg-slate-900 border border-slate-800 text-slate-350 text-xs font-medium rounded-xl opacity-0 invisible group-hover/share-link:opacity-100 group-hover/share-link:visible transition-all duration-200 shadow-2xl z-[9999] w-64 pointer-events-none leading-relaxed text-center normal-case tracking-normal animate-in fade-in slide-in-from-bottom-2 duration-150">
+                                                {shareForbiddenReason}
                                             </div>
-                                        ) : (
-                                            <button
-                                                id="drawer-publish-selected-btn"
-                                                onClick={handlePublishSelected}
-                                                className="px-4 py-2 bg-gradient-to-r from-cyan-600 to-blue-700 hover:from-cyan-500 hover:to-blue-600 text-white text-xs font-bold uppercase tracking-wider rounded-xl shadow-[0_0_12px_rgba(6,182,212,0.15)] transition-all hover:scale-[1.02] cursor-pointer flex items-center gap-1.5"
-                                            >
-                                                <Send size={12} />
-                                                Publish Selected ({selectedStagedRuns.length})
-                                            </button>
                                         )}
                                     </div>
-                                )}
-
-                                <div className="flex items-center justify-between border-b border-slate-900 pb-2 select-none">
-                                    <span className="text-xs font-black uppercase tracking-wider text-cyan-400/90">
-                                        Run Verification & Promotion Pipeline
-                                    </span>
-                                    <span className="text-[10px] text-slate-500">
-                                        {modelStats.filter(s => selectedBenchmarks.has(s.benchmarkKey)).length} Selected Runs
-                                    </span>
                                 </div>
                                 
                                 <div className="grid grid-cols-1 gap-3.5">
-                                    {modelStats.filter(s => selectedBenchmarks.has(s.benchmarkKey)).map(stat => (
-                                        <BenchmarkRow
-                                            key={stat.benchmarkKey || stat.model}
-                                            stat={stat}
-                                            isSelected={true}
-                                            isExpanded={expandedModels.has(stat.benchmarkKey || stat.model)}
-                                            isBaseline={stat.benchmarkKey === baselineBenchmarkKey}
-                                            user={user}
-                                            isAdmin={isAdmin}
-                                            submissionsMap={submissionsMap}
-                                            brv02Runs={brv02Runs}
-                                            visibleSpecs={visibleSpecs}
-                                            isLoadingSubmissions={isLoadingSubmissions}
-                                            isLocalActionPending={isLocalActionPending}
-                                            rejectingRunId={rejectingRunId}
-                                            rejectionFeedback={rejectionFeedback}
-                                            setRejectingRunId={setRejectingRunId}
-                                            setRejectionFeedback={setRejectionFeedback}
-                                            setViewingPayloadRun={setViewingPayloadRun}
-                                            setRawYamlContent={setRawYamlContent}
-                                            setRawYamlTitle={setRawYamlTitle}
-                                            handleSubmitStagedRunForReview={handleSubmitStagedRunForReview}
-                                            handleActionClick={handleActionClick}
-                                            updateSubmissionStatus={updateSubmissionStatus}
-                                            deleteSubmission={deleteSubmission}
-                                            toggleModelExpansion={toggleModelExpansion}
-                                            handleCheckboxPointerDown={handleCheckboxPointerDown}
-                                            brv02CustomLabels={brv02CustomLabels}
-                                            handleEditStagedRun={handleEditStagedRun}
-                                            defaultSources={defaultSources}
-                                            readOnly={true}
-                                        />
-                                    ))}
+                                    {modelStats.filter(s => selectedBenchmarks.has(s.benchmarkKey)).map(stat => {
+                                        const isOnlyThisVisible = !hiddenBenchmarkKeys.has(stat.benchmarkKey) &&
+                                            allSelectedKeys.length > 1 &&
+                                            allSelectedKeys.every(k => k === stat.benchmarkKey || hiddenBenchmarkKeys.has(k));
+                                        return (
+                                            <BenchmarkRow
+                                                key={stat.benchmarkKey || stat.model}
+                                                stat={stat}
+                                                isSelected={true}
+                                                isExpanded={expandedModels.has(stat.benchmarkKey || stat.model)}
+                                                isBaseline={stat.benchmarkKey === baselineBenchmarkKey}
+                                                user={user}
+                                                isAdmin={isAdmin}
+                                                submissionsMap={submissionsMap}
+                                                brv02Runs={brv02Runs}
+                                                visibleSpecs={visibleSpecs}
+                                                isLoadingSubmissions={isLoadingSubmissions}
+                                                isLocalActionPending={isLocalActionPending}
+                                                rejectingRunId={rejectingRunId}
+                                                rejectionFeedback={rejectionFeedback}
+                                                setRejectingRunId={setRejectingRunId}
+                                                setRejectionFeedback={setRejectionFeedback}
+                                                setViewingPayloadRun={setViewingPayloadRun}
+                                                setRawYamlContent={setRawYamlContent}
+                                                setRawYamlTitle={setRawYamlTitle}
+                                                handleSubmitStagedRunForReview={handleSubmitStagedRunForReview}
+                                                handleActionClick={handleActionClick}
+                                                updateSubmissionStatus={updateSubmissionStatus}
+                                                deleteSubmission={deleteSubmission}
+                                                toggleModelExpansion={toggleModelExpansion}
+                                                handleCheckboxPointerDown={handleCheckboxPointerDown}
+                                                brv02CustomLabels={brv02CustomLabels}
+                                                handleEditStagedRun={handleEditStagedRun}
+                                                defaultSources={defaultSources}
+                                                readOnly={true}
+                                                isHiddenOnGraph={hiddenBenchmarkKeys.has(stat.benchmarkKey)}
+                                                isOnlyThisVisibleOnGraph={isOnlyThisVisible}
+                                                onToggleGraphVisibility={handleToggleGraphVisibility}
+                                                onSoloOrInvertGraphVisibility={handleSoloOrInvertGraphVisibility}
+                                            />
+                                        );
+                                    })}
                                 </div>
                             </div>
                         </div>
 
                         {/* Fixed Footer */}
-                        <div className="pt-4 mt-6 border-t border-slate-900 flex items-center justify-end gap-3 flex-shrink-0 select-none">
+                        <div className="pt-4 border-t border-slate-900 flex items-center justify-end gap-3 flex-shrink-0 select-none">
+                            {selectedStagedRuns.length > 0 && (
+                                user?.permission === 'none' ? (
+                                    <div className="relative group/tooltip inline-block">
+                                        <button
+                                            disabled
+                                            className="px-4 py-2 bg-slate-800 text-slate-500 text-xs font-bold uppercase tracking-wider rounded-xl border border-slate-700/50 cursor-not-allowed flex items-center gap-1.5 opacity-60"
+                                        >
+                                            <Send size={12} />
+                                            Publish Selected ({selectedStagedRuns.length})
+                                        </button>
+                                        <div className="absolute right-0 bottom-full mb-2 px-3 py-2 bg-slate-900 border border-slate-800 text-slate-350 text-xs font-medium rounded-xl opacity-0 invisible group-hover/tooltip:opacity-100 group-hover/tooltip:visible transition-all duration-200 shadow-2xl z-[9999] w-64 pointer-events-none leading-relaxed text-center normal-case tracking-normal animate-in fade-in slide-in-from-bottom-2 duration-150">
+                                            You are not in the Results Store closed-beta. Check back later once the feature is released.
+                                        </div>
+                                    </div>
+                                ) : (
+                                    <button
+                                        id="drawer-publish-selected-btn"
+                                        onClick={handlePublishSelected}
+                                        className="px-4 py-2 bg-gradient-to-r from-cyan-600 to-blue-700 hover:from-cyan-500 hover:to-blue-600 text-white text-xs font-bold uppercase tracking-wider rounded-xl shadow-[0_0_12px_rgba(6,182,212,0.15)] transition-all hover:scale-[1.02] cursor-pointer flex items-center gap-1.5"
+                                    >
+                                        <Send size={12} />
+                                        Publish Selected ({selectedStagedRuns.length})
+                                    </button>
+                                )
+                            )}
                             <Button
                                 type="button"
                                 variant="secondary"
@@ -1858,6 +1982,13 @@ export const UnifiedDataTable = (props) => {
                                 Close
                             </Button>
                         </div>
+                </div>,
+                document.body
+            )}
+            {showToast && createPortal(
+                <div className="fixed bottom-20 left-1/2 -translate-x-1/2 z-[10000] bg-cyan-950/90 border border-cyan-500/40 text-cyan-200 px-4 py-2 rounded-xl text-xs font-semibold shadow-2xl backdrop-blur-md animate-in fade-in slide-in-from-bottom-2 duration-200 flex items-center gap-2">
+                    <Check size={14} className="text-cyan-400" />
+                    <span>{toastMessage}</span>
                 </div>,
                 document.body
             )}
@@ -1947,6 +2078,10 @@ const BenchmarkRow = React.memo(({
     handleEditStagedRun,
     defaultSources,
     readOnly = false,
+    isHiddenOnGraph = false,
+    isOnlyThisVisibleOnGraph = false,
+    onToggleGraphVisibility,
+    onSoloOrInvertGraphVisibility,
 }) => {
     const benchmarkData = stat.data || [];
     const meta = benchmarkData[0]?.metadata || {};
@@ -2041,10 +2176,29 @@ const BenchmarkRow = React.memo(({
 
 
                                     return (
-                                        <div 
-                                            key={stat.benchmarkKey || stat.model}
-                                            className={cn(
-                                                'flex flex-col bg-white dark:bg-slate-900 border rounded-lg transition-colors duration-150 shadow-sm relative',
+                                        <div className="flex items-center gap-3 w-full group/benchmark-row">
+                                            {readOnly && onToggleGraphVisibility && (
+                                                <button
+                                                    type="button"
+                                                    onClick={(e) => {
+                                                        e.stopPropagation();
+                                                        onToggleGraphVisibility(stat.benchmarkKey);
+                                                    }}
+                                                    className={cn(
+                                                        "p-2.5 rounded-xl border transition-all cursor-pointer flex-shrink-0 select-none shadow-sm",
+                                                        !isHiddenOnGraph
+                                                            ? "bg-cyan-500/10 hover:bg-cyan-500/20 border-cyan-500/30 text-cyan-400"
+                                                            : "bg-slate-900/60 hover:bg-slate-900 border-slate-800 text-slate-500 hover:text-slate-400 opacity-60"
+                                                    )}
+                                                    title={!isHiddenOnGraph ? "Hide line from graph plot" : "Show line on graph plot"}
+                                                >
+                                                    {!isHiddenOnGraph ? <Eye size={16} /> : <EyeOff size={16} />}
+                                                </button>
+                                            )}
+                                            <div 
+                                                key={stat.benchmarkKey || stat.model}
+                                                className={cn(
+                                                    'flex-1 flex flex-col bg-white dark:bg-slate-900 border rounded-lg transition-colors duration-150 shadow-sm relative',
                                                 cardBorderClass,
                                                 cardBgClass,
                                                 isBaseline && 'ring-2 ring-cyan-400/50'
@@ -2334,6 +2488,24 @@ const BenchmarkRow = React.memo(({
                                                                                              </button>
                                                                                          )}
                                                                                      </div>
+                                                                                       {onSoloOrInvertGraphVisibility && (
+                                                                                           <button
+                                                                                               type="button"
+                                                                                               onClick={(e) => {
+                                                                                                   e.stopPropagation();
+                                                                                                   onSoloOrInvertGraphVisibility(stat.benchmarkKey);
+                                                                                               }}
+                                                                                               className={cn(
+                                                                                                   "opacity-0 group-hover/benchmark-row:opacity-100 transition-opacity duration-150 text-[10px] font-extrabold uppercase tracking-wider px-2 py-0.5 rounded-md border select-none cursor-pointer flex-shrink-0 ml-1.5 shadow-sm",
+                                                                                                   isOnlyThisVisibleOnGraph
+                                                                                                       ? "bg-amber-500/10 hover:bg-amber-500/20 border-amber-500/30 text-amber-400 hover:text-amber-300"
+                                                                                                       : "bg-cyan-500/10 hover:bg-cyan-500/20 border-cyan-500/30 text-cyan-400 hover:text-cyan-300"
+                                                                                               )}
+                                                                                               title={isOnlyThisVisibleOnGraph ? "Show all other selected benchmarks on graph" : "Show only this benchmark on graph"}
+                                                                                           >
+                                                                                               {isOnlyThisVisibleOnGraph ? "Invert" : "Solo"}
+                                                                                           </button>
+                                                                                       )}
 
                                                                             {isBrv02 && !readOnly && (
                                                                                 <div className="flex flex-col items-end gap-1.5 relative">
@@ -2854,11 +3026,11 @@ const BenchmarkRow = React.memo(({
                                                                           </tr>
                                                                       ))}
                                                               </tbody>
-                                                          </table>
-                                                      </div>
-                                                </div>
-                                            )}
-                                        </div>
-                                    );
-
+                                                           </table>
+                                                       </div>
+                                                   </div>
+                                               )}
+                                           </div>
+                                       </div>
+                                   );
 });

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -20,6 +20,8 @@ import { INTEGRATIONS, getSourceTag, getBenchmarkKey, getBucket, getRatioType, g
 import { useGitHubAuth } from '../hooks/useGitHubAuth.js';
 import { Button, Modal, Spinner, Checkbox, Input } from './ui';
 import { cn } from '../utils/cn';
+import { decodeShareLink } from '../utils/shareLinkEncoder';
+import { parseReportV02, stageToEntry } from '../utils/benchmarkReportV02Parser';
 
 
 
@@ -86,6 +88,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
         handleAddAWSBucket,
         removeAWSBucket,
         toasts,
+        addToast,
         removeToast,
         brv02Runs,
         brv02CustomLabels,
@@ -209,6 +212,156 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
             onNavigate('submit-benchmarks', { intent: 'submit-review' });
         }
     }, [isAuthenticated, onNavigate]);
+
+    const hasProcessedShareLink = React.useRef(false);
+
+    React.useEffect(() => {
+        const processShareLink = async () => {
+            const params = new URLSearchParams(window.location.search);
+            const benchmarksParam = params.get('benchmarks');
+
+            if (benchmarksParam === null || hasProcessedShareLink.current) return;
+            hasProcessedShareLink.current = true;
+
+            if (benchmarksParam === '') {
+                params.delete('benchmarks');
+                const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+                window.history.replaceState(null, '', newUrl);
+                return;
+            }
+
+            let targetUuids = [];
+            try {
+                targetUuids = decodeShareLink(benchmarksParam);
+            } catch (e) {
+                console.warn('[ShareLink] Malformed share link parameter:', e.message);
+                if (dashboardData.addToast) {
+                    dashboardData.addToast('Invalid share link format', 'error');
+                }
+                params.delete('benchmarks');
+                const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+                window.history.replaceState(null, '', newUrl);
+                return;
+            }
+
+            if (targetUuids.length === 0) {
+                params.delete('benchmarks');
+                const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+                window.history.replaceState(null, '', newUrl);
+                return;
+            }
+
+            const keysToSelect = new Set();
+            const missingUuids = [];
+
+            targetUuids.forEach(uuid => {
+                const existing = (data || []).find(d => 
+                    d.run_id === uuid || 
+                    (d.source && d.source.endsWith(uuid)) ||
+                    (d.benchmarkKey && d.benchmarkKey.includes(uuid))
+                );
+                if (existing) {
+                    keysToSelect.add(getBenchmarkKey(existing));
+                } else {
+                    missingUuids.push(uuid);
+                }
+            });
+
+            let missingCount = 0;
+            let forbiddenCount = 0;
+
+            if (missingUuids.length > 0) {
+                const headers = {};
+                const token = localStorage.getItem('prism_github_token');
+                if (token) {
+                    headers['X-Prism-Github-Token'] = token;
+                }
+
+                await Promise.all(missingUuids.map(async (uuid) => {
+                    try {
+                        const res = await fetch(`/api/results/${uuid}`, { headers });
+                        if (res.status === 404) {
+                            missingCount++;
+                            return;
+                        }
+                        if (res.status === 403) {
+                            forbiddenCount++;
+                            return;
+                        }
+                        if (!res.ok) {
+                            missingCount++;
+                            return;
+                        }
+
+                        const jsonPayload = await res.json();
+                        if (jsonPayload && jsonPayload.entries && Array.isArray(jsonPayload.entries)) {
+                            const parsedEntries = [];
+                            for (const stageEntry of jsonPayload.entries) {
+                                if (stageEntry.raw_report) {
+                                    const parsedStage = parseReportV02(stageEntry.raw_report, stageEntry.filename);
+                                    if (parsedStage) {
+                                        parsedStage.runId = jsonPayload.runId;
+                                        parsedStage.runLabel = jsonPayload.runLabel;
+                                        parsedStage.github_author = jsonPayload.github_author;
+                                        parsedStage.submission_state = jsonPayload.submission_state || 'public';
+                                        parsedStage.submitted_at = jsonPayload.submitted_at;
+                                        parsedStage.well_lit_path = jsonPayload.well_lit_path || null;
+                                        parsedStage.wellLitPath = jsonPayload.well_lit_path || null;
+
+                                        const entry = stageToEntry(parsedStage);
+                                        entry.run_id = jsonPayload.runId;
+                                        entry.source = 'gcs:llm-d-benchmarks';
+                                        entry.source_info = {
+                                            type: 'benchmark_report_v02',
+                                            origin: 'gcs:llm-d-benchmarks',
+                                            submission_state: jsonPayload.submission_state || 'public',
+                                            file_identifier: jsonPayload.runId
+                                        };
+                                        parsedEntries.push(entry);
+                                    }
+                                }
+                            }
+
+                            if (parsedEntries.length > 0) {
+                                if (dashboardData.injectDynamicEntries) {
+                                    dashboardData.injectDynamicEntries(parsedEntries);
+                                }
+                                const key = getBenchmarkKey(parsedEntries[0]);
+                                keysToSelect.add(key);
+                            }
+                        }
+                    } catch (e) {
+                        console.error(`[ShareLink] Error fetching run ${uuid}:`, e);
+                        missingCount++;
+                    }
+                }));
+            }
+
+            if (missingCount > 0 && dashboardData.addToast) {
+                dashboardData.addToast(`${missingCount} shared benchmark${missingCount > 1 ? 's' : ''} could not be found or ${missingCount > 1 ? 'were' : 'was'} deleted`, 'error');
+            }
+
+            if (forbiddenCount > 0 && dashboardData.addToast) {
+                dashboardData.addToast(`${forbiddenCount} shared benchmark${forbiddenCount > 1 ? 's' : ''} could not be accessed`, 'error');
+            }
+
+            if (keysToSelect.size > 0) {
+                setSelectedBenchmarks(prev => new Set([...prev, ...keysToSelect]));
+                if (dashboardState.setShowComparisonDrawer) {
+                    dashboardState.setShowComparisonDrawer(true);
+                }
+                if (dashboardData.addToast) {
+                    dashboardData.addToast(`Loaded ${keysToSelect.size} shared benchmark${keysToSelect.size > 1 ? 's' : ''} into Compare view`, 'success');
+                }
+            }
+
+            params.delete('benchmarks');
+            const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+            window.history.replaceState(null, '', newUrl);
+        };
+
+        processShareLink();
+    }, [data, dashboardData, dashboardState, setSelectedBenchmarks]);
 
 
 
@@ -821,7 +974,9 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                         showDataPanel,
                         setShowDataPanel,
                         loadAllData,
-                        dashboardState
+                        dashboardState,
+                        addToast,
+                        dashboardData
                     }}
                 />
             </main>
@@ -847,7 +1002,9 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
         showDataPanel,
         setShowDataPanel,
         loadAllData,
-        dashboardState
+        dashboardState,
+        addToast,
+        dashboardData
     ]);
 
     return (

--- a/src/config/defaultState.js
+++ b/src/config/defaultState.js
@@ -28,7 +28,7 @@ export const defaultState = {
     sources: new Set([]),
     buckets: [],
     giqProjects: [],
-    xAxisMax: 1590,
+    xAxisMax: Infinity,
     showPerChip: false,
     showSelectedOnly: true,
     showPareto: false,

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -2463,12 +2463,24 @@ export const useDashboardData = (initialState, dashboardState) => {
         return map;
     }, [submissions]);
 
+    const injectDynamicEntries = useCallback((newEntries) => {
+        if (!newEntries || newEntries.length === 0) return;
+        setData(prev => {
+            const existingKeys = new Set(prev.map(d => `${d.run_id || d.source}:${d.workload?.input_tokens || d.isl || 0}x${d.workload?.output_tokens || d.osl || 0}`));
+            const filteredNew = newEntries.filter(e => {
+                const k = `${e.run_id || e.source}:${e.workload?.input_tokens || e.isl || 0}x${e.workload?.output_tokens || e.osl || 0}`;
+                return !existingKeys.has(k);
+            });
+            return [...prev, ...filteredNew];
+        });
+    }, []);
+
     useEffect(() => {
         loadSubmissions();
     }, [loadSubmissions]);
 
     return {
-        data, setData,
+        data, setData, injectDynamicEntries,
         loading, setLoading,
         isRestoringConnections,
         gcsProgressStats,

--- a/src/hooks/useDashboardState.js
+++ b/src/hooks/useDashboardState.js
@@ -111,6 +111,7 @@ export const useDashboardState = () => {
     // Panels
     const [showDataPanel, setShowDataPanel] = useState(false);
     const [showFilterPanel, setShowFilterPanel] = useState(true);
+    const [showComparisonDrawer, setShowComparisonDrawer] = useState(false);
     const [isInspectorOpen, setIsInspectorOpen] = useState(false);
     const [qualityInspectOpen, setQualityInspectOpen] = useState(false);
 
@@ -321,6 +322,7 @@ export const useDashboardState = () => {
         // Panels
         showDataPanel, setShowDataPanel,
         showFilterPanel, setShowFilterPanel,
+        showComparisonDrawer, setShowComparisonDrawer,
         isInspectorOpen, setIsInspectorOpen,
         qualityInspectOpen, setQualityInspectOpen,
 

--- a/src/utils/shareLinkEncoder.js
+++ b/src/utils/shareLinkEncoder.js
@@ -1,0 +1,131 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Share Link Binary Base64 Encoder / Decoder for Prism Results Store
+ */
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isValidUuid(uuid) {
+    return typeof uuid === 'string' && UUID_REGEX.test(uuid);
+}
+
+/**
+ * Encodes an array of 36-character canonical UUID strings into a compact Base64 URL-safe string.
+ * @param {string[]} uuids Array of UUID strings (format: 8-4-4-4-12)
+ * @returns {string} URL-safe Base64 encoded binary string
+ */
+export function encodeShareLink(uuids) {
+    if (!Array.isArray(uuids) || uuids.length === 0) {
+        return '';
+    }
+
+    const byteArrays = [];
+
+    for (const uuid of uuids) {
+        if (!isValidUuid(uuid)) {
+            throw new Error(`Invalid UUID format: ${uuid}`);
+        }
+
+        const hex = uuid.replace(/-/g, '');
+        if (hex.length !== 32) {
+            throw new Error(`Invalid UUID length after hyphen removal: ${uuid}`);
+        }
+
+        const bytes = new Uint8Array(16);
+        for (let i = 0; i < 16; i++) {
+            bytes[i] = parseInt(hex.substring(i * 2, i * 2 + 2), 16);
+        }
+        byteArrays.push(bytes);
+    }
+
+    // Concatenate all 16-byte arrays into contiguous Uint8Array (length 16 * N)
+    const totalBytes = new Uint8Array(16 * byteArrays.length);
+    byteArrays.forEach((arr, idx) => {
+        totalBytes.set(arr, idx * 16);
+    });
+
+    // Convert Uint8Array to binary string for btoa
+    let binary = '';
+    for (let i = 0; i < totalBytes.length; i++) {
+        binary += String.fromCharCode(totalBytes[i]);
+    }
+
+    let base64;
+    if (typeof btoa === 'function') {
+        base64 = btoa(binary);
+    } else if (typeof globalThis !== 'undefined' && globalThis.Buffer) {
+        base64 = globalThis.Buffer.from(totalBytes).toString('base64');
+    } else {
+        throw new Error("Base64 encoding not supported in this environment");
+    }
+
+    // Make URL-safe: replace '+' with '-', '/' with '_', trim padding '='
+    return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}
+
+/**
+ * Decodes a compact Base64 URL-safe string into an array of 36-character canonical UUID strings.
+ * @param {string} base64Str URL-safe Base64 encoded binary string
+ * @returns {string[]} Array of UUID strings (format: 8-4-4-4-12)
+ */
+export function decodeShareLink(base64Str) {
+    if (!base64Str || typeof base64Str !== 'string') {
+        return [];
+    }
+
+    // Restore standard Base64 characters and padding
+    let base64 = base64Str.trim().replace(/-/g, '+').replace(/_/g, '/');
+    while (base64.length % 4 !== 0) {
+        base64 += '=';
+    }
+
+    let binary;
+    try {
+        if (typeof atob === 'function') {
+            binary = atob(base64);
+        } else if (typeof globalThis !== 'undefined' && globalThis.Buffer) {
+            binary = globalThis.Buffer.from(base64, 'base64').toString('binary');
+        } else {
+            throw new Error("Base64 decoding not supported in this environment");
+        }
+    } catch {
+        throw new Error("Malformed Base64 parameter");
+    }
+
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+
+    // Validation: bytes.length > 0 and byte length must be a multiple of 16
+    if (bytes.length === 0 || bytes.length % 16 !== 0) {
+        throw new Error("Invalid byte alignment. Length must be a positive multiple of 16.");
+    }
+
+    const uuids = [];
+    for (let i = 0; i < bytes.length; i += 16) {
+        const chunk = bytes.subarray(i, i + 16);
+        let hex = '';
+        for (let j = 0; j < 16; j++) {
+            hex += chunk[j].toString(16).padStart(2, '0');
+        }
+
+        const uuid = `${hex.substring(0, 8)}-${hex.substring(8, 12)}-${hex.substring(12, 16)}-${hex.substring(16, 20)}-${hex.substring(20, 32)}`;
+        uuids.push(uuid.toLowerCase());
+    }
+
+    return uuids;
+}

--- a/src/utils/shareLinkEncoder.test.js
+++ b/src/utils/shareLinkEncoder.test.js
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { encodeShareLink, decodeShareLink, isValidUuid } from './shareLinkEncoder.js';
+import assert from 'node:assert';
+
+console.log('Running shareLinkEncoder unit tests...');
+
+// 1. isValidUuid
+assert.strictEqual(isValidUuid('123e4567-e89b-12d3-a456-426614174000'), true);
+assert.strictEqual(isValidUuid('ACD1D5D0-5663-4560-8E82-98837E54D933'), true);
+assert.strictEqual(isValidUuid('invalid-uuid'), false);
+assert.strictEqual(isValidUuid('123e4567e89b12d3a456426614174000'), false);
+
+// 2. Round-trip encoding and decoding (N = 1)
+const singleUuid = ['123e4567-e89b-12d3-a456-426614174000'];
+const encoded1 = encodeShareLink(singleUuid);
+assert.strictEqual(typeof encoded1, 'string');
+assert.strictEqual(encoded1.length, 22); // 24 chars - 2 padding = 22 URL-safe chars
+const decoded1 = decodeShareLink(encoded1);
+assert.deepStrictEqual(decoded1, singleUuid);
+
+// 3. Round-trip encoding and decoding (N = 3)
+const tripleUuids = [
+    '123e4567-e89b-12d3-a456-426614174000',
+    'acd1d5d0-5663-4560-8e82-98837e54d933',
+    '88888888-4444-4444-4444-121212121212'
+];
+const encoded3 = encodeShareLink(tripleUuids);
+assert.strictEqual(encoded3.length, 64);
+const decoded3 = decodeShareLink(encoded3);
+assert.deepStrictEqual(decoded3, tripleUuids);
+
+// 4. Invalid decoding handling
+assert.throws(() => decodeShareLink('!!!invalid_base64!!!'), /Malformed Base64/);
+assert.throws(() => decodeShareLink(btoa('12345')), /Invalid byte alignment/); // 5 bytes, not multiple of 16
+
+// 5. Empty inputs
+assert.strictEqual(encodeShareLink([]), '');
+assert.deepStrictEqual(decodeShareLink(''), []);
+
+console.log('All shareLinkEncoder unit tests passed successfully!');


### PR DESCRIPTION
## What does this PR do?

This PR implements multi-benchmark link sharing for Prism Results Store and refines the Compare & Inspect sidebar UI:
- **Share Link Implementation**: Encodes selected public/unlisted benchmark run UUIDs into compact Base64 URLs (`?share=...`) and auto-opens the Compare & Inspect sidebar upon navigation. Adds Share Link buttons with copy-to-clipboard toast feedback.
- **Compare & Inspect UI Refinements**:
  - Adds external Eye icon toggles to Compare drawer cards to hide/show individual lines on the graph plot without unselecting runs.
  - Adds hover Solo/Invert buttons to Compare drawer cards for graph line isolation/inversion.
  - Defaults the [CAP] slider to AUTO mode (`xAxisMax: Infinity`).
  - Relocates the "Publish Selected" button into the Compare drawer bottom footer.
  - Aligns the Compare dialog top header border style (`border-slate-900`).

## Why is this change needed?

Enables users to copy and share direct links to specific sets of benchmark runs, making performance comparison views easily sharable and reproducible across teams.

## How was this tested?

- [x] Unit tests added/updated (`src/utils/shareLinkEncoder.test.js`)
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed (verified URL encoding/decoding, toast notifications, graph toggling, and layout rendering)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->