### PR TITLE
Fix agentic serving guide chart axes and labels (#106)

### DIFF
--- a/skills/style.md
+++ b/skills/style.md
@@ -93,7 +93,9 @@ All from `import { ... } from './ui'` (or the relative path to `src/components/u
   one row above the plot).
 - Axes: `ChartXAxis` / `ChartYAxis` (theme-aware; same tick formatting as the
   old `CustomXAxis`/`CustomYAxis`). Grid: `<CartesianGrid {...gridProps()} />`.
-- **Axis domain and ticks**: Prefer including zero on linear scales for a proper baseline. Ticks must be normalized (even, clean distributions). Extend domains slightly beyond the max data point (e.g. 5% upper padding) so data marks are not clipped at the outer edges of the plot. Use the shared utility `getAxisConfig(minVal, maxVal, isLog, options)` from `./ui` to compute domains and ticks, and always configure sufficient margins (e.g., `left: 60`, `bottom: 45` on the chart component) to avoid clipping labels.
+- **Axis domain and ticks**: Prefer including zero on linear scales for a proper baseline. Ticks must be normalized (even, clean distributions). Extend domains slightly beyond the max data point (e.g. 5% upper padding) so data marks are not clipped at the outer edges of the plot. Use the shared utility `getAxisConfig(minVal, maxVal, isLog, options)` from `./ui` to compute domains and ticks, and always configure sufficient margins (e.g., `left: 70`, `bottom: 45` on the chart component) to avoid clipping labels.
+  - **Default to linear scale**, not log. Linear keeps a zero baseline and evenly spaced, fully-labelled ticks; log collapses a narrow data span to a sparse set of powers of ten. Only opt into log for data spanning many orders of magnitude. (`getAxisConfig`'s log branch subdivides each decade `1-2-5` so log mode stays readable when enabled.)
+  - **Render every computed tick.** When you pass an explicit `ticks` list to `ChartXAxis`, all ticks are shown (`interval={0}` is applied automatically); do not let recharts auto-hide "overlapping" ticks, which makes an evenly-spaced axis look uneven and sparse.
 - Series colors: `CHART_SERIES` in fixed order — emerald, sky, amber, violet,
   pink. Assign by entity, never by rank: a series keeps its color when filters
   change the series count. More than 5 series → fold into "Other" or use small

--- a/src/components/AgenticWorkloadsDashboard.jsx
+++ b/src/components/AgenticWorkloadsDashboard.jsx
@@ -174,7 +174,10 @@ export default function AgenticWorkloadsDashboard({ onNavigateBack, onNavigate, 
     const [showFilters, setShowFilters] = useState(true);
     const [zoomXAxis, setZoomXAxis] = useState('ntpot');
     const [zoomYAxis, setZoomYAxis] = useState('total');
-    const [zoomLogScale, setZoomLogScale] = useState(true);
+    // Default to a linear scale (matching the intelligent-routing and milestone
+    // dashboards): linear gives an even, zero-based, fully-labelled axis, whereas
+    // a log scale collapses the visible ticks to a sparse set of powers of ten.
+    const [zoomLogScale, setZoomLogScale] = useState(false);
     const [zoomPerChip, setZoomPerChip] = useState(false);
     const [visiblePercentiles, setVisiblePercentiles] = useState(['P50']);
     const [zoomXMax, setZoomXMax] = useState(null);
@@ -520,7 +523,7 @@ export default function AgenticWorkloadsDashboard({ onNavigateBack, onNavigate, 
             <div className="bg-slate-950/30 rounded-xl p-4 border border-slate-800/40 m-4 flex flex-col flex-1 select-none">
                 <div className="relative w-full h-[380px]">
                     <ResponsiveContainer width="100%" height="100%">
-                        <ScatterChart margin={{ top: 15, right: 30, left: 60, bottom: 45 }}>
+                        <ScatterChart margin={{ top: 15, right: 30, left: 70, bottom: 45 }}>
                             <CartesianGrid {...gridProps()} opacity={0.4} />
                             <ChartXAxis dataKey="x" type="number" name={zoomXAxis.toUpperCase()} label={xAxisLabel} domain={chartAxesConfig.x.domain} ticks={chartAxesConfig.x.ticks} scale={zoomLogScale ? 'log' : 'auto'} allowDataOverflow />
                             <ChartYAxis dataKey="y" type="number" name="Throughput" label={yAxisLabel} domain={chartAxesConfig.y.domain} ticks={chartAxesConfig.y.ticks} allowDataOverflow />

--- a/src/components/ui/charts/Axis.jsx
+++ b/src/components/ui/charts/Axis.jsx
@@ -35,8 +35,12 @@ const labelStyle = (t, extra = {}) => ({
     ...extra,
 });
 
-export const ChartXAxis = ({ label, ...props }) => {
+export const ChartXAxis = ({ label, ticks, interval, ...props }) => {
     const t = getChartTheme();
+    // When an explicit tick list is supplied (e.g. from getAxisConfig), render
+    // every tick. Recharts otherwise auto-hides "overlapping" ticks, which turns
+    // an evenly-spaced list into a sparse, uneven-looking axis.
+    const resolvedInterval = interval ?? (ticks ? 0 : undefined);
     return (
         <XAxis
             stroke={t.axis}
@@ -45,16 +49,19 @@ export const ChartXAxis = ({ label, ...props }) => {
             axisLine={{ stroke: t.grid }}
             label={label && { value: label, position: 'bottom', offset: 0, style: labelStyle(t) }}
             tickFormatter={formatTick(100)}
+            ticks={ticks}
+            interval={resolvedInterval}
             {...props}
         />
     );
 };
 
-export const ChartYAxis = ({ label, ...props }) => {
+export const ChartYAxis = ({ label, width, ...props }) => {
     const t = getChartTheme();
     return (
         <YAxis
             stroke={t.axis}
+            width={width ?? 68}
             tick={{ fill: t.tick, fontSize: 10, fontFamily: 'monospace' }}
             tickLine={{ stroke: t.grid }}
             axisLine={{ stroke: t.grid }}
@@ -63,7 +70,7 @@ export const ChartYAxis = ({ label, ...props }) => {
                     value: label,
                     angle: -90,
                     position: 'insideLeft',
-                    offset: -10,
+                    offset: 0,
                     style: labelStyle(t, { textAnchor: 'middle' }),
                 }
             }

--- a/src/components/ui/charts/utils.js
+++ b/src/components/ui/charts/utils.js
@@ -31,16 +31,27 @@ export function getAxisConfig(minVal, maxVal, isLog = false, options = {}) {
 
     if (isLog) {
         const min = Math.max(0.1, minVal);
-        const logMin = Math.floor(Math.log10(min));
         const paddedMaxVal = maxVal * (1 + padding);
+        const logMin = Math.floor(Math.log10(min));
         const logMax = Math.ceil(Math.log10(paddedMaxVal));
+
+        // Over a narrow span (a couple of decades) plain powers of ten collapse
+        // to just 2-3 marks, leaving the data bunched between sparse ticks.
+        // Subdivide each decade with a 1-2-5 sequence for an even distribution.
+        const subdivide = (logMax - logMin) <= 2;
+        const mantissas = subdivide ? [1, 2, 5] : [1];
+        const lo = Math.pow(10, logMin);
+        const hi = Math.pow(10, logMax);
 
         const ticks = [];
         for (let i = logMin; i <= logMax; i++) {
-            ticks.push(Math.pow(10, i));
+            for (const m of mantissas) {
+                const v = m * Math.pow(10, i);
+                if (v >= lo && v <= hi) ticks.push(v);
+            }
         }
         return {
-            domain: [Math.pow(10, logMin), Math.pow(10, logMax)],
+            domain: [lo, hi],
             ticks
         };
     }


### PR DESCRIPTION
## Summary
Fixes #106 — the agentic serving guide chart had a chopped Y-axis label and a sparse/uneven X axis.

## Root cause
- The agentic dashboard defaulted to a **log** scale (`zoomLogScale = true`), so the X axis collapsed to a sparse `10 / 100 / 1000`, unlike the intelligent-routing / milestone dashboards which default to linear.
- The shared `ChartYAxis` label offset (`-10`) clipped the rotated title at the left edge.
- Explicit ticks from `getAxisConfig` were auto-hidden by recharts, making an even tick set look uneven.

## Changes
- **AgenticWorkloadsDashboard**: default to a linear (zero-based) scale; widen the left chart margin.
- **ChartXAxis**: render every tick when an explicit `ticks` list is supplied (`interval={0}`).
- **ChartYAxis**: reserve axis width and stop clipping the title.
- **getAxisConfig (log branch)**: subdivide each decade `1-2-5` so log mode stays readable when enabled.
- **skills/style.md**: document the reusable axis principles (default linear, render all ticks, log subdivision, margins).

## Principles applied
Zero baseline, normalized/even tick distribution, and upper padding so data points don't sit at the plot edge.

## Verification
Verified in-browser with representative data: default view shows even `0/50/100/150/200` (X) and `0…25000` (Y) with padding and a fully-visible Y label; log toggle shows dense `10/20/50/100/200/500/1000`. The intelligent-routing chart is unchanged in behavior.
