### PR TITLE
fix: make container image targets usable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 # Project configuration
-# TODO: Replace {{PROJECT_NAME}} with your project name
-PROJECT_NAME ?= {{PROJECT_NAME}}
+PROJECT_NAME ?= llm-d-prism
 REGISTRY ?= ghcr.io/llm-d
 IMAGE ?= $(REGISTRY)/$(PROJECT_NAME)
 VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 PLATFORMS ?= linux/amd64,linux/arm64
+
+# Container engine: docker buildx if present, else podman. Override with
+# CONTAINER_TOOL=podman to force one.
+CONTAINER_TOOL ?= $(shell docker buildx version >/dev/null 2>&1 && echo docker || echo podman)
 
 # Go configuration
 GOFLAGS ?=
@@ -92,14 +95,23 @@ pre-commit: ## Run pre-commit hooks on all files
 
 .PHONY: image-build
 image-build: ## Build multi-arch container image (local only)
+ifeq ($(CONTAINER_TOOL),docker)
 	docker buildx build \
 		--platform $(PLATFORMS) \
 		--tag $(IMAGE):$(VERSION) \
 		--tag $(IMAGE):latest \
 		.
+else
+	podman manifest rm $(IMAGE):$(VERSION) 2>/dev/null || true
+	podman build \
+		--platform $(PLATFORMS) \
+		--manifest $(IMAGE):$(VERSION) \
+		.
+endif
 
 .PHONY: image-push
 image-push: ## Build and push multi-arch container image
+ifeq ($(CONTAINER_TOOL),docker)
 	docker buildx build \
 		--platform $(PLATFORMS) \
 		--push \
@@ -108,6 +120,11 @@ image-push: ## Build and push multi-arch container image
 		--tag $(IMAGE):$(VERSION) \
 		--tag $(IMAGE):latest \
 		.
+else
+	$(MAKE) image-build
+	podman manifest push --all $(IMAGE):$(VERSION) docker://$(IMAGE):$(VERSION)
+	podman manifest push --all $(IMAGE):$(VERSION) docker://$(IMAGE):latest
+endif
 
 ##@ CI Helpers
 


### PR DESCRIPTION
## Problem

`make image-build` and `make image-push` cannot run as they stand.

`PROJECT_NAME` is still the scaffold placeholder:

```make
# TODO: Replace {{PROJECT_NAME}} with your project name
PROJECT_NAME ?= {{PROJECT_NAME}}
```

so `IMAGE` expands to `ghcr.io/llm-d/{{PROJECT_NAME}}`, which is not a valid image reference.

Both targets also hardcode `docker buildx`, so they fail outright on a podman-based setup.

## Changes

- Set `PROJECT_NAME ?= llm-d-prism` and drop the TODO. This matches what CI actually publishes — `ci-release.yaml` derives the name via `${GITHUB_REPOSITORY##*/}`, which is `llm-d-prism` for this repo.
- Add `CONTAINER_TOOL`, auto-detecting `docker buildx` and falling back to `podman`.

The docker branch is byte-for-byte unchanged, so **CI behaviour is unaffected**. Podman has no equivalent of buildx `--push` and rejects `--annotation index:...`, so that branch uses `podman build --manifest` followed by `podman manifest push`.

## Testing

- `make image-build PLATFORMS=linux/amd64` via the podman path produces a valid `application/vnd.oci.image.index.v1+json` manifest list.
- `make -n image-build` / `make -n image-push` expand correctly on both branches.
- `make help` still renders both targets.

## Notes for reviewers

- `package.json`, `go.mod`, and `deploy.sh` all use the shorter name `prism`, while the repo and CI use `llm-d-prism`. I matched CI, since that governs published images, but happy to switch to `prism` if the intent is to align the other way.
- Multi-arch `image-build` needs qemu binfmt handlers registered locally (`podman run --rm --privileged tonistiigi/binfmt --install all`); without them the arm64 leg fails at `npm install`. GitHub runners are unaffected. Pass `PLATFORMS=linux/amd64` for a local single-arch build.