### PR TITLE
feat: sticky selection toolbar and top-right toast positioning

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -241,9 +241,9 @@ function App() {
             {currentView === 'guided-analysis' && <div className="p-8 text-center text-slate-400 mt-20">Guided Analysis Coming Soon... <button onClick={() => handleNavigate('home')} className="underline ml-2 text-indigo-400">Back</button></div>}
           </>
 
-          {/* Bottom-Right Persistent Status Toast */}
+          {/* Top-Right Persistent Status Toast */}
           {showOverlays && (
-            <div className="fixed bottom-6 right-6 z-[100] w-96 bg-slate-900/95 border border-slate-800 rounded-2xl p-4 shadow-2xl backdrop-blur-md flex flex-col space-y-3 text-sm select-none border-slate-700/50 animate-in slide-in-from-bottom duration-300">
+            <div className="fixed top-20 right-6 z-[100] w-96 bg-slate-900/95 border border-slate-800 rounded-2xl p-4 shadow-2xl backdrop-blur-md flex flex-col space-y-3 text-sm select-none border-slate-700/50 animate-in slide-in-from-top duration-300">
               <div className="flex items-center justify-between">
                 <div className="flex items-center gap-2">
                   <Loader className="w-4 h-4 animate-spin text-blue-500" />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -191,9 +191,9 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <div className="min-h-screen bg-slate-950 w-full overflow-hidden font-sans relative flex flex-col">
+      <div className="min-h-screen bg-slate-950 w-full font-sans relative flex flex-col">
         <LeftNavigation currentView={currentView} onNavigate={handleNavigate} isMobileOpen={isMobileNavOpen} />
-        <main ref={mainRef} className="flex-1 overflow-y-auto flex flex-col relative w-full h-screen">
+        <main ref={mainRef} className="flex-1 flex flex-col relative w-full min-h-screen">
           {/* Top Spark Progress Bar */}
           {showOverlays && (
             <div className="fixed top-0 left-0 right-0 h-1 bg-slate-900 z-[9999] pointer-events-none">

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1600,12 +1600,12 @@ const Dashboard = ({ mode = 'browser', onNavigateBack, onNavigate, dashboardStat
     const hasLocalBenchmarks = Array.from(selectedSources || []).some(source => source === 'local' || source.startsWith('brv02:'));
 
     return (
-        <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col font-sans antialiased relative overflow-x-hidden pt-0">
+        <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col font-sans antialiased relative pt-0">
             {/* Toast Stack */}
-            <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2">
+            <div className="fixed bottom-4 right-4 z-[100000] flex flex-col gap-2 pointer-events-none">
                 {toasts.map(t => (
                     <div key={t.id} className={cn(
-                        'px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4',
+                        'pointer-events-auto px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4',
                         t.type === 'error' ? 'bg-red-500/90 backdrop-blur' :
                             t.type === 'success' ? 'bg-green-500/90 backdrop-blur' : 'bg-blue-600/90 backdrop-blur'
                     )}>

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1602,7 +1602,7 @@ const Dashboard = ({ mode = 'browser', onNavigateBack, onNavigate, dashboardStat
     return (
         <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col font-sans antialiased relative pt-0">
             {/* Toast Stack */}
-            <div className="fixed bottom-4 right-4 z-[100000] flex flex-col gap-2 pointer-events-none">
+            <div className="fixed top-20 right-4 z-[100000] flex flex-col gap-2 pointer-events-none">
                 {toasts.map(t => (
                     <div key={t.id} className={cn(
                         'pointer-events-auto px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4',

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -2502,7 +2502,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
     return (
         <div className="h-screen bg-[#02050b] text-slate-100 flex flex-col font-sans antialiased relative overflow-hidden pt-0 pl-28">
             {/* Toast Stack */}
-            <div className="fixed bottom-4 right-4 z-[100000] flex flex-col gap-2 pointer-events-none">
+            <div className="fixed top-20 right-4 z-[100000] flex flex-col gap-2 pointer-events-none">
                 {toasts.map(t => (
                     <div key={t.id} className={cn(
                         'pointer-events-auto px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4',

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -2502,10 +2502,10 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
     return (
         <div className="h-screen bg-[#02050b] text-slate-100 flex flex-col font-sans antialiased relative overflow-hidden pt-0 pl-28">
             {/* Toast Stack */}
-            <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2">
+            <div className="fixed bottom-4 right-4 z-[100000] flex flex-col gap-2 pointer-events-none">
                 {toasts.map(t => (
                     <div key={t.id} className={cn(
-                        'px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4',
+                        'pointer-events-auto px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4',
                         t.type === 'error' ? 'bg-red-500/90 backdrop-blur' :
                         t.type === 'success' ? 'bg-green-500/90 backdrop-blur' : 'bg-blue-600/90 backdrop-blur'
                     )}>

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -14,7 +14,7 @@
 
 import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { RotateCcw, ChevronDown, ChevronUp, Star, Pin, CheckSquare, Square, Check, Pencil, Trash2, Code2, Copy, X, Database, Eye, EyeOff, ShieldCheck, AlertCircle, TrendingUp, AlertTriangle, Search, FileText, FileClock, Sliders, Activity, Send, Play, Loader, Download } from 'lucide-react';
+import { RotateCcw, ChevronDown, ChevronUp, Star, Pin, CheckSquare, Square, Check, Pencil, Trash2, Code2, Copy, Share2, X, Database, Eye, EyeOff, ShieldCheck, AlertCircle, TrendingUp, AlertTriangle, Search, FileText, FileClock, Sliders, Activity, Send, Play, Loader, Download } from 'lucide-react';
 import { RunComparisonChart } from '../Dashboard/RunComparisonChart';
 import { ThroughputCostChart } from '../Dashboard/ThroughputCostChart';
 import { Button, Badge, StatusChip, Modal, Textarea } from '../ui';
@@ -105,7 +105,7 @@ const getKpiFilterLabel = (filter) => {
 };
 
 export const UnifiedDataTable = (props) => {
-    const { dashboardState, includeUnlisted = false } = props;
+    const { dashboardState, includeUnlisted = false, addToast, dashboardData } = props;
     const { user } = useGitHubAuth();
     const isAdmin = user?.permission === 'admin';
         const [rawYamlContent, setRawYamlContent] = useState(null);
@@ -298,6 +298,35 @@ export const UnifiedDataTable = (props) => {
         loadingConnections
     } = props;
 
+    const selectionBarRef = React.useRef(null);
+    const [isStuck, setIsStuck] = useState(false);
+
+    React.useEffect(() => {
+        if (!selectedBenchmarks || selectedBenchmarks.size === 0) {
+            setIsStuck(false);
+            return;
+        }
+
+        const bar = selectionBarRef.current;
+        if (!bar) return;
+
+        const scrollParent = bar.closest('.overflow-y-auto') || window;
+
+        const checkSticky = () => {
+            if (!selectionBarRef.current) return;
+            const rect = selectionBarRef.current.getBoundingClientRect();
+            const parentTop = scrollParent === window ? 0 : scrollParent.getBoundingClientRect().top;
+            setIsStuck(rect.top <= parentTop + 76);
+        };
+
+        scrollParent.addEventListener('scroll', checkSticky, { passive: true });
+        checkSticky();
+
+        return () => {
+            scrollParent.removeEventListener('scroll', checkSticky);
+        };
+    }, [selectedBenchmarks]);
+
     const selectedStagedRuns = React.useMemo(() => {
         const stagedList = [];
         (brv02Runs || []).forEach(run => {
@@ -399,10 +428,17 @@ export const UnifiedDataTable = (props) => {
     const handleCopyShareLink = React.useCallback(() => {
         if (!canShare || shareableUuids.length === 0) return;
         const shareLink = encodeShareLink(shareableUuids);
-        navigator.clipboard.writeText(shareLink);
-        setToastMessage("Copied link to clipboard!");
-        setShowToast(true);
-    }, [canShare, shareableUuids]);
+        const fullUrl = `${window.location.origin}${window.location.pathname}?benchmarks=${shareLink}`;
+        navigator.clipboard.writeText(fullUrl);
+        if (addToast) {
+            addToast('Copied link to clipboard!', 'success');
+        } else if (dashboardData?.addToast) {
+            dashboardData.addToast('Copied link to clipboard!', 'success');
+        } else {
+            setToastMessage('Copied link to clipboard!');
+            setShowToast(true);
+        }
+    }, [canShare, shareableUuids, addToast, dashboardData]);
 
     const buildBundleForRun = React.useCallback((run) => {
         const stageFiles = run.stages.map(stage => {
@@ -1531,17 +1567,32 @@ export const UnifiedDataTable = (props) => {
                     </div>
                 </div>
             ) : (
-                /* Selected State: Highlighted context toolbar with primary actions */
-                <div className="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 px-4 py-2.5 rounded-2xl bg-cyan-950/15 border border-cyan-500/25 animate-in fade-in slide-in-from-top-1.5 duration-200 select-none shadow-md min-h-[52px]">
+                /* Selected State: Sticky context toolbar with primary actions */
+                <div
+                    ref={selectionBarRef}
+                    className={cn(
+                        "sticky top-[72px] z-40 transition-all duration-150 ease-out select-none flex flex-col sm:flex-row justify-between items-start sm:items-center gap-3 px-4 py-2.5 rounded-2xl border min-h-[52px]",
+                        isStuck
+                            ? "bg-slate-950/95 backdrop-blur-2xl border-cyan-400/80 scale-[1.015] shadow-[0_8px_20px_rgba(0,0,0,0.4),0_0_12px_rgba(6,182,212,0.15)]"
+                            : "bg-slate-950/85 backdrop-blur-xl border-cyan-500/60 hover:border-cyan-400/80 scale-100 shadow-md"
+                    )}
+                >
                     <div className="flex items-center gap-3">
-                        <div className="text-xs font-bold text-cyan-400 bg-cyan-500/10 border border-cyan-500/30 px-2.5 py-0.5 rounded-lg">
-                            {selectedBenchmarks.size} Selected
-                        </div>
+                        <span className="text-xs font-medium text-cyan-400">
+                            {selectedBenchmarks.size} {selectedBenchmarks.size === 1 ? 'Benchmark' : 'Benchmarks'} Selected
+                        </span>
                         <button
                             onClick={clearSelected}
-                            className="text-xs text-slate-455 hover:text-slate-200 transition-colors underline cursor-pointer font-medium"
+                            className="text-xs text-slate-400 hover:text-slate-200 transition-colors underline cursor-pointer font-medium"
                         >
                             Unselect all
+                        </button>
+                        <span className="text-slate-600 text-xs select-none">•</span>
+                        <button
+                            onClick={invertSelected}
+                            className="text-xs text-slate-400 hover:text-slate-200 transition-colors underline cursor-pointer font-medium"
+                        >
+                            Invert selection
                         </button>
                     </div>
                     
@@ -1580,11 +1631,31 @@ export const UnifiedDataTable = (props) => {
 
                         {/* Compare Selected Button */}
                         <button
+                            id="top-compare-publish-btn"
                             onClick={() => sortedStats.length > 0 && setShowComparisonDrawer(true)}
-                            className="px-4 py-1.5 text-xs font-semibold rounded-xl bg-cyan-500 hover:bg-cyan-400 text-slate-950 shadow-[0_0_15px_rgba(34,211,238,0.4)] flex items-center gap-1.5 transition-all duration-300 hover:scale-105 cursor-pointer"
+                            className="px-4 py-1.5 text-xs font-semibold rounded-xl bg-cyan-500 hover:bg-cyan-400 text-slate-950 shadow-[0_0_15px_rgba(34,211,238,0.4)] flex items-center gap-1.5 transition-all duration-300 hover:scale-105 cursor-pointer whitespace-nowrap"
                         >
                             {hasPromotableSelected ? `Compare & Promote (${selectedBenchmarks.size})` : `Compare & Inspect (${selectedBenchmarks.size})`}
                         </button>
+
+                        {/* Copy Link Button */}
+                        <div className="relative group/share-link">
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={handleCopyShareLink}
+                                disabled={!canShare}
+                                className={cn("gap-1.5", !canShare && "opacity-50 cursor-not-allowed")}
+                            >
+                                <Share2 size={12} />
+                                <span>Share Link</span>
+                            </Button>
+                            {!canShare && shareForbiddenReason && (
+                                <div className="absolute right-0 top-full mt-2 px-3 py-2 bg-slate-900 border border-slate-800 text-slate-350 text-xs font-medium rounded-xl opacity-0 invisible group-hover/share-link:opacity-100 group-hover/share-link:visible transition-all duration-200 shadow-2xl z-[9999] w-64 pointer-events-none leading-relaxed text-center normal-case tracking-normal animate-in fade-in slide-in-from-top-2 duration-150">
+                                    {shareForbiddenReason}
+                                </div>
+                            )}
+                        </div>
 
                         {/* Edit Selected Staged Runs */}
                         {hasAnyLocalRuns && (
@@ -1599,15 +1670,7 @@ export const UnifiedDataTable = (props) => {
                             </Button>
                         )}
 
-                        {/* Invert Selected */}
-                        <Button variant="secondary" size="sm" onClick={invertSelected}>
-                            Invert Selection
-                        </Button>
 
-                        {/* Unselect All */}
-                        <Button variant="secondary" size="sm" onClick={clearSelected}>
-                            Unselect All
-                        </Button>
 
                         {/* Delete Staged Runs */}
                         {hasAnyLocalRuns && (
@@ -2012,7 +2075,7 @@ export const UnifiedDataTable = (props) => {
                                             disabled={!canShare}
                                             className={cn("gap-1.5", !canShare && "opacity-50 cursor-not-allowed")}
                                         >
-                                            <Copy size={12} />
+                                            <Share2 size={12} />
                                             <span>Share Link</span>
                                         </Button>
                                         {!canShare && shareForbiddenReason && (
@@ -2118,85 +2181,7 @@ export const UnifiedDataTable = (props) => {
                 </div>,
                 document.body
             )}
-            {/* Floating Action Dock when runs are selected */}
-            {selectedBenchmarks.size > 0 && createPortal(
-                <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-[9999] flex items-center gap-4 bg-slate-950/90 backdrop-blur-md border border-slate-800/80 px-4 py-3 rounded-2xl shadow-[0_10px_30px_rgba(0,0,0,0.5)] animate-in slide-in-from-bottom duration-300 whitespace-nowrap max-w-fit">
-                    <span className="text-xs font-medium text-slate-300 whitespace-nowrap flex-shrink-0">
-                        {selectedBenchmarks.size} {selectedBenchmarks.size === 1 ? 'benchmark' : 'benchmarks'} selected
-                    </span>
-                    <div className="h-4 w-px bg-slate-800 flex-shrink-0" />
-                    <button
-                        onClick={clearSelected}
-                        className="text-xs font-semibold text-slate-400 hover:text-white transition-colors cursor-pointer whitespace-nowrap flex-shrink-0"
-                    >
-                        Unselect All
-                    </button>
-                    {isAdmin && onlyPendingReviewSelected && (
-                        <>
-                            <Button
-                                variant="primary"
-                                size="sm"
-                                onClick={() => handleActionClick(handleBulkApprove)}
-                                disabled={isLoadingSubmissions || isLocalActionPending}
-                                className="whitespace-nowrap flex-shrink-0"
-                            >
-                                <Check className="w-3.5 h-3.5 stroke-[3]" /> Approve
-                            </Button>
-                            <Button
-                                variant="danger"
-                                size="sm"
-                                onClick={() => handleActionClick(handleBulkReject)}
-                                disabled={isLoadingSubmissions || isLocalActionPending}
-                                className="whitespace-nowrap flex-shrink-0"
-                            >
-                                <X className="w-3.5 h-3.5" /> Reject
-                            </Button>
-                        </>
-                    )}
-                    {isAdmin && onlyRejectedSelected && (
-                        <Button
-                            variant="danger"
-                            size="sm"
-                            onClick={() => handleActionClick(handleBulkDeleteRejected)}
-                            disabled={isLoadingSubmissions || isLocalActionPending}
-                            className="whitespace-nowrap flex-shrink-0"
-                        >
-                            <Trash2 className="w-3.5 h-3.5" /> Delete
-                        </Button>
-                    )}
-                    <button
-                        id="bottom-compare-publish-btn"
-                        onClick={() => setShowComparisonDrawer(true)}
-                        className="px-4 py-2 bg-cyan-500 hover:bg-cyan-400 text-slate-950 text-xs font-semibold rounded-xl shadow-md transition-all duration-200 cursor-pointer hover:scale-105 whitespace-nowrap flex-shrink-0"
-                    >
-                        {hasPromotableSelected ? 'Compare & Promote' : 'Compare & Inspect'}
-                    </button>
-                    {hasAnyLocalRuns && (
-                        <Button
-                            variant="secondary"
-                            size="sm"
-                            onClick={handleEditSelected}
-                            disabled={selectedStagedRuns.length === 0}
-                            title={selectedStagedRuns.length === 0 ? "Select staged benchmarks to edit" : "Edit selected staged benchmarks"}
-                            className="whitespace-nowrap flex-shrink-0"
-                        >
-                            <Pencil className="w-3.5 h-3.5" /> Edit Selected
-                        </Button>
-                    )}
-                    {hasAnyLocalRuns && (
-                        <Button
-                            variant="danger"
-                            size="sm"
-                            onClick={handleDeleteSelected}
-                            disabled={localSelectedCount === 0}
-                            className="whitespace-nowrap flex-shrink-0"
-                        >
-                            <Trash2 className="w-3.5 h-3.5" /> Delete Staged ({localSelectedCount})
-                        </Button>
-                    )}
-                </div>,
-                document.body
-            )}
+
 
         </div>
     );

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -1019,7 +1019,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                 <div className="absolute bottom-0 -right-1/4 w-1/2 h-1/2 bg-emerald-600/20 rounded-full blur-3xl animate-pulse" style={{ animationDelay: '2s' }} />
             </div>
             {/* Toast Stack */}
-            <div className="fixed bottom-4 right-4 z-[100000] flex flex-col gap-2 pointer-events-none">
+            <div className="fixed top-20 right-4 z-[100000] flex flex-col gap-2 pointer-events-none">
                 {toasts.map(t => (
                     <div key={t.id} className={cn(
                         'pointer-events-auto px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4',

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -1012,15 +1012,17 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
     ]);
 
     return (
-        <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col font-sans antialiased relative overflow-x-hidden pt-0 bg-[radial-gradient(#334155_1.2px,transparent_1.2px)] bg-[size:24px_24px] bg-repeat tabular-nums">
+        <div className="min-h-screen bg-slate-950 text-slate-100 flex flex-col font-sans antialiased relative pt-0 bg-[radial-gradient(#334155_1.2px,transparent_1.2px)] bg-[size:24px_24px] bg-repeat tabular-nums">
             {/* Pulsing Vibrant Neon Glow Background Shapes */}
-            <div className="absolute top-0 -left-1/4 w-1/2 h-1/2 bg-blue-600/20 rounded-full blur-3xl pointer-events-none animate-pulse" />
-            <div className="absolute bottom-0 -right-1/4 w-1/2 h-1/2 bg-emerald-600/20 rounded-full blur-3xl pointer-events-none animate-pulse" style={{ animationDelay: '2s' }} />
+            <div className="absolute inset-0 overflow-hidden pointer-events-none z-0">
+                <div className="absolute top-0 -left-1/4 w-1/2 h-1/2 bg-blue-600/20 rounded-full blur-3xl animate-pulse" />
+                <div className="absolute bottom-0 -right-1/4 w-1/2 h-1/2 bg-emerald-600/20 rounded-full blur-3xl animate-pulse" style={{ animationDelay: '2s' }} />
+            </div>
             {/* Toast Stack */}
-            <div className="fixed bottom-4 right-4 z-[100] flex flex-col gap-2">
+            <div className="fixed bottom-4 right-4 z-[100000] flex flex-col gap-2 pointer-events-none">
                 {toasts.map(t => (
                     <div key={t.id} className={cn(
-                        'px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4',
+                        'pointer-events-auto px-4 py-3 rounded-lg shadow-lg text-white text-sm font-medium transition-all animate-in slide-in-from-right duration-300 flex items-center justify-between gap-4',
                         t.type === 'error' ? 'bg-red-500/90 backdrop-blur' :
                             t.type === 'success' ? 'bg-green-500/90 backdrop-blur' : 'bg-blue-600/90 backdrop-blur'
                     )}>
@@ -1032,7 +1034,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                 ))}
             </div>
 
-            <header className="w-full h-16 border-b border-slate-900/65 flex justify-between items-center px-6 bg-slate-950/20 backdrop-blur-md sticky top-0 z-[49]">
+            <header className="w-full h-16 border-b border-slate-800 flex justify-between items-center px-6 bg-slate-950/90 backdrop-blur-xl sticky top-0 z-[49] shadow-xl">
                 <div className="flex items-center gap-4">
                     {onNavigateBack && (
                         <button onClick={onNavigateBack} className="p-1.5 rounded-xl hover:bg-slate-900/60 text-slate-400 hover:text-white transition-colors cursor-pointer border border-transparent hover:border-slate-800/60">

--- a/src/components/ui/PageHeader.jsx
+++ b/src/components/ui/PageHeader.jsx
@@ -70,7 +70,7 @@ export function PageHeader({
 
 // "Share link" button with the built-in "Link copied!" toast used across dashboards.
 // Pass getUrl to share a constructed deep link instead of the current location.
-export function ShareLinkButton({ label = 'Share link', getUrl, className }) {
+export function ShareLinkButton({ label = 'Share Link', getUrl, className }) {
     const [copied, setCopied] = useState(false);
 
     const handleShare = () => {


### PR DESCRIPTION
## What does this PR do?

This PR overhauls the benchmark selection toolbar UX and repositions global toast notifications across the application:

1. **Sticky & Glassy Selection Toolbar**:
   - Replaces the floating bottom selection dock in `UnifiedDataTable` with a sticky bar pinned 72px below the page header.
   - Unblocks standard CSS sticky behavior by removing scroll-intercepting overflow wrappers on root app containers.
   - Applies darkened backdrop-blur glass styling with cyan border highlights and a 150ms elevation zoom transition.
   - Updates selection count pill styling to `font-medium` text.
   - Relocates "Invert selection" to the left action group as a link button, and places "Share Link" right of "Compare & Promote" with the `Share2` icon and deep-link URL copying.

2. **Top-Right Toast Positioning**:
   - Repositions toast container stacks and persistent status overlays from bottom-right to top-right (`top-20 right-4/right-6`) so that it doesn't block important buttons.
   - Elevates the toast stack container `z-index` to `z-[100000]` so toasts display above sidebars and modals without obscuring bottom action controls.

## Why is this change needed?

The floating bottom dock intercepted clicks and obstructed primary page actions at the bottom of the dataset table. Moving the selection bar to a sticky position below the header keeps selection controls accessible while scrolling. Repositioning toasts to the top-right prevents notification alerts from covering action buttons in lower views.

## How was this tested?

- [ ] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

<!-- Link to related issues: Fixes #123, Related to #456 -->