### PR TITLE
Add line connection mode selector for charts

### DIFF
--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1746,7 +1746,7 @@ const Dashboard = ({ mode = 'browser', onNavigateBack, onNavigate, dashboardStat
                                         isDragging, setIsDragging, lastMouseRef, chartColorMode, setChartColorMode,
                                         metricAvailability, filteredBySource, xAxisMax, setXAxisMax, setDebugInfo,
                                         isLogScaleX, setIsLogScaleX, setLatType, selectedBenchmarks,
-                                        baselineBenchmarkKey
+                                        baselineBenchmarkKey, lineConnectMode, setLineConnectMode
                                     }}
                                 />
 

--- a/src/components/Dashboard/RunComparisonChart.jsx
+++ b/src/components/Dashboard/RunComparisonChart.jsx
@@ -498,7 +498,7 @@ export const RunComparisonChart = ({
                 </div>
             </div>
 
-            <div className="h-72 overflow-x-auto overflow-y-hidden">
+            <div className="h-[260px] overflow-x-auto overflow-y-hidden">
                 {hasPlotData ? (
                     <div style={{ minWidth: `${Math.max(680, plotData.length * 48)}px`, height: '100%' }}>
                         <ResponsiveContainer width="100%" height="100%">

--- a/src/components/Dashboard/ThroughputCostChart.jsx
+++ b/src/components/Dashboard/ThroughputCostChart.jsx
@@ -19,7 +19,14 @@ import { CustomLabel, CustomChartTooltip } from '../common';
 import { Button, ChartContainer, ChartXAxis, ChartYAxis, Input, Select, gridProps } from '../ui';
 import { cn } from '../../utils/cn';
 import { getBucket, getEffectiveTp, getParetoFrontier } from '../../utils/dashboardHelpers';
-import { normalizeQualityModelName } from '../../utils/qualityParser';
+const getStageIdx = (d) => {
+    const raw = d.workload?.stage ?? d.prism_stage_index ?? d.stageIndex ?? d.stage ?? d.metadata?.stage_index ?? d.metadata?.stage;
+    if (raw !== null && raw !== undefined && raw !== '') {
+        const num = Number(raw);
+        if (!isNaN(num)) return num;
+    }
+    return null;
+};
 
 export const ThroughputCostChart = (props) => {
     const {
@@ -328,6 +335,19 @@ export const ThroughputCostChart = (props) => {
             }
             // 1. Calculate Data Bounds
             const getVal = (obj, key) => {
+                if (!obj) return undefined;
+                if (key === 'time_per_output_token') {
+                    const val = obj.time_per_output_token ?? obj.metrics?.tpot ?? obj.tpot ?? obj.metrics?.tpot_ms ?? obj.metrics?.time_per_output_token;
+                    if (val !== undefined) return val;
+                }
+                if (key === 'throughput' || key === 'metrics.output_tput') {
+                    const val = obj.throughput ?? obj.metrics?.output_tput ?? obj.metrics?.throughput;
+                    if (val !== undefined) return val;
+                }
+                if (key === 'metrics.request_rate') {
+                    const val = obj.metrics?.request_rate ?? obj.qps ?? obj.workload?.target_qps;
+                    if (val !== undefined) return val;
+                }
                 if (key.startsWith('quality.')) {
                     const normModel = normalizeQualityModelName(obj.model);
                     if (!qualityMetrics?.data?.[normModel]) return undefined;
@@ -341,11 +361,17 @@ export const ThroughputCostChart = (props) => {
             };
 
             // Filter Function Builder
-            // Enforce that BOTH X and Y values are present (> 0) to avoid plotting "0" for missing cost data
+            // Allow 0 for valid baseline/stage-0 metrics (e.g. 0 QPS or 0 ms) while excluding missing/null/negative data
             const createFilter = (xKey) => (d) => {
-                 const xVal = Number(getVal(d, xKey));
-                 const yVal = Number(getVal(d, yKey));
-                 return (!isNaN(xVal) && xVal > 0) && (!isNaN(yVal) && yVal > 0);
+                 const rawX = getVal(d, xKey);
+                 const rawY = getVal(d, yKey);
+                 const isStageZero = d.workload?.stage === 0 || d.prism_stage_index === 0 || d.stageIndex === 0 || d.stage === 0 || d.metadata?.stage_index === 0;
+                 const valX = rawX ?? (isStageZero ? 0 : null);
+                 const valY = rawY ?? (isStageZero ? 0 : null);
+                 if (valX === null || valX === undefined || valY === null || valY === undefined) return false;
+                 const xVal = Number(valX);
+                 const yVal = Number(valY);
+                 return !isNaN(xVal) && xVal >= 0 && !isNaN(yVal) && yVal >= 0;
             };
 
             let filterFn = createFilter(xKey);
@@ -890,7 +916,7 @@ export const ThroughputCostChart = (props) => {
                 };
 
                 return (
-                    <div className="bg-slate-900/80 border border-slate-700/60 rounded-2xl shadow-2xl flex flex-col w-full min-h-[550px] overflow-visible backdrop-blur-sm relative">
+                    <div className="bg-slate-900/80 border border-slate-700/60 rounded-2xl shadow-2xl flex flex-col w-full min-h-[495px] overflow-visible backdrop-blur-sm relative">
                         <div className="flex flex-col w-full h-full">
                             {/* Drawer Chart Header */}
                             <div className="px-6 py-4 border-b border-slate-800 bg-slate-900/85 flex justify-between items-center gap-6 shadow-sm rounded-t-2xl">
@@ -1020,7 +1046,7 @@ export const ThroughputCostChart = (props) => {
                             )}
 
                             {/* Chart Plot Area */}
-                            <div className="flex-1 min-h-[480px] p-4 relative overflow-visible flex flex-col bg-slate-950/20 rounded-b-2xl">
+                            <div className="flex-1 min-h-[432px] p-4 relative overflow-visible flex flex-col bg-slate-950/20 rounded-b-2xl">
                                 {zoomDomain && (
                                     <button 
                                         onClick={() => setZoomDomain(null)}
@@ -1032,7 +1058,7 @@ export const ThroughputCostChart = (props) => {
 
                                 <div 
                                     ref={containerRef}
-                                    className={cn('relative w-full h-[55vh] select-none', isZoomEnabled && isDragging ? 'cursor-grabbing' : 'cursor-default')}
+                                    className={cn('relative w-full h-[50vh] select-none', isZoomEnabled && isDragging ? 'cursor-grabbing' : 'cursor-default')}
                                     onWheel={handleWheel}
                                     onMouseDown={handleMouseDown}
                                     onMouseMove={handleMouseMove}
@@ -1106,6 +1132,11 @@ export const ThroughputCostChart = (props) => {
                                                 const lineData = visibleDataPoints
                                                      .filter(d => d.benchmarkKey === benchmarkKey)
                                                      .sort((a, b) => {
+                                                         const stageA = getStageIdx(a);
+                                                         const stageB = getStageIdx(b);
+                                                         if (stageA !== null && stageB !== null && stageA !== stageB) {
+                                                             return stageA - stageB;
+                                                         }
                                                          const qpsA = Number(getVal(a, 'metrics.request_rate')) || 0;
                                                          const qpsB = Number(getVal(b, 'metrics.request_rate')) || 0;
                                                          if (qpsA !== qpsB) return qpsA - qpsB;
@@ -1299,7 +1330,7 @@ export const ThroughputCostChart = (props) => {
                   </div>
                   <div
                       ref={containerRef}
-                      className={cn('relative w-full min-h-[450px] h-[60vh] select-none', isZoomEnabled && isDragging ? 'cursor-grabbing' : 'cursor-default')}
+                      className={cn('relative w-full min-h-[360px] h-[50vh] select-none', isZoomEnabled && isDragging ? 'cursor-grabbing' : 'cursor-default')}
                       onWheel={handleWheel}
                       onMouseDown={handleMouseDown}
                       onMouseMove={handleMouseMove}
@@ -1390,6 +1421,12 @@ export const ThroughputCostChart = (props) => {
                               const lineData = visibleDataPoints
                                   .filter(d => d.benchmarkKey === benchmarkKey)
                                   .sort((a, b) => {
+                                      const stageA = getStageIdx(a);
+                                      const stageB = getStageIdx(b);
+                                      if (stageA !== null && stageB !== null && stageA !== stageB) {
+                                          return stageA - stageB;
+                                      }
+
                                       // Sort by QPS (request_rate) first to ensure logical line tracing through load points
                                       const qpsA = Number(getVal(a, 'metrics.request_rate')) || 0;
                                       const qpsB = Number(getVal(b, 'metrics.request_rate')) || 0;

--- a/src/components/Dashboard/ThroughputCostChart.jsx
+++ b/src/components/Dashboard/ThroughputCostChart.jsx
@@ -28,6 +28,102 @@ const getStageIdx = (d) => {
     return null;
 };
 
+const CONNECT_MODES = [
+    {
+        id: 'stage',
+        name: 'Stage Sequence',
+        subtitle: 'Connect points in stage order (0 → 1 → 2)',
+    },
+    {
+        id: 'x',
+        name: 'Increasing X-Value',
+        subtitle: 'Connect points by increasing X-axis value',
+    },
+    {
+        id: 'y',
+        name: 'Increasing Y-Value',
+        subtitle: 'Connect points by increasing Y-axis value',
+    },
+];
+
+const CONNECT_MODE_LABELS = {
+    stage: 'Stage',
+    x: 'X-Value',
+    y: 'Y-Value',
+};
+
+const LineConnectPopover = ({ lineConnectMode, setLineConnectMode, size = 'normal' }) => {
+    const [open, setOpen] = React.useState(false);
+    const popoverRef = React.useRef(null);
+
+    React.useEffect(() => {
+        if (!open) return;
+        const handleOutsideClick = (e) => {
+            if (popoverRef.current && !popoverRef.current.contains(e.target)) {
+                setOpen(false);
+            }
+        };
+        document.addEventListener('mousedown', handleOutsideClick);
+        return () => document.removeEventListener('mousedown', handleOutsideClick);
+    }, [open]);
+
+    const activeLabel = CONNECT_MODE_LABELS[lineConnectMode] || 'Stage';
+
+    return (
+        <div className="relative inline-block" ref={popoverRef}>
+            <button
+                type="button"
+                onClick={() => setOpen(!open)}
+                className={cn(
+                    'flex items-center gap-1.5 px-3 py-1.5 rounded-lg transition-all text-[10px] font-extrabold uppercase tracking-wider border cursor-pointer',
+                    open || lineConnectMode !== 'stage'
+                        ? 'bg-slate-800 text-cyan-400 border-slate-700 shadow-sm'
+                        : 'bg-slate-800 hover:bg-slate-700 text-slate-350 hover:text-white border-slate-800 hover:border-slate-700'
+                )}
+                title="Choose how chart lines connect data points"
+            >
+                <span>Lines: {activeLabel}</span>
+                <ChevronDown className="w-3.5 h-3.5 opacity-80" />
+            </button>
+
+            {open && (
+                <div className="absolute right-0 mt-1.5 w-72 bg-slate-900 border border-slate-800 rounded-xl shadow-2xl p-2.5 z-[200] flex flex-col gap-1.5 backdrop-blur-md animate-in fade-in zoom-in-95 duration-150">
+                    <div className="text-[9.5px] uppercase tracking-wider font-extrabold text-slate-400 px-1 py-1 border-b border-slate-800 flex items-center justify-between">
+                        <span>Line Connection Mode</span>
+                    </div>
+                    <div className="flex flex-col gap-1">
+                        {CONNECT_MODES.map((option) => {
+                            const isSelected = lineConnectMode === option.id;
+                            return (
+                                <button
+                                    key={option.id}
+                                    type="button"
+                                    onClick={() => {
+                                        setLineConnectMode(option.id);
+                                        setOpen(false);
+                                    }}
+                                    className={cn(
+                                        "flex flex-col items-start p-2 rounded-lg text-left transition-all border cursor-pointer",
+                                        isSelected
+                                            ? "bg-cyan-950/50 border-cyan-800/80 text-cyan-300 shadow-sm"
+                                            : "bg-slate-950/40 border-slate-800 text-slate-300 hover:bg-slate-800/60 hover:border-slate-700"
+                                    )}
+                                >
+                                    <div className="flex items-center justify-between w-full">
+                                        <span className="text-xs font-bold text-slate-200">{option.name}</span>
+                                        {isSelected && <span className="w-2 h-2 rounded-full bg-cyan-400 shadow-sm shadow-cyan-400/50" />}
+                                    </div>
+                                    <span className="text-[10px] text-slate-400 mt-0.5 leading-tight">{option.subtitle}</span>
+                                </button>
+                            );
+                        })}
+                    </div>
+                </div>
+            )}
+        </div>
+    );
+};
+
 export const ThroughputCostChart = (props) => {
     const {
         tputType, setTputType, yQualityMode, setYQualityMode, chartMode, setChartMode,
@@ -42,6 +138,10 @@ export const ThroughputCostChart = (props) => {
     } = props;
 
     // We can infer canShowPerChip
+    const [internalLineConnectMode, setInternalLineConnectMode] = React.useState('stage');
+    const lineConnectMode = props.lineConnectMode ?? internalLineConnectMode;
+    const setLineConnectMode = props.setLineConnectMode ?? setInternalLineConnectMode;
+
     const [showFilters, setShowFilters] = React.useState(false);
     const localContainerRef = React.useRef(null);
     const containerRef = chartContainerRef || localContainerRef;
@@ -928,13 +1028,16 @@ export const ThroughputCostChart = (props) => {
                                         Toggle axis dimensions, normalizations and filters below
                                     </div>
                                 </div>
-                                <button 
-                                    onClick={() => setShowFilters(!showFilters)} 
-                                    className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-800 hover:bg-slate-700 text-slate-350 hover:text-white rounded-lg transition-all text-[10px] font-extrabold uppercase tracking-wider border border-slate-750"
-                                >
-                                    Filters
-                                    {showFilters ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
-                                </button>
+                                <div className="flex items-center gap-2">
+                                    <LineConnectPopover lineConnectMode={lineConnectMode} setLineConnectMode={setLineConnectMode} />
+                                    <button 
+                                        onClick={() => setShowFilters(!showFilters)} 
+                                        className="flex items-center gap-1.5 px-3 py-1.5 bg-slate-800 hover:bg-slate-700 text-slate-350 hover:text-white rounded-lg transition-all text-[10px] font-extrabold uppercase tracking-wider border border-slate-800 hover:border-slate-700"
+                                    >
+                                        Filters
+                                        {showFilters ? <ChevronUp className="w-3.5 h-3.5" /> : <ChevronDown className="w-3.5 h-3.5" />}
+                                    </button>
+                                </div>
                             </div>
 
                             {/* Drawer Expandable Filter Panel */}
@@ -1050,7 +1153,7 @@ export const ThroughputCostChart = (props) => {
                                 {zoomDomain && (
                                     <button 
                                         onClick={() => setZoomDomain(null)}
-                                        className="absolute top-4 right-4 z-10 bg-slate-800/85 hover:bg-slate-700 text-slate-350 hover:text-white text-[10px] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md border border-slate-750 shadow-lg flex items-center gap-1 cursor-pointer transition-all"
+                                        className="absolute top-4 right-4 z-10 bg-slate-800/85 hover:bg-slate-700 text-slate-350 hover:text-white text-[10px] font-extrabold uppercase tracking-wider px-2 py-1 rounded-md border border-slate-800 hover:border-slate-700 shadow-lg flex items-center gap-1 cursor-pointer transition-all"
                                     >
                                         <RotateCcw size={10} /> Reset Zoom
                                     </button>
@@ -1132,6 +1235,12 @@ export const ThroughputCostChart = (props) => {
                                                 const lineData = visibleDataPoints
                                                      .filter(d => d.benchmarkKey === benchmarkKey)
                                                      .sort((a, b) => {
+                                                         if (lineConnectMode === 'x') {
+                                                             return a.vx - b.vx;
+                                                         }
+                                                         if (lineConnectMode === 'y') {
+                                                             return a.vy - b.vy;
+                                                         }
                                                          const stageA = getStageIdx(a);
                                                          const stageB = getStageIdx(b);
                                                          if (stageA !== null && stageB !== null && stageA !== stageB) {
@@ -1326,6 +1435,10 @@ export const ThroughputCostChart = (props) => {
                       >
                           Pareto
                       </button>
+
+                      <div className="h-4 w-px bg-slate-300 dark:bg-slate-700"/>
+
+                      <LineConnectPopover lineConnectMode={lineConnectMode} setLineConnectMode={setLineConnectMode} size="normal" />
                     </div>
                   </div>
                   <div
@@ -1421,6 +1534,12 @@ export const ThroughputCostChart = (props) => {
                               const lineData = visibleDataPoints
                                   .filter(d => d.benchmarkKey === benchmarkKey)
                                   .sort((a, b) => {
+                                      if (lineConnectMode === 'x') {
+                                          return a.vx - b.vx;
+                                      }
+                                      if (lineConnectMode === 'y') {
+                                          return a.vy - b.vy;
+                                      }
                                       const stageA = getStageIdx(a);
                                       const stageB = getStageIdx(b);
                                       if (stageA !== null && stageB !== null && stageA !== stageB) {

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -1,9 +1,9 @@
 import React, { useState } from 'react';
-import { X, UploadCloud, CheckCircle, AlertCircle, AlertOctagon, AlertTriangle, FileText, ChevronLeft, ChevronRight, ChevronDown, Trash2, Upload, ShieldAlert, Check, ArrowRight, ArrowLeft, GitCompare, Zap, Cpu, Pencil, Layers, Split, GripVertical, Sparkles, Info } from 'lucide-react';
+import { X, UploadCloud, CheckCircle, AlertCircle, AlertOctagon, AlertTriangle, FileText, ChevronLeft, ChevronRight, ChevronDown, Trash2, Upload, ShieldAlert, Check, ArrowRight, ArrowLeft, GitCompare, Zap, Cpu, Pencil, Layers, Split, GripVertical, Sparkles, Info, RotateCcw } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 import { ComposedChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Scatter } from 'recharts';
 import { validateBenchmark, validatePrismUploadStructure } from '../../utils/benchmarkValidator';
-import { parseReportV02, stageToEntry, canonicalStringify, mutateRawReportMetadata } from '../../utils/benchmarkReportV02Parser';
+import { parseReportV02, stageToEntry, canonicalStringify, mutateRawReportMetadata, compareOriginalStageOrder } from '../../utils/benchmarkReportV02Parser';
 import yaml from 'js-yaml';
 import IntelligentRoutingChart from '../IntelligentRoutingChart';
 import { useGitHubAuth } from '../../hooks/useGitHubAuth';
@@ -146,6 +146,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
 
     // Coalescing & Selection states
     const [selectedBundleIds, setSelectedBundleIds] = useState([]);
+    const [confirmDeleteStage, setConfirmDeleteStage] = useState(null);
     const [isConflictModalOpen, setIsConflictModalOpen] = useState(false);
     const [pendingCoalesceBundles, setPendingCoalesceBundles] = useState([]);
     const [draggedStageIndex, setDraggedStageIndex] = useState(null);
@@ -245,7 +246,6 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
         let combinedConfig = null;
         let combinedSummary = null;
 
-        let globalStageIndex = 0;
         targetBundles.forEach(bundle => {
             if (bundle.stageFiles) {
                 combinedStageFiles.push(...bundle.stageFiles);
@@ -270,11 +270,16 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                 });
                 combinedEntries.push({
                     ...entry,
-                    prism_stage_index: globalStageIndex++,
                     run_description: resolvedMetadata.runLabel || entry.run_description,
                     raw_report: mutatedRawReport
                 });
             });
+        });
+
+        // Sort combined entries by original BRV02 stage index / filename and assign sequential prism_stage_index
+        combinedEntries.sort(compareOriginalStageOrder);
+        combinedEntries.forEach((entry, idx) => {
+            entry.prism_stage_index = idx;
         });
 
         const newPayload = {
@@ -589,6 +594,93 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                 }
             };
         }));
+    };
+
+    const isStageOrderingModified = (entries) => {
+        if (!entries || entries.length < 2) return false;
+        const sorted = [...entries].sort(compareOriginalStageOrder);
+        return entries.some((entry, idx) => entry.filename !== sorted[idx].filename || entry.run_uid !== sorted[idx].run_uid || entry.prism_stage_index !== idx);
+    };
+
+    const handleRestoreOriginalStageOrder = (bundleId) => {
+        setStagedFiles(prev => prev.map(bundle => {
+            if (bundle.id !== bundleId || !bundle.payload?.entries || bundle.payload.entries.length < 2) {
+                return bundle;
+            }
+
+            const sortedEntries = [...bundle.payload.entries].sort(compareOriginalStageOrder);
+            const reindexedEntries = sortedEntries.map((entry, idx) => ({
+                ...entry,
+                prism_stage_index: idx
+            }));
+
+            const updatedPayload = {
+                ...bundle.payload,
+                entries: reindexedEntries
+            };
+
+            setStageSortConfig(prevConfig => {
+                const copy = { ...prevConfig };
+                delete copy[bundleId];
+                return copy;
+            });
+
+            const uploadValidation = validatePrismUploadStructure(updatedPayload, { isUpload: false });
+            return {
+                ...bundle,
+                payload: updatedPayload,
+                validation: {
+                    ...bundle.validation,
+                    errors: uploadValidation.errors || [],
+                    warnings: uploadValidation.warnings || [],
+                    fieldErrors: uploadValidation.fieldErrors || {}
+                }
+            };
+        }));
+    };
+
+    const handleDeleteStage = (bundleId, stageIndexToDelete) => {
+        setStagedFiles(prev => {
+            const bundle = prev.find(b => b.id === bundleId);
+            if (!bundle || !bundle.payload?.entries) return prev;
+
+            const remainingEntries = bundle.payload.entries.filter((_, idx) => idx !== stageIndexToDelete);
+            if (remainingEntries.length === 0) {
+                return prev.filter(b => b.id !== bundleId);
+            }
+
+            const reindexedEntries = remainingEntries.map((entry, idx) => ({
+                ...entry,
+                prism_stage_index: idx
+            }));
+
+            const remainingFilenames = new Set(remainingEntries.map(e => e.filename));
+            const updatedStageFiles = (bundle.stageFiles || []).filter(sf => {
+                const fname = sf.file?.name || sf.name || sf.filename || sf.path;
+                return remainingFilenames.has(fname) || remainingEntries.some(e => e.filename?.endsWith(fname));
+            });
+
+            const updatedPayload = {
+                ...bundle.payload,
+                entries: reindexedEntries
+            };
+
+            const uploadValidation = validatePrismUploadStructure(updatedPayload, { isUpload: false });
+            return prev.map(b => {
+                if (b.id !== bundleId) return b;
+                return {
+                    ...b,
+                    stageFiles: updatedStageFiles,
+                    payload: updatedPayload,
+                    validation: {
+                        ...b.validation,
+                        errors: uploadValidation.errors || [],
+                        warnings: uploadValidation.warnings || [],
+                        fieldErrors: uploadValidation.fieldErrors || {}
+                    }
+                };
+            });
+        });
     };
 
     React.useEffect(() => {
@@ -1485,6 +1577,12 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     }
                 });
             }
+
+            // Sort payload entries by original BRV02 stage index / filename and assign normalized sequential prism_stage_index
+            payloadEntries.sort(compareOriginalStageOrder);
+            payloadEntries.forEach((entry, idx) => {
+                entry.prism_stage_index = idx;
+            });
 
             let initialInferenceTool = "";
             let initialInferenceToolVersion = "";
@@ -2639,7 +2737,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     {(wizardStep === 1 || wizardStep === 2) && stagedFiles.length > 0 && (
                     <div className={cn(
                         wizardStep === 1 ? (isUploadSidebarCollapsed ? 'w-full' : 'w-2/3 border-l border-slate-900/60') : 'w-full',
-                        'bg-slate-950 overflow-y-auto p-6 relative transition-all duration-300'
+                        'bg-slate-950 overflow-y-auto p-6 pb-24 relative transition-all duration-300'
                     )}>
                         {stagedFiles.length === 0 ? (
                             <div className="absolute inset-0 flex flex-col items-center justify-center p-6 text-center">
@@ -2791,7 +2889,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                     const _otherToolsStr = otherTools.length > 0 ? otherTools.join(', ') : 'generic/unknown';
 
                                     return (
-                                        <Panel key={bundle.id} padding="none" className="border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden shadow-none">
+                                        <Panel key={bundle.id} padding="none" className="border border-slate-200 dark:border-slate-700 rounded-lg overflow-visible shadow-none">
                                             <div 
                                                 className="flex items-center justify-between p-3 cursor-pointer hover:bg-slate-50 dark:hover:bg-slate-700/50"
                                                 onClick={() => toggleExpand(bundle.id)}
@@ -2897,7 +2995,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                           * Fields marked with "Inferred" are auto-populated by guessing from configuration files and should be verified (these fields will become editable in the next stage).
                                                       </div>
 
-                                                      <div className="mb-4 overflow-hidden border border-slate-800/40 rounded-xl bg-slate-950/40 backdrop-blur-md shadow-sm">
+                                                      <div className="mb-4 overflow-hidden border border-slate-800/40 rounded-xl bg-slate-950/40 shadow-sm">
                                                           <table className="w-full text-left text-xs border-collapse">
                                                               <tbody className="divide-y divide-slate-800/35">
                                                                   <tr className="hover:bg-slate-900/20">
@@ -3316,13 +3414,35 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                     {bundle.payload.entries && bundle.payload.entries.length > 0 && (
                                                         <div>
                                                             <h4 className="font-bold text-slate-300 text-xs uppercase tracking-wider mb-2.5 select-none">Parsed Sub-runs / Stages Validation Checklist ({bundle.payload.entries.length})</h4>
-                                                            <div className="overflow-x-auto border border-slate-900/60 rounded-xl bg-slate-950/20">
+                                                            <div className="overflow-visible border border-slate-900/60 rounded-xl bg-slate-950/20">
                                                                 <table className="w-full text-left text-xs border-collapse">
                                                                     <thead className="bg-[#0b101c]/45 text-slate-400 border-b border-slate-900/80 uppercase tracking-widest text-[9px]">
                                                                         <tr>
-                                                                            <th className="px-2 py-1.5 w-8 text-center"></th>
-                                                                            <th className="px-3 py-1.5 w-12 text-center">Stage</th>
-                                                                            <th className="px-3 py-1.5 text-center">File</th>
+                                                                            <th className="pl-2 pr-0 py-1.5 w-8 text-center"></th>
+                                                                            <th className="px-3 py-1.5 w-14 text-center select-none">
+                                                                                <div className="relative inline-flex items-center justify-center gap-1 group/stage-tooltip cursor-help">
+                                                                                    <span className="underline decoration-dotted underline-offset-4 decoration-slate-500/70 hover:decoration-cyan-400">
+                                                                                        Stage
+                                                                                    </span>
+                                                                                    <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover/stage-tooltip:block w-56 px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-normal break-words text-center normal-case tracking-normal font-sans font-normal pointer-events-none">
+                                                                                        <span className="text-[11px] text-slate-300">Stages are automatically sequential and do not reflect the original values.</span>
+                                                                                    </div>
+                                                                                </div>
+                                                                            </th>
+                                                                            <th
+                                                                                onClick={() => handleSortStages(bundle.id, 'filename')}
+                                                                                className="px-3 py-1.5 text-center cursor-pointer hover:text-cyan-400 select-none transition-colors group"
+                                                                                title="Click to sort by file name"
+                                                                            >
+                                                                                <div className="flex items-center justify-center gap-1">
+                                                                                    <span>File</span>
+                                                                                    {stageSortConfig[bundle.id]?.column === 'filename' ? (
+                                                                                        <span className="text-cyan-400 font-bold">{stageSortConfig[bundle.id].direction === 'asc' ? '▲' : '▼'}</span>
+                                                                                    ) : (
+                                                                                        <span className="opacity-0 group-hover:opacity-60 text-slate-500">▲</span>
+                                                                                    )}
+                                                                                </div>
+                                                                            </th>
                                                                             <th
                                                                                 onClick={() => handleSortStages(bundle.id, 'timestamp')}
                                                                                 className="px-3 py-1.5 cursor-pointer hover:text-cyan-400 select-none transition-colors group"
@@ -3365,7 +3485,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                     <span className="underline decoration-dotted underline-offset-4 decoration-slate-500/70 hover:decoration-cyan-400">
                                                                                         Latency
                                                                                     </span>
-                                                                                    <div className="absolute right-0 top-full mt-2 hidden group-hover/metric-tooltip:block px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-nowrap text-right normal-case tracking-normal font-sans font-normal pointer-events-none">
+                                                                                    <div className="absolute right-0 bottom-full mb-2 hidden group-hover/metric-tooltip:block px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-nowrap text-right normal-case tracking-normal font-sans font-normal pointer-events-none">
                                                                                         <span className="text-[11px] text-slate-300">End-to-End Latency</span>
                                                                                     </div>
                                                                                 </div>
@@ -3384,7 +3504,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                     <span className="underline decoration-dotted underline-offset-4 decoration-slate-500/70 hover:decoration-cyan-400">
                                                                                         TTFT
                                                                                     </span>
-                                                                                    <div className="absolute right-0 top-full mt-2 hidden group-hover/metric-tooltip:block px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-nowrap text-right normal-case tracking-normal font-sans font-normal pointer-events-none">
+                                                                                    <div className="absolute right-0 bottom-full mb-2 hidden group-hover/metric-tooltip:block px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-nowrap text-right normal-case tracking-normal font-sans font-normal pointer-events-none">
                                                                                         <span className="text-[11px] text-slate-300">Time to First Token (Prefill)</span>
                                                                                     </div>
                                                                                 </div>
@@ -3403,7 +3523,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                     <span className="underline decoration-dotted underline-offset-4 decoration-slate-500/70 hover:decoration-cyan-400">
                                                                                         TPOT
                                                                                     </span>
-                                                                                    <div className="absolute right-0 top-full mt-2 hidden group-hover/metric-tooltip:block px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-nowrap text-right normal-case tracking-normal font-sans font-normal pointer-events-none">
+                                                                                    <div className="absolute right-0 bottom-full mb-2 hidden group-hover/metric-tooltip:block px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-nowrap text-right normal-case tracking-normal font-sans font-normal pointer-events-none">
                                                                                         <span className="text-[11px] text-slate-300">Time per Output Token (Decode)</span>
                                                                                     </div>
                                                                                 </div>
@@ -3429,12 +3549,54 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                         }}
                                                                                         className="hover:bg-slate-900/30 border-b border-slate-900/10 font-medium transition-colors"
                                                                                     >
-                                                                                        <td className="px-2 py-1.5 text-center">
-                                                                                            <div
-                                                                                                className="cursor-grab active:cursor-grabbing p-1 text-slate-500 hover:text-cyan-400 transition-colors inline-block"
-                                                                                                title="Drag to re-order stage"
-                                                                                            >
-                                                                                                <GripVertical size={14} />
+                                                                                        <td className="pl-2 pr-0 py-1.5 text-center">
+                                                                                            <div className="flex items-center justify-center gap-0.5">
+                                                                                                <div
+                                                                                                    className="cursor-grab active:cursor-grabbing p-1 text-slate-500 hover:text-cyan-400 transition-colors inline-block"
+                                                                                                    title="Drag to re-order stage"
+                                                                                                >
+                                                                                                    <GripVertical size={14} />
+                                                                                                </div>
+                                                                                                <div className="relative inline-block">
+                                                                                                    <button
+                                                                                                        onClick={(e) => {
+                                                                                                            e.stopPropagation();
+                                                                                                            if (confirmDeleteStage?.bundleId === bundle.id && confirmDeleteStage?.stageIndex === idx) {
+                                                                                                                setConfirmDeleteStage(null);
+                                                                                                            } else {
+                                                                                                                setConfirmDeleteStage({ bundleId: bundle.id, stageIndex: idx });
+                                                                                                            }
+                                                                                                        }}
+                                                                                                        className="p-1 text-slate-500 hover:text-red-400 hover:bg-red-500/10 rounded transition-colors cursor-pointer"
+                                                                                                        title="Delete sub-run stage"
+                                                                                                    >
+                                                                                                        <X size={13} />
+                                                                                                    </button>
+                                                                                                    {confirmDeleteStage?.bundleId === bundle.id && confirmDeleteStage?.stageIndex === idx && (
+                                                                                                        <div className="absolute left-full ml-2 top-1/2 -translate-y-1/2 z-50 bg-slate-900 border border-slate-700/90 text-slate-200 rounded-lg shadow-2xl px-2.5 py-1.5 text-xs whitespace-nowrap flex items-center gap-2 normal-case tracking-normal font-sans">
+                                                                                                            <span className="text-[11px] font-medium text-slate-200">Delete stage?</span>
+                                                                                                            <button
+                                                                                                                onClick={(e) => {
+                                                                                                                    e.stopPropagation();
+                                                                                                                    handleDeleteStage(bundle.id, idx);
+                                                                                                                    setConfirmDeleteStage(null);
+                                                                                                                }}
+                                                                                                                className="px-1.5 py-0.5 text-[10px] font-bold bg-red-500/20 hover:bg-red-500/30 text-red-400 border border-red-500/30 rounded transition-colors cursor-pointer"
+                                                                                                            >
+                                                                                                                Delete
+                                                                                                            </button>
+                                                                                                            <button
+                                                                                                                onClick={(e) => {
+                                                                                                                    e.stopPropagation();
+                                                                                                                    setConfirmDeleteStage(null);
+                                                                                                                }}
+                                                                                                                className="px-1.5 py-0.5 text-[10px] font-medium bg-slate-800 hover:bg-slate-700 text-slate-300 rounded transition-colors cursor-pointer"
+                                                                                                            >
+                                                                                                                Cancel
+                                                                                                            </button>
+                                                                                                        </div>
+                                                                                                    )}
+                                                                                                </div>
                                                                                             </div>
                                                                                         </td>
                                                                                         <td className="px-3 py-1.5 text-center font-bold font-mono text-slate-400">{check.stageIndex}</td>
@@ -3447,7 +3609,15 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                                 <Info size={15} />
                                                                                             </div>
                                                                                         </td>
-                                                                                        <td className="px-3 py-1.5 font-mono text-[10px] text-slate-400 whitespace-nowrap" title={check.timestamp}>{check.timestamp}</td>
+                                                                                        <td className="px-3 py-1.5 font-mono whitespace-nowrap" title={check.timestamp}>
+                                                                                            {check.timestamp === 'N/A' || !check.timestamp ? (
+                                                                                                <span className="text-amber-400 italic" title="Timestamp missing or unavailable">
+                                                                                                    N/A
+                                                                                                </span>
+                                                                                            ) : (
+                                                                                                <span className="text-slate-400">{check.timestamp}</span>
+                                                                                            )}
+                                                                                        </td>
                                                                                         
                                                                                         <td className="px-3 py-1.5 text-right font-mono">
                                                                                             {check.throughput.isValid ? (
@@ -3502,6 +3672,18 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                     </tbody>
                                                                 </table>
                                                             </div>
+                                                            {isStageOrderingModified(bundle.payload.entries) && (
+                                                                <div className="flex justify-end mt-2">
+                                                                    <button
+                                                                        onClick={() => handleRestoreOriginalStageOrder(bundle.id)}
+                                                                        className="text-[11px] text-slate-400 hover:text-cyan-400 font-semibold flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-slate-900/60 hover:bg-slate-900 border border-slate-800/80 hover:border-cyan-500/40 transition-colors cursor-pointer"
+                                                                        title="Restore initial stage ordering based on original benchmark report stage numbers"
+                                                                    >
+                                                                        <RotateCcw size={12} className="text-cyan-400" />
+                                                                        <span>Restore Original Stage Order</span>
+                                                                    </button>
+                                                                </div>
+                                                            )}
                                                         </div>
                                                     )}
 

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -1861,7 +1861,7 @@ export const UnifiedDataTable = (props) => {
                         <div className="flex-1 overflow-y-auto overflow-x-hidden space-y-8 pr-1 custom-scrollbar">
                             
                             {/* Section 1: Chart Container */}
-                            <div className="min-h-[500px] w-full flex flex-col">
+                            <div className="min-h-[450px] w-full flex flex-col">
                                 <ThroughputCostChart
                                     tputType={drawerTputType}
                                     setTputType={setDrawerTputType}

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -128,6 +128,7 @@ export const UnifiedDataTable = (props) => {
         isLogScaleX: sharedIsLogScaleX, setIsLogScaleX: sharedSetIsLogScaleX,
         latType: sharedLatType, setLatType: sharedSetLatType,
         chartColorMode: sharedChartColorMode, setChartColorMode: sharedSetChartColorMode,
+        lineConnectMode: sharedLineConnectMode, setLineConnectMode: sharedSetLineConnectMode,
     } = dashboardState || {};
 
     // Local state fallbacks (if no shared dashboardState is present)
@@ -146,6 +147,10 @@ export const UnifiedDataTable = (props) => {
     const [localIsLogScaleX, localSetIsLogScaleX] = useState(false);
     const [localLatType, localSetLatType] = useState('e2e');
     const [localChartColorMode, localSetChartColorMode] = useState('hardware');
+    const [localLineConnectMode, localSetLineConnectMode] = useState('stage');
+
+    const drawerLineConnectMode = sharedLineConnectMode !== undefined ? sharedLineConnectMode : localLineConnectMode;
+    const setDrawerLineConnectMode = sharedSetLineConnectMode || localSetLineConnectMode;
 
     const drawerTputType = sharedTputType !== undefined ? sharedTputType : localTputType;
     const setDrawerTputType = sharedSetTputType || localSetTputType;
@@ -1906,6 +1911,8 @@ export const UnifiedDataTable = (props) => {
                                     setLatType={setDrawerLatType}
                                     selectedBenchmarks={selectedBenchmarks}
                                     baselineBenchmarkKey={baselineBenchmarkKey}
+                                    lineConnectMode={drawerLineConnectMode}
+                                    setLineConnectMode={setDrawerLineConnectMode}
                                 />
                             </div>
 

--- a/src/components/common/CustomChartTooltip.jsx
+++ b/src/components/common/CustomChartTooltip.jsx
@@ -152,6 +152,9 @@ export const CustomChartTooltip = ({ active, payload, label, xLabel, yLabel, qua
                      const osl = formatSeqNum(rawOsl);
                      const seqLen = (isl && osl) ? `${isl} / ${osl}` : null;
                      
+                     const rawStage = d.workload?.stage ?? d.prism_stage_index ?? d.stageIndex ?? d.stage ?? meta.stage ?? d.raw_report?.workload?.stage ?? d.rawReport?.workload?.stage;
+                     const stageVal = (rawStage != null && rawStage !== '') ? rawStage : null;
+
                      // Format X-Value logic
                      const formattedXValue = (() => {
                         const val = Number(label);
@@ -187,6 +190,7 @@ export const CustomChartTooltip = ({ active, payload, label, xLabel, yLabel, qua
                             </div>
 
                             {/* Metadata Rows */}
+                            <Row label="Stage" value={stageVal} />
                             <Row label="Accelerator" value={accelerator || hardware} />
                             {isDisaggregated ? (
                                <Row label="Nodes (P/D)" value={`P:${meta.prefill_node_count}(TP${meta.prefill_tp}) | D:${meta.decode_node_count}(TP${meta.decode_tp})`} />

--- a/src/components/ui/Modal.jsx
+++ b/src/components/ui/Modal.jsx
@@ -85,7 +85,7 @@ export function Modal({
                         )}
                     </div>
                 )}
-                <div className="px-6 py-4 overflow-y-auto">{children}</div>
+                <div className="px-6 py-4 overflow-y-auto custom-scrollbar">{children}</div>
                 {footer && (
                     <div className="flex items-center justify-end gap-2 px-6 py-4 border-t border-theme-border shrink-0">
                         {footer}

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -2007,9 +2007,38 @@ export const useDashboardData = (initialState, dashboardState) => {
                 // Resolved ID for the staged run
                 const resolvedRunId = bundleRunId || null;
 
-                if (bundle.stageFiles && bundle.stageFiles.length > 0) {
+                if (bundle.payload?.entries && bundle.payload.entries.length > 0) {
+                    for (let idx = 0; idx < bundle.payload.entries.length; idx++) {
+                        const entry = bundle.payload.entries[idx];
+                        const record = await parseReportV02(entry.raw_report || entry.content, entry.filename);
+                        if (record) {
+                            record.runId = resolvedRunId || record.runId;
+                            record.runLabel = bundleRunLabel || record.runLabel;
+                            record.run_id = entry.run_id || uuidv4();
+                            record.prism_stage_index = entry.prism_stage_index !== undefined ? entry.prism_stage_index : idx;
+                            if (record.workload) {
+                                record.workload.stage = record.prism_stage_index;
+                            }
+                            // Enrich stage record with bundle metadata
+                            record.model_name = bundle.payload.model_name || null;
+                            record.hardware = bundle.payload.hardware || null;
+                            record.config = config || bundle.payload.config || null;
+                            record.summary = summary || bundle.payload.summary || null;
+                            record.wellLitPath = bundle.payload.well_lit_path;
+                            record.well_lit_path = bundle.payload.well_lit_path;
+                            record.targetDashboards = bundle.targetDashboards;
+                            
+                            const isDupInBatch = trulyNewStages.some(s => s.filename === record.filename && s.runId === record.runId);
+                            const isDupInExisting = otherStages.some(existingStage => existingStage.filename === record.filename && existingStage.runId === record.runId);
+                            
+                            if (!isDupInBatch && !isDupInExisting) {
+                                trulyNewStages.push(record);
+                            }
+                        }
+                    }
+                } else if (bundle.stageFiles && bundle.stageFiles.length > 0) {
                     for (const sf of bundle.stageFiles) {
-                        const identifier = sf.file.webkitRelativePath || sf.file.name;
+                        const identifier = sf.file?.webkitRelativePath || sf.file?.name || sf.filename || sf.name;
                         const record = await parseReportV02(sf.validation?.parsedData || sf.content, identifier);
                         if (record) {
                             record.runId = resolvedRunId || record.runId;
@@ -2023,30 +2052,6 @@ export const useDashboardData = (initialState, dashboardState) => {
                             record.summary = summary;
                             record.wellLitPath = bundle.payload?.well_lit_path || null;
                             record.well_lit_path = bundle.payload?.well_lit_path || null;
-                            record.targetDashboards = bundle.targetDashboards;
-                            
-                            const isDupInBatch = trulyNewStages.some(s => s.filename === record.filename && s.runId === record.runId);
-                            const isDupInExisting = otherStages.some(existingStage => existingStage.filename === record.filename && existingStage.runId === record.runId);
-                            
-                            if (!isDupInBatch && !isDupInExisting) {
-                                trulyNewStages.push(record);
-                            }
-                        }
-                    }
-                } else if (bundle.payload?.entries && bundle.payload.entries.length > 0) {
-                    for (const entry of bundle.payload.entries) {
-                        const record = await parseReportV02(entry.raw_report || entry.content, entry.filename);
-                        if (record) {
-                            record.runId = resolvedRunId || record.runId;
-                            record.runLabel = bundleRunLabel || record.runLabel;
-                            record.run_id = entry.run_id || uuidv4();
-                            // Enrich stage record with bundle metadata
-                            record.model_name = bundle.payload.model_name || null;
-                            record.hardware = bundle.payload.hardware || null;
-                            record.config = config || bundle.payload.config || null;
-                            record.summary = summary || bundle.payload.summary || null;
-                            record.wellLitPath = bundle.payload.well_lit_path;
-                            record.well_lit_path = bundle.payload.well_lit_path;
                             record.targetDashboards = bundle.targetDashboards;
                             
                             const isDupInBatch = trulyNewStages.some(s => s.filename === record.filename && s.runId === record.runId);

--- a/src/hooks/useDashboardState.js
+++ b/src/hooks/useDashboardState.js
@@ -80,6 +80,7 @@ export const useDashboardState = () => {
     // Quality mode
     const [xQualityMode, setXQualityMode] = useState(initialState.xQualityMode);
     const [yQualityMode, setYQualityMode] = useState(initialState.yQualityMode);
+    const [lineConnectMode, setLineConnectMode] = useState('stage');
 
     // Chart configs
     const [xAxisMax, setXAxisMax] = useState(initialState.xAxisMax);
@@ -307,6 +308,7 @@ export const useDashboardState = () => {
         latType, setLatType,
         xQualityMode, setXQualityMode,
         yQualityMode, setYQualityMode,
+        lineConnectMode, setLineConnectMode,
 
         // Chart Configs
         xAxisMax, setXAxisMax,

--- a/src/index.css
+++ b/src/index.css
@@ -89,3 +89,56 @@
   -ms-overflow-style: none;  /* IE and Edge */
   scrollbar-width: none;  /* Firefox */
 }
+
+/* Prism Custom Scrollbars */
+::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-thumb {
+  background: #334155;
+  border-radius: 9999px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+  background: #475569;
+}
+
+::-webkit-scrollbar-corner {
+  background: transparent;
+}
+
+* {
+  scrollbar-width: thin;
+  scrollbar-color: #334155 rgba(15, 23, 42, 0.4);
+}
+
+.custom-scrollbar::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-track {
+  background: rgba(15, 23, 42, 0.4);
+  border-radius: 9999px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb {
+  background: #334155;
+  border-radius: 9999px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover {
+  background: #475569;
+}
+
+.custom-scrollbar {
+  scrollbar-width: thin;
+  scrollbar-color: #334155 rgba(15, 23, 42, 0.4);
+}

--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -334,7 +334,7 @@ export function parseReportV02(yamlText, filename) {
         runCid: doc.run?.cid || null,
         runPid: doc.run?.pid || null,
         timestamp: doc.run?.time?.start || null,
-        stageIndex: load.stage ?? null,
+        stageIndex: doc.workload?.stage ?? load.stage ?? null,
         loadMetadata: doc.scenario?.load?.metadata || null,
         scenario,
         performance,
@@ -342,6 +342,53 @@ export function parseReportV02(yamlText, filename) {
         components,
         rawReport: doc,
     };
+}
+
+export function getOriginalStageIndex(entry) {
+    if (!entry) return 0;
+    
+    const raw = entry.raw_report || entry.rawReport || entry;
+    if (raw?.workload?.stage !== undefined && raw?.workload?.stage !== null) {
+        const num = Number(raw.workload.stage);
+        if (!isNaN(num)) return num;
+    }
+    if (raw?.stageIndex !== undefined && raw?.stageIndex !== null) {
+        const num = Number(raw.stageIndex);
+        if (!isNaN(num)) return num;
+    }
+    const strToMatch = entry.filename || entry.run_uid || '';
+    const match = strToMatch.match(/stage[_-]?(\d+)/i);
+    if (match) {
+        const num = parseInt(match[1], 10);
+        if (!isNaN(num)) return num;
+    }
+    return 0;
+}
+
+/**
+ * Compares two stage entries by original BRV02 stage number or filename.
+ */
+export function compareOriginalStageOrder(a, b) {
+    const idxA = getOriginalStageIndex(a);
+    const idxB = getOriginalStageIndex(b);
+    if (idxA !== idxB) {
+        return idxA - idxB;
+    }
+    const nameA = (a.filename || a.run_uid || '').split('/').pop();
+    const nameB = (b.filename || b.run_uid || '').split('/').pop();
+    return nameA.localeCompare(nameB, undefined, { numeric: true, sensitivity: 'base' });
+}
+
+/**
+ * Compares two stage entries respecting prism_stage_index first, then original stage number or filename.
+ */
+export function compareStageOrder(a, b) {
+    const idxA = a?.prism_stage_index !== undefined && a?.prism_stage_index !== null ? Number(a.prism_stage_index) : null;
+    const idxB = b?.prism_stage_index !== undefined && b?.prism_stage_index !== null ? Number(b.prism_stage_index) : null;
+    if (idxA !== null && idxB !== null && !isNaN(idxA) && !isNaN(idxB)) {
+        return idxA - idxB;
+    }
+    return compareOriginalStageOrder(a, b);
 }
 
 /**
@@ -402,13 +449,9 @@ export function groupStagesIntoRuns(stageRecords) {
         if (!targetRun.targetDashboards && record.targetDashboards) targetRun.targetDashboards = record.targetDashboards;
     }
     
-    // Sort stages within each run by stageIndex
+    // Sort stages within each run respecting prism_stage_index then original stage index
     for (const run of runsList) {
-        run.stages.sort((a, b) => {
-            if (a.stageIndex === null) return 1;
-            if (b.stageIndex === null) return -1;
-            return a.stageIndex - b.stageIndex;
-        });
+        run.stages.sort(compareStageOrder);
     }
 
     // Propagate the runLabel to all stages

--- a/src/utils/benchmarkValidator.js
+++ b/src/utils/benchmarkValidator.js
@@ -72,8 +72,8 @@ export function validateBenchmark(fileContent, filename) {
                 
                 const entry = stageToEntry(stage);
                 const latencyVal = entry.latency && typeof entry.latency === 'object' ? entry.latency.mean : entry.latency;
-                if (entry.throughput === null || entry.throughput <= 0 || latencyVal === null || latencyVal <= 0) {
-                    result.errors.push(`Stage ${stage.stageIndex} has zero or negative metrics.`);
+                if (entry.throughput === null || entry.throughput < 0 || latencyVal === null || latencyVal < 0) {
+                    result.errors.push(`Stage ${stage.stageIndex} has negative metrics.`);
                 }
                 entries.push({
                     model_name: entry.model_name,
@@ -317,10 +317,10 @@ export function validatePrismUploadStructure(uploadData, options = {}) {
                 }
             }
 
-            // 4. Verify no zero or negative metrics
+            // 4. Verify no negative metrics
             const latencyVal = normalizedEntry.latency && typeof normalizedEntry.latency === 'object' ? normalizedEntry.latency.mean : normalizedEntry.latency;
-            if (normalizedEntry.throughput === null || normalizedEntry.throughput <= 0 || latencyVal === null || latencyVal <= 0) {
-                errors.push(`Stage ${stageIndex} (${entry.filename}) has zero or negative metrics.`);
+            if (normalizedEntry.throughput === null || normalizedEntry.throughput < 0 || latencyVal === null || latencyVal < 0) {
+                errors.push(`Stage ${stageIndex} (${entry.filename}) has negative metrics.`);
             }
 
         } catch (e) {

--- a/src/utils/dataParser.js
+++ b/src/utils/dataParser.js
@@ -994,7 +994,8 @@ export function parseLpgLatencyProfile(json, filename) {
             workload: {
                 input_tokens: isl,
                 output_tokens: osl,
-                target_qps: reqRate
+                target_qps: reqRate,
+                stage: idx
             },
 
             metadata: {

--- a/src/utils/manualCoalescing.test.js
+++ b/src/utils/manualCoalescing.test.js
@@ -1,0 +1,207 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from 'node:assert';
+import { v4 as uuidv4 } from 'uuid';
+import { validatePrismUploadStructure } from './benchmarkValidator.js';
+import { PrismResultPayloadSchema } from '../../server/results/api.ts';
+import { mutateRawReportMetadata, getOriginalStageIndex, compareOriginalStageOrder } from './benchmarkReportV02Parser.js';
+
+console.log('Running manual benchmark coalescing unit tests...');
+
+// 1. Validate payload schema with prism_stage_index
+const samplePayload = {
+    runId: uuidv4(),
+    runLabel: "Coalesced uBench Multi-Stage Run",
+    model_name: "meta-llama/Llama-3-8B-Instruct",
+    hardware: {
+        hardware_name: "H100",
+        accelerator_count: 8
+    },
+    format: "brv02",
+    entries: [
+        {
+            run_id: uuidv4(),
+            run_description: "Coalesced uBench Multi-Stage Run",
+            filename: "stage_0_report.yaml",
+            prism_stage_index: 0,
+            raw_report: {
+                version: "0.2",
+                workload: { stage: 0 },
+                run: { uid: "ubench-stage-0" },
+                scenario: { model: "meta-llama/Llama-3-8B-Instruct" },
+                results: {
+                    request_performance: {
+                        aggregate: {
+                            throughput: { output_token_rate: { mean: 45.2 } },
+                            latency: { request_latency: { mean: 0.25 }, time_to_first_token: { mean: 0.1 }, time_per_output_token: { mean: 0.02 } }
+                        }
+                    }
+                }
+            }
+        },
+        {
+            run_id: uuidv4(),
+            run_description: "Coalesced uBench Multi-Stage Run",
+            filename: "stage_1_report.yaml",
+            prism_stage_index: 1,
+            raw_report: {
+                version: "0.2",
+                workload: { stage: 1 },
+                run: { uid: "ubench-stage-1" },
+                scenario: { model: "meta-llama/Llama-3-8B-Instruct" },
+                results: {
+                    request_performance: {
+                        aggregate: {
+                            throughput: { output_token_rate: { mean: 55.0 } },
+                            latency: { request_latency: { mean: 0.22 }, time_to_first_token: { mean: 0.09 }, time_per_output_token: { mean: 0.018 } }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+};
+
+// Test Zod schema validation
+const parseResult = PrismResultPayloadSchema.safeParse(samplePayload);
+assert.strictEqual(parseResult.success, true, `Zod validation failed: ${JSON.stringify(parseResult.error?.issues)}`);
+assert.strictEqual(samplePayload.entries[0].prism_stage_index, 0);
+assert.strictEqual(samplePayload.entries[1].prism_stage_index, 1);
+
+// Test validatePrismUploadStructure helper
+const structValidation = validatePrismUploadStructure(samplePayload, { isUpload: false });
+assert.strictEqual(structValidation.isValid, true, `Structure validation failed: ${structValidation.errors?.join(', ')}`);
+
+// 2. Test raw report immutability during stage re-indexing
+const rawReportBefore0 = { ...samplePayload.entries[0].raw_report };
+const reindexedEntries = samplePayload.entries.map((entry, idx) => ({
+    ...entry,
+    prism_stage_index: 1 - idx // reverse ordering
+}));
+
+assert.deepStrictEqual(reindexedEntries[0].raw_report, rawReportBefore0, "Raw report object was mutated during re-indexing");
+assert.strictEqual(reindexedEntries[0].prism_stage_index, 1, "prism_stage_index was not updated");
+assert.strictEqual(reindexedEntries[1].prism_stage_index, 0, "prism_stage_index was not updated");
+
+// 3. Test Auto-Group heuristic grouping logic
+const runA = {
+    id: "run-1",
+    payload: {
+        model_name: "meta-llama/Llama-3-8B-Instruct",
+        hardware: { hardware_name: "H100", accelerator_count: 8 },
+        inference_tool: "vllm"
+    }
+};
+const runB = {
+    id: "run-2",
+    payload: {
+        model_name: "meta-llama/Llama-3-8B-Instruct",
+        hardware: { hardware_name: "H100", accelerator_count: 8 },
+        inference_tool: "vllm"
+    }
+};
+const runC = {
+    id: "run-3",
+    payload: {
+        model_name: "Qwen/Qwen2.5-7B",
+        hardware: { hardware_name: "TPU v6e", accelerator_count: 4 },
+        inference_tool: "tgi"
+    }
+};
+
+const bundles = [runA, runB, runC];
+const groupsMap = new Map();
+bundles.forEach(bundle => {
+    const m = (bundle.payload?.model_name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    const h = (bundle.payload?.hardware?.hardware_name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+    const tool = (bundle.payload?.inference_tool || '').toLowerCase().trim();
+    const key = `${m}::${h}::${tool}`;
+
+    if (!groupsMap.has(key)) {
+        groupsMap.set(key, [bundle]);
+    } else {
+        groupsMap.get(key).push(bundle);
+    }
+});
+
+assert.strictEqual(groupsMap.size, 2, "Auto-grouping did not produce expected number of distinct groups");
+const matchingGroup = Array.from(groupsMap.values()).find(g => g.length === 2);
+assert.notStrictEqual(matchingGroup, undefined, "Auto-grouping failed to match candidate runs");
+assert.strictEqual(matchingGroup.length, 2, "Candidate group does not contain 2 matched runs");
+assert.strictEqual(matchingGroup[0].id, "run-1");
+assert.strictEqual(matchingGroup[1].id, "run-2");
+
+// 4. Test Stage Sorting by Original BRV02 Stage Number & Normalization
+const unsortedEntries = [
+    { filename: "stage_9_report.yaml", raw_report: { workload: { stage: 9 } } },
+    { filename: "stage_3_report.yaml", raw_report: { workload: { stage: 3 } } },
+    { filename: "stage_8_report.yaml", raw_report: { workload: { stage: 8 } } },
+    { filename: "stage_5_report.yaml", raw_report: { workload: { stage: 5 } } }
+];
+
+unsortedEntries.sort(compareOriginalStageOrder);
+unsortedEntries.forEach((entry, idx) => {
+    entry.prism_stage_index = idx;
+});
+
+assert.strictEqual(unsortedEntries[0].raw_report.workload.stage, 3);
+assert.strictEqual(unsortedEntries[0].prism_stage_index, 0);
+
+assert.strictEqual(unsortedEntries[1].raw_report.workload.stage, 5);
+assert.strictEqual(unsortedEntries[1].prism_stage_index, 1);
+
+assert.strictEqual(unsortedEntries[2].raw_report.workload.stage, 8);
+assert.strictEqual(unsortedEntries[2].prism_stage_index, 2);
+
+assert.strictEqual(unsortedEntries[3].raw_report.workload.stage, 9);
+assert.strictEqual(unsortedEntries[3].prism_stage_index, 3);
+
+// 5. Test raw_report metadata mutation synchronization
+const brv02Report = {
+    version: "0.2",
+    run: { uid: "stage-uid-123", description: "Old Run Description" },
+    scenario: {
+        stack: [
+            {
+                standardized: {
+                    role: "aggregate",
+                    model: { name: "qwen3_coder_480b_a35b_instruct-fp8_8k_1k_inference_perf" },
+                    accelerator: { model: "Old Hardware" }
+                }
+            }
+        ],
+        load: {
+            native: {
+                config: {
+                    server: { model_name: "qwen3_coder_480b_a35b_instruct-fp8_8k_1k_inference_perf" }
+                }
+            }
+        }
+    }
+};
+
+const updatedReport = mutateRawReportMetadata(brv02Report, {
+    model_name: "qwen3_coder_480b",
+    hardware_name: "H100",
+    runLabel: "Unified Coalesced Run"
+});
+
+assert.strictEqual(updatedReport.run.uid, "stage-uid-123", "Stage uid was mutated");
+assert.strictEqual(updatedReport.run.description, "Unified Coalesced Run", "Run description was not updated");
+assert.strictEqual(updatedReport.scenario.stack[0].standardized.model.name, "qwen3_coder_480b", "Model name in scenario.stack was not updated");
+assert.strictEqual(updatedReport.scenario.load.native.config.server.model_name, "qwen3_coder_480b", "Model name in load.native was not updated");
+assert.strictEqual(updatedReport.scenario.stack[0].standardized.accelerator.model, "H100", "Hardware in scenario.stack was not updated");
+
+console.log('All manual benchmark coalescing unit tests passed successfully!');


### PR DESCRIPTION
## What does this PR do?

This PR introduces chart line connection mode controls, Stage 0 point rendering and ordering fixes, custom scrollbar styling for modals, and support for sub-run stage reordering and deletion during benchmark staging.

### Summary of Changes:
- **Line Connection Mode Selector**:
  - Added a popover selector for chart line connection modes in chart controls.
  - Supports three connection modes: **Stage Sequence** (Default, `0 → 1 → 2`), **Increasing X-Value**, and **Increasing Y-Value**.
  - Positioned the line connection selector button in the drawer header directly to the left of the Filters button, matching its dark slate styling.
  - Synchronized connection mode selection across chart drawer views.

- **Custom Scrollbar Styling**:
  - Added custom scrollbar styling across modals for a consistent dark slate appearance matching the Prism theme.

- **Stage 0 Rendering & Point Ordering Fixes**:
  - Updated chart rendering to default missing or zero metric values for Stage 0 baseline/idle points so they display properly on chart lines.
  - Ordered line data points by stage sequence first before throughput and coordinate values.
  - Added stage metadata indicators to chart hover tooltips.
  - Adjusted metric validation to accept non-negative Stage 0 metric values.
  - Optimized chart plot heights for better screen visibility.

- **Sub-Run Stage Reordering & Deletion**:
  - Added sub-run stage deletion with inline confirmation dialogs during benchmark staging.
  - Added column header sorting and stage reordering guidance.
  - Added an option to restore original stage ordering.
  - Preserved multi-stage index ordering when staging consolidated benchmark runs.

## Why is this change needed?

- **Flexible Chart Visualization**: When comparing benchmark runs across different workloads, connecting points strictly by throughput or X-axis values can produce overlapping lines. Explicit connection modes (by stage sequence, X-value, or Y-value) allow users to trace multi-stage workloads logically.
- **Stage 0 Visualization**: Stage 0 benchmarks (representing baseline/idle metrics) were previously omitted or misplaced on chart lines due to missing value fallbacks and default sorting.
- **Staging Flexibility**: Staging multi-stage benchmark runs requires sub-stage deletion, reordering flexibility, and index normalization.
- **Consistent Visual Design**: Native browser scrollbars in modals clashed with Prism's dark theme.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)