### PR TITLE
Fix BR v0.2 total token throughput

### DIFF
--- a/specs/main/completed/results-api/parser_and_data_model.md
+++ b/specs/main/completed/results-api/parser_and_data_model.md
@@ -70,6 +70,9 @@ containing:
 
 - Output token throughput rate (`throughput` representing output tokens/s).
 - Input token throughput rate (tokens/s).
+- Total token throughput rate (tokens/s). Prism prefers the reported total,
+  falls back to input plus output when total is absent, and can derive a missing
+  input rate from total minus output when the result is non-negative.
 - Request rate (req/s).
 - **Latency values (converted from seconds to milliseconds):**
     - Time-To-First-Token (TTFT) mean, p50, and p99.

--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -142,6 +142,7 @@ const RawBRV02ReportSchema = z.object({
                 throughput: z.object({
                     output_token_rate: z.object({ mean: numericField }).nullable().optional(),
                     input_token_rate: z.object({ mean: numericField }).nullable().optional(),
+                    total_token_rate: z.object({ mean: numericField }).nullable().optional(),
                     request_rate: z.object({ mean: numericField }).nullable().optional(),
                 }).nullable().optional(),
                 latency: z.object({
@@ -257,6 +258,7 @@ export function parseReportV02(yamlText, filename) {
     const performance = {
         outputTokenRate: tput.output_token_rate?.mean ?? null,
         inputTokenRate: tput.input_token_rate?.mean ?? null,
+        totalTokenRate: tput.total_token_rate?.mean ?? null,
         requestRate: tput.request_rate?.mean ?? null,
         ttftMean: lat.time_to_first_token?.mean ?? null,
         ttftP50: lat.time_to_first_token?.p50 ?? null,
@@ -516,8 +518,23 @@ export function stageToEntry(stage) {
     }
 
     hardware = normalizeHardware(hardware);
-    const ts         = timestamp || new Date().toISOString();
-    const throughput = performance.outputTokenRate ?? null;
+    const ts = timestamp || new Date().toISOString();
+    const outputTokenRate = performance.outputTokenRate ?? null;
+    const reportedInputTokenRate = performance.inputTokenRate ?? null;
+    const reportedTotalTokenRate = performance.totalTokenRate ?? null;
+    const inputTokenRate = reportedInputTokenRate ?? (
+        reportedTotalTokenRate !== null &&
+        outputTokenRate !== null &&
+        reportedTotalTokenRate >= outputTokenRate
+            ? reportedTotalTokenRate - outputTokenRate
+            : null
+    );
+    const totalTokenRate = reportedTotalTokenRate ?? (
+        inputTokenRate !== null && outputTokenRate !== null
+            ? inputTokenRate + outputTokenRate
+            : null
+    );
+    const throughput = outputTokenRate;
     const latency    = {
         mean: performance.e2eMean ?? null,
         p50: performance.e2eP50 ?? null,
@@ -591,8 +608,9 @@ export function stageToEntry(stage) {
 
         metrics: {
             throughput: throughput ?? null,
-            output_tput: throughput ?? null,
-            input_tput: performance.inputTokenRate ?? null,
+            output_tput: outputTokenRate,
+            input_tput: inputTokenRate,
+            total_tput: totalTokenRate,
             request_rate: performance.requestRate ?? null,
             latency,
             ttft,
@@ -612,7 +630,6 @@ export function stageToEntry(stage) {
         },
 
         rawReport: stage.rawReport || null,
-        payload: stage.payload || null,
         _diagnostics: { msg: [], raw_snapshot: {} },
     });
 }

--- a/src/utils/benchmarkReportV02Parser.test.js
+++ b/src/utils/benchmarkReportV02Parser.test.js
@@ -1,0 +1,96 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { parseReportV02, stageToEntry } from './benchmarkReportV02Parser.js';
+
+const createReport = (throughput) => ({
+    version: '0.2',
+    scenario: {
+        stack: [{
+            standardized: {
+                role: 'aggregate',
+                model: { name: 'test-model' },
+                accelerator: { model: 'H100', count: 1 },
+            },
+        }],
+        load: { standardized: { tool: 'vllm' } },
+    },
+    results: {
+        request_performance: {
+            aggregate: { throughput },
+        },
+    },
+});
+
+const parseRates = (throughput) => {
+    const stage = parseReportV02(createReport(throughput), 'report.yaml');
+    assert.ok(stage);
+    return { stage, entry: stageToEntry(stage) };
+};
+
+test('BR v0.2 preserves and normalizes reported token rates', () => {
+    const { stage, entry } = parseRates({
+        input_token_rate: { mean: 80 },
+        output_token_rate: { mean: 20 },
+        total_token_rate: { mean: 105 },
+    });
+
+    assert.equal(stage.performance.totalTokenRate, 105);
+    assert.equal(entry.metrics.input_tput, 80);
+    assert.equal(entry.metrics.output_tput, 20);
+    assert.equal(entry.metrics.total_tput, 105);
+});
+
+test('BR v0.2 derives total token rate when it is absent', () => {
+    const { entry } = parseRates({
+        input_token_rate: { mean: 80 },
+        output_token_rate: { mean: 20 },
+    });
+
+    assert.equal(entry.metrics.total_tput, 100);
+});
+
+test('BR v0.2 derives input token rate from total and output rates', () => {
+    const { entry } = parseRates({
+        output_token_rate: { mean: 20 },
+        total_token_rate: { mean: 100 },
+    });
+
+    assert.equal(entry.metrics.input_tput, 80);
+});
+
+test('BR v0.2 leaves rates null when fallback inputs are insufficient or invalid', () => {
+    const missingTotal = parseRates({ output_token_rate: { mean: 20 } });
+    assert.equal(missingTotal.entry.metrics.input_tput, null);
+    assert.equal(missingTotal.entry.metrics.total_tput, null);
+
+    const inconsistent = parseRates({
+        output_token_rate: { mean: 20 },
+        total_token_rate: { mean: 10 },
+    });
+    assert.equal(inconsistent.entry.metrics.input_tput, null);
+    assert.equal(inconsistent.entry.metrics.total_tput, 10);
+});
+
+test('BR v0.2 token-rate normalization preserves zero and coerces numeric strings', () => {
+    const { stage, entry } = parseRates({
+        input_token_rate: { mean: '0' },
+        output_token_rate: { mean: '20.5' },
+    });
+
+    assert.equal(stage.performance.inputTokenRate, 0);
+    assert.equal(stage.performance.outputTokenRate, 20.5);
+    assert.equal(entry.metrics.input_tput, 0);
+    assert.equal(entry.metrics.total_tput, 20.5);
+});


### PR DESCRIPTION
## What does this PR do?

- Preserves reported `total_token_rate` values from Benchmark Report v0.2 files.
- Maps total throughput to `metrics.total_tput`.
- Derives total from input plus output when needed, and derives missing input from a valid total minus output.
- Adds regression coverage and documents the fallback behavior.

## Why is this change needed?

The nested Zod throughput schema dropped `total_token_rate`, and the normalized BR v0.2 entry did not populate `metrics.total_tput`. As a result, fresh BR v0.2 imports could show a blank Total Tok/s value.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

Additional checks:

- `make test`
- `node --test src/utils/*.test.js server/*.test.js`
- Targeted ESLint for the changed parser and test
- `npm run type-check`
- `npm run build`

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`make test`)
- [ ] Linters pass (`make lint`) — repository-wide ESLint has pre-existing
  failures; changed parser files pass targeted lint
- [x] Documentation updated (if applicable)

## Related Issues

Fixes: #120

Related to llm-d/llm-d-benchmark#1744
