### PR TITLE
feat: support subdirectory scoping for GCS bucket sources

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The following environment variables can be set via `--set-env-vars` in the `gclo
 - **`SITE_NAME`**: Custom text appended to "Prism".
 - **`CONTACT_US_URL`**: URL or email for the support link.
 - **`DEFAULT_PROJECTS`**: Comma-separated list of Project IDs for GIQ data.
-- **`DEFAULT_BUCKETS`**: Comma-separated list of GCS buckets for results.
+- **`DEFAULT_BUCKETS`**: Comma-separated list of GCS buckets for results. An entry may be scoped to a subdirectory with a `bucket/path/to/dir` suffix, restricting the scan to objects under that prefix (e.g. `my-bucket/team-a/results`).
 - **`DEFAULT_S3_BUCKETS`**: Comma-separated list of public AWS S3 buckets.
 - **`GOOGLE_API_KEY`**: API Key for Google Drive/Sheets (auto-detected from `.env.local` if present).
 - **`GITHUB_CLIENT_ID`**: The Client ID of your registered GitHub OAuth App (used for authentication).

--- a/server/buckets.js
+++ b/server/buckets.js
@@ -1,0 +1,65 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const DEFAULT_RESULTS_BUCKETS = 'llm-d-benchmarks-staging,llm-d-benchmarks';
+
+/**
+ * Parses a single DEFAULT_BUCKETS entry of the form "bucket" or
+ * "bucket/path/to/dir" (optionally scheme-prefixed) into its bucket name
+ * and normalized object prefix ("" or "path/to/dir/").
+ *
+ * @param {string} entry
+ * @returns {{ bucket: string, prefix: string }}
+ */
+export function parseBucketEntry(entry) {
+    const cleaned = String(entry || '')
+        .trim()
+        .replace(/^(gs|s3|https?):\/\//i, '')
+        .replace(/\/+$/, '');
+    const slashIdx = cleaned.indexOf('/');
+    if (slashIdx === -1) {
+        return { bucket: cleaned, prefix: '' };
+    }
+    const pathParts = cleaned.slice(slashIdx + 1).split('/').filter(Boolean);
+    return {
+        bucket: cleaned.slice(0, slashIdx),
+        prefix: pathParts.length ? `${pathParts.join('/')}/` : ''
+    };
+}
+
+/**
+ * Returns the raw (trimmed) entries configured via DEFAULT_BUCKETS,
+ * which may include "bucket/path" scoped entries.
+ *
+ * @param {string|undefined} rawBuckets - typically process.env.DEFAULT_BUCKETS
+ * @returns {string[]}
+ */
+export function getConfiguredBucketEntries(rawBuckets) {
+    const raw = rawBuckets || DEFAULT_RESULTS_BUCKETS;
+    return raw.split(',').map(e => e.trim()).filter(Boolean);
+}
+
+/**
+ * Returns the bucket names configured via DEFAULT_BUCKETS with any
+ * "/path" scoping suffixes stripped. Use this wherever an entry must be
+ * compared against or used as a plain GCS bucket name.
+ *
+ * @param {string|undefined} rawBuckets - typically process.env.DEFAULT_BUCKETS
+ * @returns {string[]}
+ */
+export function getConfiguredBucketNames(rawBuckets) {
+    return getConfiguredBucketEntries(rawBuckets)
+        .map(e => parseBucketEntry(e).bucket)
+        .filter(Boolean);
+}

--- a/server/buckets.test.js
+++ b/server/buckets.test.js
@@ -1,0 +1,64 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { parseBucketEntry, getConfiguredBucketEntries, getConfiguredBucketNames, DEFAULT_RESULTS_BUCKETS } from './buckets.js';
+import assert from 'node:assert';
+
+console.log('Running buckets unit tests...');
+
+// 1. parseBucketEntry: bare bucket names
+assert.deepStrictEqual(parseBucketEntry('my-bucket'), { bucket: 'my-bucket', prefix: '' });
+assert.deepStrictEqual(parseBucketEntry(' my-bucket '), { bucket: 'my-bucket', prefix: '' });
+assert.deepStrictEqual(parseBucketEntry('gs://my-bucket/'), { bucket: 'my-bucket', prefix: '' });
+assert.deepStrictEqual(parseBucketEntry(''), { bucket: '', prefix: '' });
+assert.deepStrictEqual(parseBucketEntry(null), { bucket: '', prefix: '' });
+
+// 2. parseBucketEntry: path-scoped entries yield a normalized trailing-slash prefix
+assert.deepStrictEqual(parseBucketEntry('my-bucket/team-a'), { bucket: 'my-bucket', prefix: 'team-a/' });
+assert.deepStrictEqual(parseBucketEntry('my-bucket/team-a/results/'), { bucket: 'my-bucket', prefix: 'team-a/results/' });
+assert.deepStrictEqual(parseBucketEntry('gs://my-bucket/team-a/'), { bucket: 'my-bucket', prefix: 'team-a/' });
+assert.deepStrictEqual(parseBucketEntry('my-bucket//team-a//'), { bucket: 'my-bucket', prefix: 'team-a/' });
+
+// 3. getConfiguredBucketEntries: raw scoped entries pass through to clients
+assert.deepStrictEqual(
+    getConfiguredBucketEntries('bucket-a, bucket-b/sub/dir ,,'),
+    ['bucket-a', 'bucket-b/sub/dir']
+);
+
+// 4. getConfiguredBucketEntries / getConfiguredBucketNames: default fallback
+assert.deepStrictEqual(getConfiguredBucketEntries(undefined), DEFAULT_RESULTS_BUCKETS.split(','));
+assert.deepStrictEqual(getConfiguredBucketNames(undefined), ['llm-d-benchmarks-staging', 'llm-d-benchmarks']);
+assert.deepStrictEqual(getConfiguredBucketNames(''), ['llm-d-benchmarks-staging', 'llm-d-benchmarks']);
+
+// 5. getConfiguredBucketNames: path scoping is stripped for bucket-name comparisons,
+// so results-store and IAM permission checks still recognize scoped entries.
+assert.deepStrictEqual(
+    getConfiguredBucketNames('llm-d-benchmarks-staging/team-a,other-bucket/sub/dir'),
+    ['llm-d-benchmarks-staging', 'other-bucket']
+);
+assert.deepStrictEqual(
+    getConfiguredBucketNames('gs://bucket-a/x, bucket-b'),
+    ['bucket-a', 'bucket-b']
+);
+
+// 6. Multiple prefixes of the same bucket are independent entries
+assert.deepStrictEqual(
+    getConfiguredBucketEntries('b1/p1,b1/p2,b2/p3'),
+    ['b1/p1', 'b1/p2', 'b2/p3']
+);
+assert.deepStrictEqual(getConfiguredBucketNames('b1/p1,b1/p2,b2/p3'), ['b1', 'b1', 'b2']);
+assert.deepStrictEqual(parseBucketEntry('b1/p1'), { bucket: 'b1', prefix: 'p1/' });
+assert.deepStrictEqual(parseBucketEntry('b1/p2'), { bucket: 'b1', prefix: 'p2/' });
+
+console.log('All buckets unit tests passed successfully!');

--- a/server/iam.ts
+++ b/server/iam.ts
@@ -14,6 +14,7 @@
 
 import { GoogleAuth, UserRefreshClient } from 'google-auth-library';
 import fs from 'fs';
+import { getConfiguredBucketNames } from './buckets.js';
 
 const auth = new GoogleAuth();
 
@@ -24,8 +25,7 @@ export type PermissionLevel = 'none' | 'user' | 'admin';
  * Uses staging bucket if staging is in DEFAULT_BUCKETS, otherwise defaults to production bucket.
  */
 function getIAMBucket(): string {
-    const rawBuckets = process.env.DEFAULT_BUCKETS || 'llm-d-benchmarks-staging,llm-d-benchmarks';
-    const buckets = rawBuckets.split(',').map(b => b.trim());
+    const buckets = getConfiguredBucketNames(process.env.DEFAULT_BUCKETS);
     if (buckets.includes('llm-d-benchmarks-staging')) {
         return 'llm-d-benchmarks-staging';
     }

--- a/server/results/gcs.ts
+++ b/server/results/gcs.ts
@@ -14,6 +14,7 @@
 
 import type { PrismResultPayload, PrismSubmissionState, PrismResultContext } from './api.ts';
 import { Storage } from '@google-cloud/storage';
+import { getConfiguredBucketNames } from '../buckets.js';
 
 export function encodeContextValue(val: string): string {
     return 'e' + Buffer.from(val, 'utf8').toString('base64url');
@@ -37,8 +38,7 @@ export const storage = new Storage(
  * Resolves the primary Google Cloud Storage bucket for storing and listing Prism benchmark results.
  */
 export function getPrismResultsBucket(): string {
-    const rawBuckets = process.env.DEFAULT_BUCKETS || 'llm-d-benchmarks-staging,llm-d-benchmarks';
-    const buckets = rawBuckets.split(',').map(b => b.trim());
+    const buckets = getConfiguredBucketNames(process.env.DEFAULT_BUCKETS);
     if (buckets.includes('llm-d-benchmarks-staging')) {
         return 'llm-d-benchmarks-staging';
     }

--- a/server/server.js
+++ b/server/server.js
@@ -24,6 +24,7 @@ import { fileURLToPath } from 'url';
 import { oauthRouter, validateGitHubToken } from './oauth.ts';
 import { resultsRouter } from './results/index.ts';
 import { storage } from './results/gcs.ts';
+import { getConfiguredBucketEntries, getConfiguredBucketNames } from './buckets.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -60,12 +61,11 @@ const auth = new GoogleAuth();
 
 // --- API: Shared Configuration ---
 app.get('/api/config', (req, res) => {
-    const rawBuckets = process.env.DEFAULT_BUCKETS || 'llm-d-benchmarks-staging,llm-d-benchmarks';
-    const defaultBuckets = rawBuckets.split(',');
+    const defaultBuckets = getConfiguredBucketEntries(process.env.DEFAULT_BUCKETS);
     const defaultProjects = process.env.DEFAULT_PROJECTS ? process.env.DEFAULT_PROJECTS.split(',') : [];
 
     res.json({
-        buckets: defaultBuckets.map(b => b.trim()).filter(b => b),
+        buckets: defaultBuckets,
         projects: defaultProjects.map(p => p.trim()).filter(p => p),
         hostProject: process.env.GOOGLE_CLOUD_PROJECT || null,
         siteName: process.env.SITE_NAME || null,
@@ -581,8 +581,7 @@ app.all('/api/gcs/*', async (req, res) => {
         }
 
         const parsed = parseGcsPath(req.params[0]);
-        const rawBuckets = process.env.DEFAULT_BUCKETS || 'llm-d-benchmarks-staging,llm-d-benchmarks';
-        const resultsBuckets = rawBuckets.split(',').map(b => b.trim());
+        const resultsBuckets = getConfiguredBucketNames(process.env.DEFAULT_BUCKETS);
         const isTargetBucket = parsed && resultsBuckets.includes(parsed.bucket);
 
         let isResultsStore = false;

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -26,10 +26,16 @@ import { useAWS } from './useAWS';
 import { useGitHubAuth } from './useGitHubAuth';
 import { v4 as uuidv4 } from 'uuid';
 import { getBenchmarkKey } from '../utils/dashboardHelpers';
-import { getCanonicalBucketName, getBucketAlias, dedupeBucketConfigs } from '../utils/bucketUtils';
+import { getCanonicalBucketName, getBucketAlias, dedupeBucketConfigs, getBucketBaseName, getBucketPrefix } from '../utils/bucketUtils';
 
-const getPrefixForBucket = (bucketName) => {
-    if (bucketName === 'llm-d-benchmarks' || bucketName === 'llm-d-benchmarks-staging') {
+const getPrefixForBucket = (entry) => {
+    // A "bucket/path" scoped entry restricts the scan to that subdirectory.
+    const explicitPrefix = getBucketPrefix(entry);
+    if (explicitPrefix) {
+        return explicitPrefix;
+    }
+    const baseName = getBucketBaseName(entry);
+    if (baseName === 'llm-d-benchmarks' || baseName === 'llm-d-benchmarks-staging') {
         return 'prism-results-store/';
     }
     return '';

--- a/src/hooks/useGCS.js
+++ b/src/hooks/useGCS.js
@@ -61,8 +61,16 @@ const limitConcurrency = async (tasks, limit, onProgressUpdate) => {
 
 export const useGCS = ({ pendingRequests, addToast, accessToken }) => {
     const fetchBucketData = useCallback(async (bucket, forceRefresh = false, prefix = '', onProgress = null) => {
-        const cleanBucketName = bucket.replace(/^gs:\/\//, '');
-        const cacheKey = prefix ? `${cleanBucketName}:${prefix}` : cleanBucketName;
+        // A bucket may be scoped to a subdirectory via a "bucket/path" name.
+        // The scoped name stays the source identity; only the base name is a
+        // valid GCS bucket for API URLs, with the path applied as list prefix.
+        const scopedBucketName = bucket.replace(/^gs:\/\//, '').replace(/\/+$/, '');
+        const slashIdx = scopedBucketName.indexOf('/');
+        const cleanBucketName = slashIdx === -1 ? scopedBucketName : scopedBucketName.slice(0, slashIdx);
+        const pathParts = slashIdx === -1 ? [] : scopedBucketName.slice(slashIdx + 1).split('/').filter(Boolean);
+        const pathPrefix = pathParts.length ? `${pathParts.join('/')}/` : '';
+        const effectivePrefix = prefix || pathPrefix;
+        const cacheKey = effectivePrefix ? `${cleanBucketName}:${effectivePrefix}` : cleanBucketName;
 
         if (pendingRequests.current.has(`gcs:${cacheKey}`) && !forceRefresh) {
              console.log(`[Dedupe] Already fetching ${cacheKey}, returning shared promise.`);
@@ -73,7 +81,7 @@ export const useGCS = ({ pendingRequests, addToast, accessToken }) => {
             const cached = await CacheManager.get('gcs', cacheKey);
             if (cached) {
                 console.log(`[Cache Hit] Loading GCS bucket ${cacheKey} from cache.`);
-                addToast(`[Cache] Loaded ${cleanBucketName}${prefix ? ` (${prefix})` : ''}`, 'success');
+                addToast(`[Cache] Loaded ${cleanBucketName}${effectivePrefix ? ` (${effectivePrefix})` : ''}`, 'success');
                 return cached;
             }
         }
@@ -83,8 +91,8 @@ export const useGCS = ({ pendingRequests, addToast, accessToken }) => {
         const fetchPromise = (async () => {
             try {
                 const queryParams = new URLSearchParams();
-                if (prefix) {
-                    queryParams.set('prefix', prefix);
+                if (effectivePrefix) {
+                    queryParams.set('prefix', effectivePrefix);
                 }
                 const queryString = queryParams.toString();
                 const suffix = queryString ? `?${queryString}` : '';
@@ -141,7 +149,7 @@ export const useGCS = ({ pendingRequests, addToast, accessToken }) => {
                         try {
                             const jsonContent = JSON.parse(content);
                             if (jsonContent.metrics || jsonContent.load_summary) {
-                                const entry = parseJsonEntry({ ...jsonContent, source: `gcs:${cleanBucketName}` }, file.name);
+                                const entry = parseJsonEntry({ ...jsonContent, source: `gcs:${scopedBucketName}` }, file.name);
                                 entries = [entry];
                             } else if (jsonContent.format === 'brv02' && Array.isArray(jsonContent.entries)) {
                                 for (const stageEntry of jsonContent.entries) {
@@ -183,18 +191,18 @@ export const useGCS = ({ pendingRequests, addToast, accessToken }) => {
                         
                         if (entries.length > 0) {
                             entries.forEach(e => {
-                                e.source = `gcs:${cleanBucketName}`; 
+                                e.source = `gcs:${scopedBucketName}`; 
                                 let type = 'storage';
 
                                 if (e.source_info) {
-                                    e.source_info.origin = `gcs:${cleanBucketName}`;
+                                    e.source_info.origin = `gcs:${scopedBucketName}`;
                                     if (e.source_info.type !== 'benchmark_report_v02') {
                                         e.source_info.type = type;
                                     }
                                 } else {
                                     e.source_info = {
                                         type,
-                                        origin: `gcs:${cleanBucketName}`,
+                                        origin: `gcs:${scopedBucketName}`,
                                         file_identifier: file.name,
                                         raw_url: file.mediaLink
                                     };
@@ -226,21 +234,21 @@ export const useGCS = ({ pendingRequests, addToast, accessToken }) => {
                 });
 
                 if (onProgress) {
-                    onProgress({ loaded: 0, total: tasks.length, bucketName: cleanBucketName });
+                    onProgress({ loaded: 0, total: tasks.length, bucketName: scopedBucketName });
                 }
 
                 await limitConcurrency(tasks, 6, (loaded, total) => {
                     if (onProgress) {
-                        onProgress({ loaded, total, bucketName: cleanBucketName });
+                        onProgress({ loaded, total, bucketName: scopedBucketName });
                     }
                 });
 
                 const result = {
-                    bucketName: cleanBucketName,
+                    bucketName: scopedBucketName,
                     entries: newEntries,
                     profile: {
-                        bucketName: cleanBucketName,
-                        prefix: prefix || null,
+                        bucketName: scopedBucketName,
+                        prefix: effectivePrefix || null,
                         files: fileMetadata,
                         entryCount: fileMetadata.filter(f => f.entryCount > 0).length, 
                         loadedAt: new Date().toISOString(),
@@ -250,19 +258,19 @@ export const useGCS = ({ pendingRequests, addToast, accessToken }) => {
                 
                 const saved = await CacheManager.set('gcs', cacheKey, result);
                 if (!saved) {
-                    addToast(`[Error] Cache Full - Could not save ${cleanBucketName}${prefix ? ` (${prefix})` : ''}`, 'error');
+                    addToast(`[Error] Cache Full - Could not save ${cleanBucketName}${effectivePrefix ? ` (${effectivePrefix})` : ''}`, 'error');
                 } else {
-                    addToast(`[Network] Fetched ${cleanBucketName}${prefix ? ` (${prefix})` : ''}`, 'info');
+                    addToast(`[Network] Fetched ${cleanBucketName}${effectivePrefix ? ` (${effectivePrefix})` : ''}`, 'info');
                 }
                 return result;
 
             } catch (err) {
                 console.error(`Error fetching bucket ${bucket}:`, err);
                 return {
-                    bucketName: cleanBucketName,
+                    bucketName: scopedBucketName,
                     entries: [],
                     profile: {
-                        bucketName: cleanBucketName,
+                        bucketName: scopedBucketName,
                         files: [],
                         entryCount: 0,
                         loadedAt: new Date().toISOString(),

--- a/src/utils/bucketUtils.js
+++ b/src/utils/bucketUtils.js
@@ -32,6 +32,38 @@ export function getCanonicalBucketName(entry) {
 }
 
 /**
+ * Extracts the plain bucket name from a bucket config entry, stripping any
+ * "/path" scoping suffix. Use this wherever a real GCS bucket name is needed
+ * (e.g. building storage API URLs).
+ * e.g., "gs://slabe-bucket/team-a/results" -> "slabe-bucket"
+ *
+ * @param {string|object} entry
+ * @returns {string}
+ */
+export function getBucketBaseName(entry) {
+    const canonical = getCanonicalBucketName(entry);
+    const slashIdx = canonical.indexOf('/');
+    return slashIdx === -1 ? canonical : canonical.slice(0, slashIdx);
+}
+
+/**
+ * Extracts the object prefix from a "bucket/path" scoped config entry,
+ * normalized to always end with a trailing slash.
+ * e.g., "gs://slabe-bucket/team-a/results/" -> "team-a/results/"
+ *       "slabe-bucket" -> ""
+ *
+ * @param {string|object} entry
+ * @returns {string}
+ */
+export function getBucketPrefix(entry) {
+    const canonical = getCanonicalBucketName(entry);
+    const slashIdx = canonical.indexOf('/');
+    if (slashIdx === -1) return '';
+    const pathParts = canonical.slice(slashIdx + 1).split('/').filter(Boolean);
+    return pathParts.length ? `${pathParts.join('/')}/` : '';
+}
+
+/**
  * Extracts the custom alias from a bucket string or object, if present and non-empty.
  *
  * @param {string|object} entry

--- a/src/utils/bucketUtils.test.js
+++ b/src/utils/bucketUtils.test.js
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { getCanonicalBucketName, getBucketAlias, dedupeBucketConfigs } from './bucketUtils.js';
+import { getCanonicalBucketName, getBucketAlias, dedupeBucketConfigs, getBucketBaseName, getBucketPrefix } from './bucketUtils.js';
 import assert from 'node:assert';
 
 console.log('Running bucketUtils unit tests...');
@@ -55,5 +55,34 @@ const sampleOrder2 = [
 const result2 = dedupeBucketConfigs(sampleOrder2);
 assert.strictEqual(result2.length, 1);
 assert.deepStrictEqual(result2[0], { bucket: 'slabe-bucket', alias: 'slabe' });
+
+// 5. Path-scoped entries: canonical name retains the path as identity
+assert.strictEqual(getCanonicalBucketName('gs://slabe-bucket/team-a/results/'), 'slabe-bucket/team-a/results');
+assert.strictEqual(getCanonicalBucketName({ bucket: 'slabe-bucket/team-a' }), 'slabe-bucket/team-a');
+
+// 6. getBucketBaseName strips any path scoping
+assert.strictEqual(getBucketBaseName('slabe-bucket'), 'slabe-bucket');
+assert.strictEqual(getBucketBaseName('gs://slabe-bucket/team-a/results/'), 'slabe-bucket');
+assert.strictEqual(getBucketBaseName({ bucket: 'gs://slabe-bucket/team-a', alias: 'slabe' }), 'slabe-bucket');
+assert.strictEqual(getBucketBaseName(null), '');
+
+// 7. getBucketPrefix extracts a normalized trailing-slash prefix
+assert.strictEqual(getBucketPrefix('slabe-bucket'), '');
+assert.strictEqual(getBucketPrefix('slabe-bucket/team-a'), 'team-a/');
+assert.strictEqual(getBucketPrefix('gs://slabe-bucket/team-a/results/'), 'team-a/results/');
+assert.strictEqual(getBucketPrefix('slabe-bucket//team-a//'), 'team-a/');
+assert.strictEqual(getBucketPrefix({ bucket: 'slabe-bucket/team-a', alias: 'slabe' }), 'team-a/');
+assert.strictEqual(getBucketPrefix(null), '');
+
+// 8. Dedupe treats different prefixes of the same bucket as distinct sources
+const scopedInput = [
+    'slabe-bucket/team-a',
+    'gs://slabe-bucket/team-a/',
+    'slabe-bucket/team-b',
+    'slabe-bucket'
+];
+const scopedResult = dedupeBucketConfigs(scopedInput);
+assert.strictEqual(scopedResult.length, 3);
+assert.deepStrictEqual(scopedResult, ['slabe-bucket/team-a', 'slabe-bucket/team-b', 'slabe-bucket']);
 
 console.log('All bucketUtils unit tests passed successfully!');


### PR DESCRIPTION
## What does this PR do?

Allows a GCS bucket source to be restricted to a subdirectory. A `DEFAULT_BUCKETS`
entry (or a bucket added in the UI) may now carry a path suffix, e.g.
`DEFAULT_BUCKETS=my-bucket/team-a/results,other-bucket`, which restricts the scan
of that source to objects under the `team-a/results/` prefix. Bare bucket names
behave exactly as before.

Changes:
- `src/utils/bucketUtils.js`: new `getBucketBaseName` / `getBucketPrefix` helpers;
  the canonical name keeps the path so scoped entries stay distinct sources
- `src/hooks/useGCS.js`: `fetchBucketData` splits the scoped name from the base
  bucket name, using the base for storage API URLs and the path as the list
  `prefix` (an explicit `prefix` argument still takes precedence)
- `src/hooks/useDashboardData.jsx`: `getPrefixForBucket` now derives the prefix
  from the config entry, falling back to the existing hardcoded
  `prism-results-store/` default for the llm-d results buckets
- `server/buckets.js`: new shared parser used by `/api/config`, the `/api/gcs/*`
  proxy, `getPrismResultsBucket`, and `getIAMBucket`, so bucket-name comparisons
  strip path suffixes. Without this, a scoped entry for a results bucket would
  silently fail the `resultsBuckets.includes(...)` check and skip the
  results-store permission handling
- `README.md`: documents the new `DEFAULT_BUCKETS` syntax

Note: this scopes what the dashboard scans; it is not an access-control boundary.
The `/api/gcs/*` proxy still forwards whatever prefix a client requests, as it
did before this change.

## Why is this change needed?

The prefix plumbing already existed in `fetchBucketData` but was only reachable
through the hardcoded results-store mapping. Any other bucket was always scanned
from the root, and typing a path into the bucket name produced an invalid
storage API URL (the path ended up inside the bucket segment). Deployments that
share a bucket across teams or store results under a subdirectory currently have
no way to point Prism at just that subtree.

## How was this tested?

New `server/buckets.test.js` and extended `src/utils/bucketUtils.test.js`
(same plain-node style as the existing tests):
`node server/buckets.test.js && node src/utils/bucketUtils.test.js`

Manual: started the server with
`DEFAULT_BUCKETS='my-bucket/team-a/results, plain-bucket'` and verified
`/api/config` passes scoped entries through. `npm run lint`, `npm run type-check`,
and `npm run build` show no new issues relative to `main` (lint and type-check
baselines on `main` are unchanged by this PR).

