### PR TITLE
feat: add BRV0.2 benchmark downloading support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "compression": "^1.7.4",
         "express": "^4.18.2",
         "express-rate-limit": "^7.1.5",
+        "fflate": "^0.8.3",
         "google-auth-library": "^9.4.1",
         "js-yaml": "^4.1.1",
         "lucide-react": "^0.554.0",
@@ -3290,6 +3291,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "compression": "^1.7.4",
     "express": "^4.18.2",
     "express-rate-limit": "^7.1.5",
+    "fflate": "^0.8.3",
     "google-auth-library": "^9.4.1",
     "js-yaml": "^4.1.1",
     "lucide-react": "^0.554.0",

--- a/server/results/exporter.ts
+++ b/server/results/exporter.ts
@@ -1,0 +1,132 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import yaml from 'js-yaml';
+import { zipSync, strToU8 } from 'fflate';
+import { PrismResultPayload } from './api.ts';
+
+/**
+ * Sanitizes a string for safe filename and directory usage while preserving commas.
+ */
+export function sanitizeFilename(name: string): string {
+    if (!name || typeof name !== 'string') return 'benchmark_report';
+    return name
+        .replace(/[^a-zA-Z0-9._,-]/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^\.+/, '')
+        .substring(0, 100);
+}
+
+/**
+ * Returns canonical BRV0.2 filename for a given stage index.
+ */
+export function getBRV02StageFilename(stageIndex: number): string {
+    const stageNum = typeof stageIndex === 'number' && !isNaN(stageIndex) ? stageIndex : 0;
+    return `benchmark_report_v0.2,_stage_${stageNum}_lifecycle_metrics.json.yaml`;
+}
+
+/**
+ * Resolves a human-friendly run label from PrismResultPayload,
+ * ignoring internal synthetic keys (e.g. "brv02:...", "results-store:...").
+ */
+export function resolvePayloadRunLabel(payload: PrismResultPayload): string {
+    const firstReport = (payload.entries?.[0]?.raw_report || {}) as Record<string, any>;
+    const rawStack = Array.isArray(firstReport.scenario?.stack) ? firstReport.scenario.stack : [];
+    const stackModel = rawStack.find((c: any) => c?.standardized?.model?.name)?.standardized?.model?.name;
+    const modelName = payload.model_name || stackModel || '';
+
+    const candidates = [
+        payload.runLabel,
+        firstReport.run?.description,
+        firstReport.run?.label,
+        firstReport.scenario?.model,
+    ];
+
+    // Priority 1: Pick first non-empty, non-synthetic label that isn't the model name or generic string
+    for (const c of candidates) {
+        if (c && typeof c === 'string') {
+            const trimmed = c.trim();
+            if (
+                trimmed &&
+                !trimmed.startsWith('brv02:') &&
+                !trimmed.startsWith('results-store:') &&
+                !trimmed.startsWith('file:') &&
+                trimmed.toLowerCase() !== 'custom model' &&
+                trimmed.toLowerCase() !== 'unknown' &&
+                trimmed.toLowerCase() !== 'unknown model' &&
+                (modelName ? trimmed.toLowerCase() !== modelName.toLowerCase() : true)
+            ) {
+                return trimmed;
+            }
+        }
+    }
+
+    // Priority 2: Fallback to any valid non-synthetic candidate or modelName
+    for (const c of candidates) {
+        if (c && typeof c === 'string') {
+            const trimmed = c.trim();
+            if (
+                trimmed &&
+                !trimmed.startsWith('brv02:') &&
+                !trimmed.startsWith('results-store:') &&
+                !trimmed.startsWith('file:')
+            ) {
+                return trimmed;
+            }
+        }
+    }
+
+    return modelName || 'benchmark_run';
+}
+
+/**
+ * Serializes a raw BRV0.2 report object into a clean YAML string.
+ */
+export function serializeRawReportToYaml(rawReport: unknown): string {
+    if (!rawReport) return '';
+    if (typeof rawReport === 'string') return rawReport;
+    return yaml.dump(rawReport, {
+        noRefs: true,
+        lineWidth: -1,
+        quotingType: '"',
+        forceQuotes: false,
+    });
+}
+
+/**
+ * Packs all constituent stage entries of a PrismResultPayload into a ZIP buffer containing BRV0.2 .yaml files.
+ */
+export function createRunZipBuffer(payload: PrismResultPayload): { buffer: Buffer; filename: string } {
+    const rawLabel = resolvePayloadRunLabel(payload);
+    const runLabel = sanitizeFilename(rawLabel);
+    const rawRunId = payload.runId || '';
+    const shortRunId = rawRunId ? (rawRunId.split('-')[0] || rawRunId.substring(0, 8)) : '';
+    const archiveName = shortRunId ? `${runLabel}-${shortRunId}` : runLabel;
+    const zipFiles: Record<string, Uint8Array> = {};
+
+    const entries = payload.entries || [];
+    entries.forEach((entry, idx) => {
+        const rawYaml = serializeRawReportToYaml(entry.raw_report);
+        const stageNum = entry.prism_stage_index ?? idx;
+        const cleanStageName = getBRV02StageFilename(stageNum);
+        const fullPath = `${archiveName}/${cleanStageName}`;
+        zipFiles[fullPath] = strToU8(rawYaml);
+    });
+
+    const zipped = zipSync(zipFiles);
+    return {
+        buffer: Buffer.from(zipped),
+        filename: `${archiveName}.zip`,
+    };
+}

--- a/server/results/gcs.ts
+++ b/server/results/gcs.ts
@@ -172,7 +172,8 @@ export async function listResults(options: ListResultsOptions): Promise<ListResu
                 runLabel,
                 model_name,
                 hardware: {
-                    hardware_name
+                    hardware_name,
+                    accelerator_count: 1
                 },
                 format: 'brv02',
                 state: itemState,

--- a/server/results/index.ts
+++ b/server/results/index.ts
@@ -18,11 +18,14 @@ import { submitResultsHandler } from './routes/submit.ts';
 import { getResultsHandler } from './routes/get.ts';
 import { reviewResultsHandler } from './routes/review.ts';
 import { deleteResultsHandler } from './routes/delete.ts';
+import { exportResultsHandler, downloadEntryHandler } from './routes/export.ts';
 
 export const resultsRouter = Router();
 
 resultsRouter.get('/api/results', listResultsHandler);
 resultsRouter.post('/api/results', submitResultsHandler);
+resultsRouter.get('/api/results/:runId/export', exportResultsHandler);
+resultsRouter.get('/api/results/:runId/entries/:entryIndex/download', downloadEntryHandler);
 resultsRouter.get('/api/results/:runId', getResultsHandler);
 resultsRouter.post('/api/results/:runId/status', reviewResultsHandler);
 resultsRouter.delete('/api/results/:runId', deleteResultsHandler);
@@ -32,6 +35,9 @@ export * from './routes/submit.ts';
 export * from './routes/get.ts';
 export * from './routes/review.ts';
 export * from './routes/delete.ts';
+export * from './routes/export.ts';
 export * from './processing.ts';
 export * from './gcs.ts';
 export * from './api.ts';
+export * from './exporter.ts';
+

--- a/server/results/routes/export.ts
+++ b/server/results/routes/export.ts
@@ -1,0 +1,158 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Request, Response } from 'express';
+import { validateGitHubToken } from '../../oauth.ts';
+import { readResultPayload, readResultMetadata } from '../gcs.ts';
+import { PrismResultPayload } from '../api.ts';
+import { createRunZipBuffer, getBRV02StageFilename, serializeRawReportToYaml } from '../exporter.ts';
+
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+/**
+ * Helper to validate user authorization for accessing a benchmark result run.
+ */
+async function fetchAndAuthorizeResult(req: Request, runId: string): Promise<{
+    allowed: boolean;
+    payload?: PrismResultPayload;
+    status: number;
+    error?: string;
+}> {
+    if (!UUID_REGEX.test(runId)) {
+        return { allowed: false, status: 400, error: 'Invalid runId format. Must be a UUID.' };
+    }
+
+    const token = req.headers['x-prism-github-token'] as string | undefined;
+    let username: string | null = null;
+    let permission = 'none';
+
+    if (token) {
+        try {
+            const authResult = await validateGitHubToken(token);
+            username = authResult.username;
+            permission = authResult.permission;
+        } catch (e: any) {
+            console.warn('[Results Export API] Invalid session token:', e.message);
+        }
+    }
+
+    const metadata = await readResultMetadata(runId);
+    if (!metadata) {
+        return { allowed: false, status: 404, error: 'Result not found' };
+    }
+
+    const { user: itemUser, state: itemState } = metadata;
+    let allowed = false;
+
+    if (permission === 'admin') {
+        allowed = true;
+    } else if (itemState === 'public' || itemState === 'promoted' || itemState === 'unlisted') {
+        allowed = true;
+    } else if (username && itemUser.toLowerCase() === username.toLowerCase()) {
+        allowed = true;
+    }
+
+    if (!allowed) {
+        return { allowed: false, status: 403, error: 'Access denied. You do not have permissions to export this result.' };
+    }
+
+    const payload = await readResultPayload(runId);
+    return { allowed: true, status: 200, payload };
+}
+
+/**
+ * GET /api/results/:runId/export
+ * 
+ * Downloads an entire benchmark run dissected into BRV0.2 YAML files as a ZIP archive (or single .yaml file if format=yaml and single stage).
+ */
+export async function exportResultsHandler(req: Request, res: Response) {
+    const { runId } = req.params;
+
+    try {
+        const authRes = await fetchAndAuthorizeResult(req, runId);
+        if (!authRes.allowed || !authRes.payload) {
+            return res.status(authRes.status).json({ error: authRes.error });
+        }
+
+        const payload = authRes.payload;
+        const entries = payload.entries || [];
+        if (entries.length === 0) {
+            return res.status(400).json({ error: 'No benchmark stage entries found in run payload.' });
+        }
+
+        const formatQuery = (req.query.format as string || '').toLowerCase();
+
+        // If single stage and format=yaml requested, return the single YAML file directly
+        if (entries.length === 1 && formatQuery === 'yaml') {
+            const entry = entries[0];
+            const yamlContent = serializeRawReportToYaml(entry.raw_report);
+            const stageNum = entry.prism_stage_index ?? 0;
+            const filename = getBRV02StageFilename(stageNum);
+
+            res.setHeader('Content-Type', 'application/x-yaml');
+            res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+            return res.send(yamlContent);
+        }
+
+        // Default: Zip constituent stage .yaml reports
+        const { buffer, filename } = createRunZipBuffer(payload);
+        res.setHeader('Content-Type', 'application/zip');
+        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+        return res.send(buffer);
+
+    } catch (error: any) {
+        console.error('[Results Export API Error]', error);
+        return res.status(500).json({ error: 'Failed to export benchmark run', details: error.message });
+    }
+}
+
+/**
+ * GET /api/results/:runId/entries/:entryIndex/download
+ * 
+ * Downloads a specific stage entry from a benchmark run as a standalone BRV0.2 .yaml file.
+ */
+export async function downloadEntryHandler(req: Request, res: Response) {
+    const { runId, entryIndex: entryIndexStr } = req.params;
+    const entryIndex = parseInt(entryIndexStr, 10);
+
+    if (isNaN(entryIndex) || entryIndex < 0) {
+        return res.status(400).json({ error: 'Invalid entryIndex parameter.' });
+    }
+
+    try {
+        const authRes = await fetchAndAuthorizeResult(req, runId);
+        if (!authRes.allowed || !authRes.payload) {
+            return res.status(authRes.status).json({ error: authRes.error });
+        }
+
+        const payload = authRes.payload;
+        const entries = payload.entries || [];
+        if (entryIndex >= entries.length) {
+            return res.status(404).json({ error: `Stage entry at index ${entryIndex} not found.` });
+        }
+
+        const entry = entries[entryIndex];
+        const yamlContent = serializeRawReportToYaml(entry.raw_report);
+        const stageNum = entry.prism_stage_index ?? entryIndex;
+        const filename = getBRV02StageFilename(stageNum);
+
+        res.setHeader('Content-Type', 'application/x-yaml');
+        res.setHeader('Content-Disposition', `attachment; filename="${filename}"`);
+        return res.send(yamlContent);
+
+    } catch (error: any) {
+        console.error('[Results Entry Download API Error]', error);
+        return res.status(500).json({ error: 'Failed to download stage entry', details: error.message });
+    }
+}

--- a/specs/changes/download-brv02-benchmarks-spec.md
+++ b/specs/changes/download-brv02-benchmarks-spec.md
@@ -1,0 +1,129 @@
+# Spec: BRV0.2 Benchmark Download Specification
+
+- **Status**: Implemented
+- **Author**: diamondburned, Jetski
+- **Date**: August 5, 2026
+
+## 1. Objective & Context
+
+This proposal specifies the design and implementation for downloading **Benchmark Report v0.2 (BRV0.2)** files from the Prism Results Store.
+
+In Prism, benchmark runs uploaded or ingested into the Cloud Results Store are coalesced into a single unified JSON payload object ([`PrismResultPayload`](../main/completed/results-api/README.md#2-combined-api-payload-schema)) stored in Google Cloud Storage (`gs://<bucket>/prism-results-store/<runId>.v1.json`). Each payload contains descriptive run-level metadata alongside an `entries` array of parsed benchmark stages ([`PrismStageEntry`](../main/completed/results-api/README.md#2-combined-api-payload-schema)). Within each stage entry, the original parsed report is stored in the `raw_report` dictionary property.
+
+Upstream developers, benchmark analysts, and MLOps engineers need to extract these raw BRV0.2 benchmark files back out of Prism for offline analysis, re-running, or integration with external command-line utilities (such as `llm-d-benchmark` scripts).
+
+### Key Capabilities
+
+1. **Individual Entry YAML Download**: Dissect and export any single stage entry (`entries[i].raw_report`) directly as a clean, standardized `.yaml` file matching the BRV0.2 specification.
+2. **Single-Run ZIP Download**: Dissect and package all constituent BRV0.2 stage entries of a single benchmark run into a downloadable `.zip` archive containing individual stage `.yaml` reports.
+3. **Programmatic REST API Endpoints**: Expose server-side GET download routes allowing both browser UI interactions and command-line HTTP clients (`curl`, `wget`, python scripts) to retrieve raw YAML files and ZIP archives directly.
+
+## 2. Background & Existing Architecture
+
+### Existing Data Structures
+
+As documented in the [Prism Results Store Specification](../main/completed/results-api/README.md) and [Parser & Data Model Spec](../main/completed/results-api/parser_and_data_model.md), a stored benchmark run payload has the following structure:
+
+```json
+{
+  "runId": "e2bb0924-f746-4553-91ed-d771beae8057",
+  "runLabel": "llm-d-tpu-v6e-findings-20260731",
+  "model_name": "google/gemma-4-9b-it",
+  "hardware": {
+    "hardware_name": "TPU v6e",
+    "accelerator_count": 4
+  },
+  "format": "brv02",
+  "entries": [
+    {
+      "run_id": "e2bb0924-f746-4553-91ed-d771beae8057",
+      "run_description": "llm-d-tpu-v6e-findings-20260731",
+      "filename": "benchmark_report_v0.2,_stage_0_lifecycle_metrics.json.yaml",
+      "prism_stage_index": 0,
+      "raw_report": {
+        "version": "0.2",
+        "run": { "description": "llm-d-tpu-v6e-findings-20260731" },
+        "scenario": { ... },
+        "metrics": { ... }
+      }
+    }
+  ]
+}
+```
+
+## 3. BRV0.2 Report Dissection & ZIP Serialization Specification
+
+### 3.1 Supported Data Sources & Scope Exclusivity
+
+Downloading exclusively supports benchmark runs from:
+- **Cloud GCS Results Store**: Payloads stored in Cloud Storage under `/prism-results-store/*.v1.json`.
+- **Local BRV0.2 Files**: Staged BRV0.2 benchmark runs stored locally in the browser context (`brv02:*`).
+
+Legacy static benchmarks, Google Drive imports, and non-BRV0.2 sample datasets are out of scope and do not support export operations.
+
+### 3.2 Stage Dissection & Canonical Filename Schema
+
+When extracting a constituent stage entry from a benchmark run:
+1. The raw stage report dictionary is extracted.
+2. Output stage files are formatted according to the canonical BRV0.2 stage filename pattern:
+   `benchmark_report_v0.2,_stage_${STAGE}_lifecycle_metrics.json.yaml`
+   where `${STAGE}` is the 0-indexed stage number (0, 1, 2...).
+3. The raw report is serialized to a clean, standardized UTF-8 YAML document.
+
+### 3.3 Single-Run ZIP Archive Packaging & Run Label Resolution
+
+When exporting a single run, the generated ZIP archive is named according to the canonical pattern:
+`<sanitized_run_label>-<short_runId>.zip`
+where:
+- `<sanitized_run_label>` is the sanitized human-readable run label or directory upload name.
+- `<short_runId>` is the first segment (first 8 characters) of the run UUID (e.g. `e2bb0924`).
+
+#### Run Label Resolution & Fallback Hierarchy
+
+Run label resolution prioritizes descriptive metadata to prevent generic model names from obscuring run identities:
+1. **Explicit Run Descriptions**: Uses explicit run descriptions or labels defined within the benchmark report metadata.
+2. **Directory & Folder Names**: Uses directory or folder names specified during batch uploads when explicit report descriptions are absent.
+3. **User Custom Labels**: Respects user-defined custom labels assigned within the UI.
+4. **Model Name Fallback**: Falls back to the standardized model name only if no distinct run description, folder name, or custom label is present.
+
+Example ZIP Archive structure:
+
+```
+llm-d-tpu-v6e-findings-20260731-e2bb0924.zip
+├── benchmark_report_v0.2,_stage_0_lifecycle_metrics.json.yaml
+└── benchmark_report_v0.2,_stage_1_lifecycle_metrics.json.yaml
+```
+
+## 4. API Route Specification
+
+To support CLI tools, automated pipelines, and programmatic downloads, two backend endpoints are provided under `/api/results`:
+
+1. `GET /api/results/:runId/export`: Downloads an entire benchmark run dissected into constituent BRV0.2 YAML files as a ZIP archive (or a single YAML file if the run contains only 1 stage).
+2. `GET /api/results/:runId/entries/:entryIndex/download`: Downloads a specific stage entry from a benchmark run as a standalone BRV0.2 YAML file.
+
+## 5. Frontend UI Integration & User Experience
+
+### 5.1 Table Row Action Panel
+
+In the Results Store table row details section:
+- Under each expanded benchmark run's details panel, a **Download BRV0.2** button is positioned directly to the left of the **Inspect Raw Manifest** button.
+- **Targeted Visibility**: The Download button is displayed exclusively for valid BRV0.2 benchmark runs stored in the Cloud Results Store or staged locally, and is hidden for static sample datasets, built-in Drive files, and legacy benchmarks.
+- **Header Alignment & Visual Divider**: The action panel buttons stretch vertically to align with the full height of the adjacent metadata header box, separated by a thin 1px vertical divider line.
+- Clicking **Download BRV0.2** triggers an instant browser download of a ZIP archive for multi-stage runs or a single YAML report file for single-stage runs.
+
+### 5.2 Raw Report Inspector Modal
+
+Inside the raw manifest inspector modal:
+- Next to the **Copy YAML** button, a **Download BRV0.2** button provides direct single-stage or run-level export capability.
+
+## 6. Security & Authorization
+
+Export and download endpoints follow the exact same authorization and access control rules as result viewing. For complete details on identity resolution, role mappings, and submission state access permissions, refer to [iam.md](../main/completed/results-api/iam.md).
+
+## 7. Implementation Notes
+
+### 7.1 Data Pipeline Architecture & Payload Retention
+
+Previously, data ingestion unpacked canonical `PrismResultPayload` objects into isolated scatter plot points, discarding parent run metadata and raw stage structures. UI components and export tools had to heuristically reconstruct run labels and stage arrays on the fly, leading to field drift and missing metadata.
+
+Under the current architecture, data loaders retain the original `PrismResultPayload` directly on ingested data points at load time. This payload flows intact through scatter plot parsing, table row grouping, and action panel handlers. Export and inspection utilities consume this canonical payload directly, eliminating heuristic reconstruction and ensuring exact structural parity between client views and server APIs.

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1366,8 +1366,11 @@ const Dashboard = ({ mode = 'browser', onNavigateBack, onNavigate, dashboardStat
                 return { name, url, fileCount, fileNames };
             });
 
+            const payload = groupingData[0]?.payload;
+
             stats.push({
                 benchmarkKey,
+                runLabel: payload?.runLabel || '',
                 model,
                 configuration, // Explicitly pass configuration
                 maxTput,
@@ -1379,6 +1382,7 @@ const Dashboard = ({ mode = 'browser', onNavigateBack, onNavigate, dashboardStat
                 node_count, // Pre-computed: accelerator_count / tensor_parallelism
                 tp: tensor_parallelism,
                 sourceLinks,
+                payload,
                 // Store reference to the actual data for this benchmark
                 // Fix Duplicates & Sort by QPS
                 data: (() => {

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -1532,7 +1532,8 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             if (firstParsedStage) {
                 if (firstParsedStage.validation?.format === 'brv02') {
                     const stageParsed = parseReportV02(firstParsedStage.content, getFilePath(firstParsedStage.file));
-                    runLabelFromStage = stageParsed?.runLabel || firstParsedStage.runLabel || '';
+                    const rawDoc = stageParsed?.rawReport || {};
+                    runLabelFromStage = rawDoc.run?.description || rawDoc.run?.label || stageParsed?.runLabel || '';
                 } else {
                     runLabelFromStage = firstParsedStage.runLabel || '';
                 }

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -14,7 +14,7 @@
 
 import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { RotateCcw, ChevronDown, ChevronUp, Star, Pin, CheckSquare, Square, Check, Pencil, Trash2, Code2, Copy, X, Database, Eye, EyeOff, ShieldCheck, AlertCircle, TrendingUp, AlertTriangle, Search, FileText, FileClock, Sliders, Activity, Send, Play, Loader } from 'lucide-react';
+import { RotateCcw, ChevronDown, ChevronUp, Star, Pin, CheckSquare, Square, Check, Pencil, Trash2, Code2, Copy, X, Database, Eye, EyeOff, ShieldCheck, AlertCircle, TrendingUp, AlertTriangle, Search, FileText, FileClock, Sliders, Activity, Send, Play, Loader, Download } from 'lucide-react';
 import { RunComparisonChart } from '../Dashboard/RunComparisonChart';
 import { ThroughputCostChart } from '../Dashboard/ThroughputCostChart';
 import { Button, Badge, StatusChip, Modal, Textarea } from '../ui';
@@ -25,6 +25,7 @@ import { useGitHubAuth } from '../../hooks/useGitHubAuth';
 import { validateBenchmark } from '../../utils/benchmarkValidator';
 import { encodeShareLink, isValidUuid } from '../../utils/shareLinkEncoder';
 import { v4 as uuidv4 } from 'uuid';
+import { downloadRunBRV02, downloadSingleStageYaml } from '../../utils/brv02Exporter';
 
 const getCleanModelName = (name) => {
     if (!name) return '';
@@ -1768,9 +1769,26 @@ export const UnifiedDataTable = (props) => {
                     title={`Raw Report: ${rawYamlTitle}`}
                     className="max-w-3xl"
                     footer={
-                        <Button variant="secondary" size="sm" onClick={() => setRawYamlContent(null)}>
-                            Close
-                        </Button>
+                        <div className="flex items-center gap-2">
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => {
+                                    try {
+                                        downloadSingleStageYaml(rawYamlContent, rawYamlTitle);
+                                    } catch (err) {
+                                        console.error("Failed to download stage YAML:", err);
+                                        alert("Failed to download stage YAML: " + (err.message || err));
+                                    }
+                                }}
+                                className="flex items-center gap-1.5"
+                            >
+                                <Download size={13} /> Download YAML
+                            </Button>
+                            <Button variant="secondary" size="sm" onClick={() => setRawYamlContent(null)}>
+                                Close
+                            </Button>
+                        </div>
                     }
                 >
                     <div className="font-mono text-xs select-all whitespace-pre-wrap">
@@ -1793,28 +1811,53 @@ export const UnifiedDataTable = (props) => {
                     }
                     className="max-w-3xl"
                     footer={
-                        <button
-                            onClick={() => {
-                                try {
-                                    const dataToDump = viewingPayloadRun.data?.[0] || viewingPayloadRun;
-                                    const yamlStr = yaml.dump(dataToDump, { noRefs: true });
-                                    navigator.clipboard.writeText(yamlStr);
-                                    alert('Manifest copied to clipboard');
-                                } catch (err) {
-                                    console.error("Failed to copy YAML:", err);
-                                    alert('Failed to copy manifest');
-                                }
-                            }}
-                            className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-cyan-400 bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-500/30 rounded-lg transition-colors cursor-pointer"
-                        >
-                            <Copy className="w-3.5 h-3.5" /> Copy YAML
-                        </button>
+                        <div className="flex items-center gap-2">
+                            {(() => {
+                                const isViewBrv02 =
+                                    viewingPayloadRun?.payload?.format === 'brv02' ||
+                                    viewingPayloadRun?.source?.startsWith('brv02:') ||
+                                    viewingPayloadRun?.data?.[0]?.source_info?.type === 'benchmark_report_v02' ||
+                                    viewingPayloadRun?.data?.[0]?.source?.startsWith('brv02:');
+
+                                return isViewBrv02 ? (
+                                    <button
+                                        onClick={() => {
+                                            try {
+                                                downloadRunBRV02(viewingPayloadRun);
+                                            } catch (err) {
+                                                console.error("Failed to download BRV0.2:", err);
+                                                alert("Failed to download benchmark: " + (err.message || err));
+                                            }
+                                        }}
+                                        className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/20 border border-emerald-500/30 rounded-lg transition-colors cursor-pointer"
+                                    >
+                                        <Download className="w-3.5 h-3.5" /> Download BRV0.2
+                                    </button>
+                                ) : null;
+                            })()}
+                            <button
+                                onClick={() => {
+                                    try {
+                                        const dataToDump = viewingPayloadRun.payload || viewingPayloadRun.data?.[0] || viewingPayloadRun;
+                                        const yamlStr = yaml.dump(dataToDump, { noRefs: true });
+                                        navigator.clipboard.writeText(yamlStr);
+                                        alert('Manifest copied to clipboard');
+                                    } catch (err) {
+                                        console.error("Failed to copy YAML:", err);
+                                        alert('Failed to copy manifest');
+                                    }
+                                }}
+                                className="flex items-center gap-1.5 px-3 py-1.5 text-xs text-cyan-400 bg-cyan-500/10 hover:bg-cyan-500/20 border border-cyan-500/30 rounded-lg transition-colors cursor-pointer"
+                            >
+                                <Copy className="w-3.5 h-3.5" /> Copy YAML
+                            </button>
+                        </div>
                     }
                 >
                     <pre className="m-0 font-mono text-xs leading-relaxed whitespace-pre-wrap">
                         {(() => {
                             try {
-                                const dataToDump = viewingPayloadRun.data?.[0] || viewingPayloadRun;
+                                const dataToDump = viewingPayloadRun.payload || viewingPayloadRun.data?.[0] || viewingPayloadRun;
                                 return yaml.dump(dataToDump, { noRefs: true });
                             } catch (err) {
                                 console.error("Failed to dump to YAML:", err);
@@ -2996,19 +3039,42 @@ const BenchmarkRow = React.memo(({
                                                      )}
 
                                                      {canViewRaw && (
-                                                         <Button
-                                                             variant="secondary"
-                                                             size="sm"
-                                                             onClick={(e) => {
-                                                                 e.stopPropagation();
-                                                                 setViewingPayloadRun(stat);
-                                                             }}
-                                                             className="flex-shrink-0 whitespace-nowrap animate-in fade-in duration-200"
-                                                             title="Inspect Raw YAML / JSON Manifest"
-                                                         >
-                                                             <Code2 size={13} />
-                                                             Inspect Raw Manifest
-                                                         </Button>
+                                                         <div className="flex items-stretch gap-2 flex-shrink-0">
+                                                             <div className="w-px bg-slate-300/70 dark:bg-slate-700/80 self-stretch my-0.5 mr-0.5" />
+                                                             {isBrv02 && (
+                                                                 <Button
+                                                                     variant="secondary"
+                                                                     size="sm"
+                                                                     onClick={(e) => {
+                                                                         e.stopPropagation();
+                                                                         try {
+                                                                             downloadRunBRV02(stat, benchmarkData);
+                                                                         } catch (err) {
+                                                                             console.error("Failed to download BRV0.2 benchmark:", err);
+                                                                             alert("Failed to download benchmark: " + (err.message || err));
+                                                                         }
+                                                                     }}
+                                                                     className="h-full whitespace-nowrap animate-in fade-in duration-200 gap-1.5 flex items-center justify-center"
+                                                                     title={benchmarkData.length > 1 ? "Download BRV0.2 Stage Reports (ZIP Archive)" : "Download BRV0.2 Report (YAML File)"}
+                                                                 >
+                                                                     <Download size={13} />
+                                                                     {benchmarkData.length > 1 ? "Download BRV0.2 (ZIP)" : "Download BRV0.2 (YAML)"}
+                                                                 </Button>
+                                                             )}
+                                                             <Button
+                                                                 variant="secondary"
+                                                                 size="sm"
+                                                                 onClick={(e) => {
+                                                                     e.stopPropagation();
+                                                                     setViewingPayloadRun(stat);
+                                                                 }}
+                                                                 className="h-full whitespace-nowrap animate-in fade-in duration-200 gap-1.5 flex items-center justify-center"
+                                                                 title="Inspect Raw YAML / JSON Manifest"
+                                                             >
+                                                                 <Code2 size={13} />
+                                                                 Inspect Raw Manifest
+                                                             </Button>
+                                                         </div>
                                                      )}
                                                  </div>
 

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -573,8 +573,11 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                 return currVal > prevVal ? curr : prev;
             }, groupingData[0] || {});
 
+            const payload = groupingData[0]?.payload;
+
             stats.push({
                 benchmarkKey,
+                runLabel: payload?.runLabel || '',
                 model,
                 configuration,
                 maxTput,
@@ -590,7 +593,8 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                 uniqueIsl,
                 uniqueOsl,
                 peakRun,
-                nodesAndParallelismText
+                nodesAndParallelismText,
+                payload
             });
         });
 

--- a/src/hooks/useGCS.js
+++ b/src/hooks/useGCS.js
@@ -173,8 +173,9 @@ export const useGCS = ({ pendingRequests, addToast, accessToken }) => {
 
                                             const resolvedWellLit = jsonContent.well_lit_path || customMeta.well_lit_path || null;
                                             parsedStage.well_lit_path = resolvedWellLit;
-                                            parsedStage.wellLitPath = resolvedWellLit;
+                                            parsedStage.payload = jsonContent;
                                             const entry = stageToEntry(parsedStage);
+                                            entry.payload = jsonContent;
                                             entries.push(entry);
                                         }
                                     }

--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -49,18 +49,7 @@ const pct = (val) => {
 
 const deriveRunLabel = (doc) => {
     if (doc.run?.description) return doc.run.description;
-
-    // Build label from scenario model name if available
-    const stack = doc.scenario?.stack || [];
-    const primary = (
-        stack.find(c => c.standardized?.role === 'aggregate') ||
-        stack.find(c => c.standardized?.role === 'decode') ||
-        stack.find(c => c.standardized?.kind === 'inference_engine') ||
-        stack[0]
-    );
-    const model = primary?.standardized?.model?.name || doc.scenario?.load?.native?.config?.server?.model_name;
-    if (model && model !== 'Unknown' && model !== 'Unknown Model') return model.split('/').pop();
-
+    if (doc.run?.label) return doc.run.label;
     return "";
 };
 
@@ -543,6 +532,7 @@ export function stageToEntry(stage) {
     const harness = scenario.harness && scenario.harness !== 'unknown' ? scenario.harness : '';
 
     return createEntry({
+        payload: stage.payload || null,
         run_id: stage.runId,
         runLabel: stage.runLabel || '',
         github_author: stage.github_author,
@@ -622,6 +612,7 @@ export function stageToEntry(stage) {
         },
 
         rawReport: stage.rawReport || null,
+        payload: stage.payload || null,
         _diagnostics: { msg: [], raw_snapshot: {} },
     });
 }

--- a/src/utils/brv02Exporter.js
+++ b/src/utils/brv02Exporter.js
@@ -1,0 +1,250 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import yaml from 'js-yaml';
+import { zipSync, strToU8 } from 'fflate';
+
+/**
+ * Sanitizes a string for safe filename usage while preserving commas.
+ */
+export function sanitizeFilename(name) {
+    if (!name || typeof name !== 'string') return 'benchmark_report';
+    return name
+        .replace(/[^a-zA-Z0-9._,-]/g, '_')
+        .replace(/_+/g, '_')
+        .replace(/^\.+/, '')
+        .substring(0, 100);
+}
+
+/**
+ * Returns canonical BRV0.2 filename for a given stage index.
+ */
+export function getBRV02StageFilename(stageIndex) {
+    const stageNum = typeof stageIndex === 'number' && !isNaN(stageIndex) ? stageIndex : 0;
+    return `benchmark_report_v0.2,_stage_${stageNum}_lifecycle_metrics.json.yaml`;
+}
+
+/**
+ * Resolves a human-friendly run label from payload/stat/benchmarkData objects,
+ * ignoring internal synthetic keys and fallback model names when a distinct run label exists.
+ */
+export function resolveRunLabel(runPayloadOrStat, benchmarkData = [], stages = []) {
+    const dataArr = Array.isArray(benchmarkData) && benchmarkData.length > 0
+        ? benchmarkData
+        : (runPayloadOrStat?.data || []);
+
+    const first = dataArr[0] || {};
+    const firstReport = runPayloadOrStat?.entries?.[0]?.raw_report ||
+        runPayloadOrStat?.stages?.[0]?.rawReport ||
+        stages[0]?.rawReport ||
+        first?.rawReport || first?.raw_report || {};
+
+    const rawStack = Array.isArray(firstReport?.scenario?.stack) ? firstReport.scenario.stack : [];
+    const stackModel = rawStack.find(c => c?.standardized?.model?.name)?.standardized?.model?.name;
+    const modelName = runPayloadOrStat?.model_name || runPayloadOrStat?.model || first?.model_name || first?.model || stackModel || '';
+
+    const candidates = [
+        runPayloadOrStat?.runLabel,
+        runPayloadOrStat?.run_description,
+        runPayloadOrStat?.payload?.runLabel,
+        firstReport?.run?.description,
+        firstReport?.run?.label,
+        first?.runLabel,
+        first?.source_info?.origin?.replace(/^brv02:/, ''),
+    ];
+
+    // Priority 1: Pick first non-empty, non-synthetic label that isn't the model name or generic string
+    for (const c of candidates) {
+        if (c && typeof c === 'string') {
+            const trimmed = c.trim();
+            if (
+                trimmed &&
+                !trimmed.startsWith('brv02:') &&
+                !trimmed.startsWith('results-store:') &&
+                !trimmed.startsWith('file:') &&
+                trimmed.toLowerCase() !== 'custom model' &&
+                trimmed.toLowerCase() !== 'unknown' &&
+                trimmed.toLowerCase() !== 'unknown model' &&
+                (modelName ? trimmed.toLowerCase() !== modelName.toLowerCase() : true)
+            ) {
+                return trimmed;
+            }
+        }
+    }
+
+    // Priority 2: Fallback to any valid non-synthetic candidate or model name
+    for (const c of candidates) {
+        if (c && typeof c === 'string') {
+            const trimmed = c.trim();
+            if (
+                trimmed &&
+                !trimmed.startsWith('brv02:') &&
+                !trimmed.startsWith('results-store:') &&
+                !trimmed.startsWith('file:')
+            ) {
+                return trimmed;
+            }
+        }
+    }
+
+    return modelName || 'benchmark_run';
+}
+
+/**
+ * Serializes a raw BRV0.2 report object into a clean YAML string.
+ */
+export function serializeRawReportToYaml(rawReport) {
+    if (!rawReport) return '';
+    if (typeof rawReport === 'string') return rawReport;
+    return yaml.dump(rawReport, {
+        noRefs: true,
+        lineWidth: -1,
+        quotingType: '"',
+        forceQuotes: false,
+    });
+}
+
+/**
+ * Triggers a browser file download from a Blob or Uint8Array.
+ */
+export function triggerFileDownload(data, filename, mimeType = 'application/octet-stream') {
+    const blob = data instanceof Blob ? data : new Blob([data], { type: mimeType });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = filename;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+    setTimeout(() => URL.revokeObjectURL(url), 1000);
+}
+
+/**
+ * Exports an individual stage raw report object directly as a .yaml file download.
+ */
+export function downloadSingleStageYaml(rawReport, stageIndexOrName = 0) {
+    const yamlStr = serializeRawReportToYaml(rawReport);
+    if (!yamlStr) {
+        throw new Error('No raw report content available to export.');
+    }
+    let stageNum = 0;
+    if (typeof stageIndexOrName === 'number') {
+        stageNum = stageIndexOrName;
+    } else if (typeof stageIndexOrName === 'string') {
+        const match = stageIndexOrName.match(/stage[_\s]*(\d+)/i);
+        if (match) {
+            stageNum = parseInt(match[1], 10);
+        }
+    }
+    const cleanName = getBRV02StageFilename(stageNum);
+    triggerFileDownload(yamlStr, cleanName, 'application/x-yaml');
+}
+
+/**
+ * Dissects and exports a benchmark run's constituent stage reports into a ZIP file (or single .yaml if 1 stage).
+ */
+export function downloadRunBRV02(runPayloadOrStat, benchmarkData = []) {
+    let stages = [];
+    let rawRunId = '';
+
+    // Option 1: Direct PrismResultPayload with .entries
+    if (runPayloadOrStat?.entries && Array.isArray(runPayloadOrStat.entries)) {
+        rawRunId = runPayloadOrStat.runId || '';
+        stages = runPayloadOrStat.entries.map((entry, idx) => ({
+            rawReport: entry.raw_report || entry.rawReport || entry.content || entry,
+            stageIndex: entry.prism_stage_index ?? idx,
+        }));
+    }
+    // Option 2: Object with .payload containing .entries
+    else if (runPayloadOrStat?.payload?.entries && Array.isArray(runPayloadOrStat.payload.entries)) {
+        const p = runPayloadOrStat.payload;
+        rawRunId = p.runId || '';
+        stages = p.entries.map((entry, idx) => ({
+            rawReport: entry.raw_report || entry.rawReport || entry.content || entry,
+            stageIndex: entry.prism_stage_index ?? idx,
+        }));
+    }
+    // Option 3: Local staged run object with .stages
+    else if (runPayloadOrStat?.stages && Array.isArray(runPayloadOrStat.stages)) {
+        rawRunId = runPayloadOrStat.runId || '';
+        stages = runPayloadOrStat.stages.map((stage, idx) => ({
+            rawReport: stage.rawReport || stage.raw_report || stage,
+            stageIndex: stage.prism_stage_index ?? stage.workload?.stage ?? idx,
+        }));
+    }
+    // Option 4: Table stat object or benchmarkData array from UnifiedDataTable
+    else {
+        const dataArr = Array.isArray(benchmarkData) && benchmarkData.length > 0
+            ? benchmarkData
+            : (runPayloadOrStat?.data || []);
+
+        const first = dataArr[0] || {};
+
+        if (first?.payload?.entries && Array.isArray(first.payload.entries)) {
+            const p = first.payload;
+            rawRunId = p.runId || '';
+            stages = p.entries.map((entry, idx) => ({
+                rawReport: entry.raw_report || entry.rawReport || entry.content || entry,
+                stageIndex: entry.prism_stage_index ?? idx,
+            }));
+        } else {
+            rawRunId = runPayloadOrStat?.runId || runPayloadOrStat?.run_id || first?.run_id || first?.runId || first?.source_info?.run_id || '';
+
+            if (!rawRunId) {
+                const key = runPayloadOrStat?.benchmarkKey || first?.source || '';
+                if (key.startsWith('results-store:')) {
+                    rawRunId = key.substring('results-store:'.length);
+                } else if (key.startsWith('brv02:')) {
+                    rawRunId = key.substring('brv02:'.length);
+                }
+            }
+
+            stages = dataArr.map((d, idx) => ({
+                rawReport: d.rawReport || d.raw_report || d.payload?.entries?.[0]?.raw_report || d,
+                stageIndex: d.workload?.stage ?? d.prism_stage_index ?? idx,
+            }));
+        }
+    }
+
+    if (stages.length === 0) {
+        throw new Error('No stage benchmark reports found in run payload.');
+    }
+
+    const runLabel = resolveRunLabel(runPayloadOrStat, benchmarkData, stages);
+
+    if (stages.length === 1) {
+        const singleStage = stages[0];
+        const rawYaml = serializeRawReportToYaml(singleStage.rawReport);
+        const stageNum = singleStage.stageIndex ?? 0;
+        const stageFileName = getBRV02StageFilename(stageNum);
+        triggerFileDownload(rawYaml, stageFileName, 'application/x-yaml');
+        return;
+    }
+
+    const zipFiles = {};
+    const sanitizedLabel = sanitizeFilename(runLabel);
+    const shortRunId = rawRunId ? (rawRunId.split('-')[0] || rawRunId.substring(0, 8)) : '';
+    const archiveName = shortRunId ? `${sanitizedLabel}-${shortRunId}` : sanitizedLabel;
+
+    stages.forEach((stage, idx) => {
+        const rawYaml = serializeRawReportToYaml(stage.rawReport);
+        const stageNum = stage.stageIndex ?? idx;
+        const cleanStageName = getBRV02StageFilename(stageNum);
+        const fullPath = `${archiveName}/${cleanStageName}`;
+        zipFiles[fullPath] = strToU8(rawYaml);
+    });
+
+    const zipped = zipSync(zipFiles);
+    triggerFileDownload(zipped, `${archiveName}.zip`, 'application/zip');
+}


### PR DESCRIPTION
## What does this PR do?

Adds support for downloading Benchmark Report v0.2 (BRV0.2) benchmark runs from the Prism Results Store and local staging:

- **Single-Run ZIP Download**: Dissects and packages constituent BRV0.2 stage entries into `<sanitized_run_label>-<short_runId>.zip` containing standardized individual stage `.yaml` report files (`benchmark_report_v0.2,_stage_${STAGE}_lifecycle_metrics.json.yaml`).
- **Single-Stage YAML Export**: Dissects and exports single-stage reports directly as clean UTF-8 BRV0.2 `.yaml` files.
- **REST API Endpoints**: Introduces `GET /api/results/:runId/export` and `GET /api/results/:runId/entries/:entryIndex/download` for CLI tools, python scripts, and automated pipelines.
- **Frontend UI Controls**: Adds a **Download BRV0.2** button in the Results Store table details panel (stretched vertically with a thin divider) and raw manifest preview modals, conditionally rendered for GCS and local BRV0.2 runs.
- **Load-Time Payload Retention**: Retains canonical `PrismResultPayload` objects directly on ingested data points at load time to preserve original run metadata without field drift.
- **Run Label Resolution Hierarchy**: Prioritizes explicit report descriptions, directory upload names, and user custom labels ahead of model names to prevent fallback model names from obscuring run archive identities.

## Why is this change needed?

Upstream developers, benchmark analysts, and MLOps engineers need to extract raw BRV0.2 benchmark report files back out of Prism for offline analysis, re-running, or integration with external CLI tools (such as `llm-d-benchmark` scripts).

Previously, data ingestion unpacked canonical `PrismResultPayload` objects into isolated scatter plot points, discarding parent run metadata. UI components had to heuristically reconstruct run labels and stage arrays on the fly, leading to field drift and missing metadata when attempting exports.

## How was this tested?

- [x] Manual testing performed (verified single-stage YAML and multi-stage ZIP downloads from Results Store table rows and raw preview modal).
- [x] Type checking verified via `npm run type-check`.
- [x] Production build verified via `npm run build`.

## Checklist

- [x] Commits are signed off (`git commit -s`) per DCO
- [x] Code follows project contributing guidelines
- [x] Documentation updated (`specs/changes/download-brv02-benchmarks-spec.md`)