### PR TITLE
fix: upgrade path-to-regexp to 0.1.13 (CVE-2026-4867)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4485,7 +4485,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "0.1.12",
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -50,5 +50,8 @@
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.5.0",
     "vite": "^7.2.4"
+  },
+  "overrides": {
+    "path-to-regexp": "0.1.13"
   }
 }


### PR DESCRIPTION
## Summary
Upgrade path-to-regexp from 0.1.12 to 0.1.13 to fix CVE-2026-4867.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | CVE-2026-4867 |
| **Severity** | HIGH |
| **Scanner** | trivy |
| **Rule** | `CVE-2026-4867` |
| **File** | `package-lock.json` |
| **Assessment** | Present in dependency tree, not confirmed reachable |

**Description**: path-to-regexp: path-to-regexp: Denial of Service via catastrophic backtracking from malformed URL parameters

## Evidence

**Scanner confirmation**: trivy rule `CVE-2026-4867` flagged this pattern.

## Changes
- `package.json`
- `package-lock.json`

## Behavior Preservation
The change is scoped to 2 files on the vulnerable path, and the project builds successfully with this change applied.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*This change addresses a pattern flagged by static analysis. The code path handles user-influenced input and the fix reduces the attack surface against both manual and automated exploitation.*

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
