### PR TITLE
Sync filter state with URL parameters and apply instantly

### DIFF
--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -14,7 +14,7 @@
 
 import React, { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import { Filter, ChevronDown, ChevronUp, Check, ArrowDown01, ArrowDown10, Loader, FileText, FileClock, Sliders, Search, Activity, TrendingUp, ShieldCheck, Database, Layout, HelpCircle, Bookmark, Trash2, Settings, X, Pencil, Laptop, CloudUpload, ArrowRight } from 'lucide-react';
+import { Filter, ChevronDown, ChevronUp, Check, ArrowDown01, ArrowDown10, Loader, FileText, FileClock, Sliders, Search, Activity, TrendingUp, ShieldCheck, Database, Layout, HelpCircle, Bookmark, Trash2, Settings, X, Pencil, Laptop, CloudUpload, ArrowRight, RotateCcw } from 'lucide-react';
 import { MultiSelectDropdown } from '../common';
 import { Button, Input, Select, Label } from '../ui';
 import { cn } from '../../utils/cn';
@@ -116,7 +116,6 @@ export const FilterPanel = ({
     const { user } = useGitHubAuth();
 
 
-    const [draftFilters, setDraftFilters] = useState(null);
     const [openSections, setOpenSections] = useState({
         stack: true,
         infra: false,
@@ -126,33 +125,6 @@ export const FilterPanel = ({
 
     const toggleSection = (section) => {
         setOpenSections(prev => ({ ...prev, [section]: !prev[section] }));
-    };
-
-    // Sync draft filters with activeFilters when the drawer opens
-    useEffect(() => {
-        if (isAdvancedExpanded) {
-            const draft = {};
-            Object.entries(activeFilters).forEach(([key, val]) => {
-                draft[key] = new Set(val);
-            });
-            setDraftFilters(draft);
-        } else {
-            setDraftFilters(null);
-        }
-    }, [isAdvancedExpanded, activeFilters]);
-
-    const toggleDraftFilter = (category, value) => {
-        setDraftFilters(prev => {
-            if (!prev) return prev;
-            const newSet = new Set(prev[category] || []);
-            if (value === '' || value === undefined) {
-                newSet.clear();
-            } else {
-                if (newSet.has(value)) newSet.delete(value);
-                else newSet.add(value);
-            }
-            return { ...prev, [category]: newSet };
-        });
     };
 
     const [showSpecsDropdown, setShowSpecsDropdown] = useState(false);
@@ -237,16 +209,32 @@ export const FilterPanel = ({
     };
 
     const hasFiltersToSave = React.useMemo(() => {
-        const filtersToUse = draftFilters || activeFilters;
+        const filtersToUse = activeFilters;
         const hasActiveFilters = Object.values(filtersToUse).some(valSet => valSet instanceof Set && valSet.size > 0);
         return hasActiveFilters || !!searchTerm || !!kpiFilter;
-    }, [draftFilters, activeFilters, searchTerm, kpiFilter]);
+    }, [activeFilters, searchTerm, kpiFilter]);
+
+    const hasAnyActiveFilters = React.useMemo(() => {
+        const hasActiveFacet = Object.values(activeFilters).some(valSet => valSet instanceof Set && valSet.size > 0);
+        return hasActiveFacet || !!searchTerm || !!kpiFilter || !!includeUnlisted;
+    }, [activeFilters, searchTerm, kpiFilter, includeUnlisted]);
+
+    const handleClearAllFilters = () => {
+        setSearchTerm('');
+        setKpiFilter(null);
+        if (setIncludeUnlisted) setIncludeUnlisted(false);
+        const newFilters = {};
+        Object.keys(activeFilters).forEach(key => {
+            newFilters[key] = new Set();
+        });
+        setActiveFilters(newFilters);
+    };
 
     const handleSavePreset = (e) => {
         e.preventDefault();
         if (!newPresetName.trim() || !hasFiltersToSave) return;
         
-        const filtersToUse = draftFilters || activeFilters;
+        const filtersToUse = activeFilters;
         const filtersToSave = {};
         Object.entries(filtersToUse).forEach(([key, set]) => {
             if (set instanceof Set && set.size > 0) {
@@ -1229,7 +1217,22 @@ export const FilterPanel = ({
                     </div>
 
                     {/* Scrollable Content */}
-                    <div className="flex-1 overflow-y-auto p-5 space-y-6 custom-scrollbar">
+                    <div className="flex-1 overflow-y-auto p-5 space-y-5 custom-scrollbar">
+                        {/* Reset All Active Filters Button */}
+                        <button
+                            type="button"
+                            onClick={handleClearAllFilters}
+                            disabled={!hasAnyActiveFilters}
+                            className={cn(
+                                'w-full py-2 px-3 text-xs font-bold uppercase rounded-xl transition-all cursor-pointer flex items-center justify-center gap-2 border shadow-sm select-none',
+                                hasAnyActiveFilters
+                                ? 'bg-slate-900 hover:bg-slate-800 text-red-400 border-red-500/30 hover:border-red-500/50 hover:shadow-md'
+                                : 'bg-slate-950/40 text-slate-600 border-slate-900 cursor-not-allowed opacity-60'
+                            )}
+                        >
+                            <RotateCcw size={13} className={cn(hasAnyActiveFilters ? 'text-red-400' : 'text-slate-600')} /> Reset All Active Filters
+                        </button>
+
                         {/* Saved Presets Section */}
                         <div className="bg-slate-950/20 p-4 rounded-xl border border-slate-900/60 shadow-md shadow-slate-950/20 space-y-3.5 mb-2">
                             <h4 className="text-[10px] font-black uppercase tracking-wider text-cyan-400 border-b border-slate-800/60 pb-1.5 flex items-center gap-1.5 select-none">
@@ -1453,15 +1456,15 @@ export const FilterPanel = ({
                                         <MultiSelectDropdown 
                                             label="Serving Stack"
                                             options={filterOptions.servingStack || []}
-                                            selected={draftFilters ? draftFilters.servingStack : (activeFilters.servingStack || new Set())}
-                                            onChange={(val) => toggleDraftFilter('servingStack', val)}
+                                            selected={activeFilters.servingStack || new Set()}
+                                            onChange={(val) => toggleFilter('servingStack', val)}
                                             counts={facetCounts.servingStack || {}}
                                         />
                                         <MultiSelectDropdown 
                                             label="Model Server"
                                             options={filterOptions.modelServer}
-                                            selected={draftFilters ? draftFilters.modelServer : (activeFilters.modelServer || new Set())}
-                                            onChange={(val) => toggleDraftFilter('modelServer', val)}
+                                            selected={activeFilters.modelServer || new Set()}
+                                            onChange={(val) => toggleFilter('modelServer', val)}
                                             counts={facetCounts.modelServer}
                                         />
                                         <MultiSelectDropdown 
@@ -1475,15 +1478,15 @@ export const FilterPanel = ({
                                                 "Approximate prefix aware routing",
                                                 "Precise prefix aware routing"
                                             ]}
-                                            selected={draftFilters ? draftFilters.optimizations : (activeFilters.optimizations || new Set())}
-                                            onChange={(val) => toggleDraftFilter('optimizations', val)}
+                                            selected={activeFilters.optimizations || new Set()}
+                                            onChange={(val) => toggleFilter('optimizations', val)}
                                             counts={facetCounts.optimizations}
                                         />
                                         <MultiSelectDropdown 
                                             label="Precisions"
                                             options={filterOptions.precisions}
-                                            selected={draftFilters ? draftFilters.precisions : (activeFilters.precisions || new Set())}
-                                            onChange={(val) => toggleDraftFilter('precisions', val)}
+                                            selected={activeFilters.precisions || new Set()}
+                                            onChange={(val) => toggleFilter('precisions', val)}
                                             counts={facetCounts.precisions}
                                         />
                                     </div>
@@ -1504,29 +1507,29 @@ export const FilterPanel = ({
                                         <MultiSelectDropdown 
                                             label="Machine Type"
                                             options={filterOptions.machines}
-                                            selected={draftFilters ? draftFilters.machines : (activeFilters.machines || new Set())}
-                                            onChange={(val) => toggleDraftFilter('machines', val)}
+                                            selected={activeFilters.machines || new Set()}
+                                            onChange={(val) => toggleFilter('machines', val)}
                                             counts={facetCounts.machines}
                                         />
                                         <MultiSelectDropdown 
                                             label="Accelerator Count"
                                             options={filterOptions.acc_count}
-                                            selected={draftFilters ? draftFilters.acc_count : (activeFilters.acc_count || new Set())}
-                                            onChange={(val) => toggleDraftFilter('acc_count', val)}
+                                            selected={activeFilters.acc_count || new Set()}
+                                            onChange={(val) => toggleFilter('acc_count', val)}
                                             counts={facetCounts.acc_count}
                                         />
                                         <MultiSelectDropdown 
                                             label="Tensor Parallelism (TP)"
                                             options={filterOptions.tp || []}
-                                            selected={draftFilters ? draftFilters.tp : (activeFilters.tp || new Set())}
-                                            onChange={(val) => toggleDraftFilter('tp', val)}
+                                            selected={activeFilters.tp || new Set()}
+                                            onChange={(val) => toggleFilter('tp', val)}
                                             counts={facetCounts.tp}
                                         />
                                         <MultiSelectDropdown 
                                             label="P/D Node Ratio"
                                             options={filterOptions.pdRatio}
-                                            selected={draftFilters ? draftFilters.pdRatio : (activeFilters.pdRatio || new Set())}
-                                            onChange={(val) => toggleDraftFilter('pdRatio', val)}
+                                            selected={activeFilters.pdRatio || new Set()}
+                                            onChange={(val) => toggleFilter('pdRatio', val)}
                                             counts={facetCounts.pdRatio}
                                         />
                                     </div>
@@ -1547,29 +1550,29 @@ export const FilterPanel = ({
                                         <MultiSelectDropdown 
                                             label="Input (ISL)"
                                             options={filterOptions.isl}
-                                            selected={draftFilters ? draftFilters.isl : (activeFilters.isl || new Set())}
-                                            onChange={(val) => toggleDraftFilter('isl', val)}
+                                            selected={activeFilters.isl || new Set()}
+                                            onChange={(val) => toggleFilter('isl', val)}
                                             counts={facetCounts.isl}
                                         />
                                         <MultiSelectDropdown 
                                             label="Output (OSL)"
                                             options={filterOptions.osl}
-                                            selected={draftFilters ? draftFilters.osl : (activeFilters.osl || new Set())}
-                                            onChange={(val) => toggleDraftFilter('osl', val)}
+                                            selected={activeFilters.osl || new Set()}
+                                            onChange={(val) => toggleFilter('osl', val)}
                                             counts={facetCounts.osl}
                                         />
                                         <MultiSelectDropdown 
                                             label="Workload Type"
                                             options={filterOptions.ratio}
-                                            selected={draftFilters ? draftFilters.ratio : (activeFilters.ratio || new Set())}
-                                            onChange={(val) => toggleDraftFilter('ratio', val)}
+                                            selected={activeFilters.ratio || new Set()}
+                                            onChange={(val) => toggleFilter('ratio', val)}
                                             counts={facetCounts.ratio}
                                         />
                                         <MultiSelectDropdown 
                                             label="Use Case"
                                             options={filterOptions.useCase}
-                                            selected={draftFilters ? draftFilters.useCase : (activeFilters.useCase || new Set())}
-                                            onChange={(val) => toggleDraftFilter('useCase', val)}
+                                            selected={activeFilters.useCase || new Set()}
+                                            onChange={(val) => toggleFilter('useCase', val)}
                                             counts={facetCounts.useCase}
                                             formatLabel={(opt) => {
                                                 const meta = USE_CASE_META[opt];
@@ -1597,14 +1600,14 @@ export const FilterPanel = ({
                                             </div>
                                             <div className="bg-[#0b0f17]/40 border border-slate-800/40 rounded-xl p-2.5 max-h-60 overflow-y-auto space-y-1">
                                                 {(() => {
-                                                    const selectedConnectionNames = draftFilters ? draftFilters.connectionNames : (activeFilters.connectionNames || new Set());
+                                                    const selectedConnectionNames = activeFilters.connectionNames || new Set();
                                                     const selectedCount = selectedConnectionNames.size;
                                                     const options = filterOptions.connectionNames || [];
                                                     return (
                                                         <>
                                                             <div
                                                                 className={cn('flex items-center gap-2 px-2.5 py-1.5 rounded-lg cursor-pointer hover:bg-slate-800/80 transition-all', selectedCount === 0 ? 'bg-cyan-500/10 text-cyan-400 font-semibold' : 'text-slate-300 hover:text-slate-200')}
-                                                                onClick={() => toggleDraftFilter('connectionNames', '')}
+                                                                onClick={() => toggleFilter('connectionNames', '')}
                                                             >
                                                                  <div className={cn('w-3.5 h-3.5 rounded border flex items-center justify-center transition-colors', selectedCount === 0 ? 'bg-cyan-500 border-cyan-500 text-white' : 'border-slate-800/40 bg-slate-950')}>
                                                                     {selectedCount === 0 && <Check size={10} className="text-white" strokeWidth={3} />}
@@ -1626,7 +1629,7 @@ export const FilterPanel = ({
                                                                             count === 0 ? 'opacity-45 hover:bg-slate-800/30' : 'hover:bg-slate-800/80',
                                                                             isSelected ? 'bg-cyan-500/10 text-cyan-400 font-semibold' : 'text-slate-300 hover:text-slate-200'
                                                                         )}
-                                                                        onClick={() => toggleDraftFilter('connectionNames', opt)}
+                                                                        onClick={() => toggleFilter('connectionNames', opt)}
                                                                     >
                                                                          <div className={cn('w-3.5 h-3.5 rounded border flex items-center justify-center transition-colors', isSelected ? 'bg-cyan-500 border-cyan-500 text-white' : 'border-slate-800/40 bg-slate-950')}>
                                                                             {isSelected && <Check size={10} className="text-white" strokeWidth={3} />}
@@ -1646,8 +1649,8 @@ export const FilterPanel = ({
                                         <MultiSelectDropdown 
                                             label="Origin / Folder"
                                             options={filterOptions.origins || []}
-                                            selected={draftFilters ? draftFilters.origins : (activeFilters.origins || new Set())}
-                                            onChange={(val) => toggleDraftFilter('origins', val)}
+                                            selected={activeFilters.origins || new Set()}
+                                            onChange={(val) => toggleFilter('origins', val)}
                                             counts={facetCounts.origins || {}}
                                             formatLabel={formatOriginLabel}
                                         />
@@ -1655,31 +1658,6 @@ export const FilterPanel = ({
                                 )}
                             </div>
                         </div>
-                    </div>
-
-                    {/* Drawer Footer Actions */}
-                    <div className="p-4 bg-slate-950/80 border-t border-slate-800/80 flex items-center justify-between gap-3 select-none">
-                        <Button
-                            type="button"
-                            variant="secondary"
-                            size="sm"
-                            className="flex-1"
-                            onClick={() => setIsAdvancedExpanded(false)}
-                        >
-                            Cancel
-                        </Button>
-                        <button
-                            type="button"
-                            onClick={() => {
-                                if (draftFilters) {
-                                    setActiveFilters(draftFilters);
-                                }
-                                setIsAdvancedExpanded(false);
-                            }}
-                            className="px-4 py-2 text-xs font-bold uppercase text-white bg-cyan-600 hover:bg-cyan-500 rounded-xl transition-all shadow-md cursor-pointer flex-1 text-center"
-                        >
-                            Apply Filters
-                        </button>
                     </div>
                 </div>,
                 document.body

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -145,12 +145,30 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
         } catch { return []; }
     });
     const [activeTab, setActiveTab] = React.useState('all'); // 'all' or 'submissions'
-    const [searchTerm, setSearchTerm] = React.useState('');
+    const [searchTerm, setSearchTerm] = React.useState(() => {
+        try {
+            const params = new URLSearchParams(window.location.search);
+            const urlQ = params.get('q') || params.get('search');
+            if (urlQ) return urlQ;
+
+            const saved = localStorage.getItem('prism_search_term');
+            if (saved) return saved;
+        } catch {}
+        return '';
+    });
 
     const [includeUnlisted, setIncludeUnlisted] = React.useState(() => {
         try {
             const params = new URLSearchParams(window.location.search);
-            return params.get('includeUnlisted') === '1' || params.get('includeUnlisted') === 'true';
+            if (params.has('unlisted')) {
+                return params.get('unlisted') === 'true' || params.get('unlisted') === '1';
+            }
+            if (params.has('includeUnlisted')) {
+                return params.get('includeUnlisted') === 'true' || params.get('includeUnlisted') === '1';
+            }
+
+            const saved = localStorage.getItem('prism_include_unlisted');
+            if (saved !== null) return saved === 'true';
         } catch {
             return false;
         }
@@ -159,12 +177,15 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
     const [kpiFilter, setKpiFilter] = React.useState(() => {
         try {
             const params = new URLSearchParams(window.location.search);
-            const urlKpi = params.get('kpiFilter');
-            if (urlKpi) return urlKpi;
+            const urlStatus = params.get('status') || params.get('kpiFilter');
+            if (urlStatus) return urlStatus;
 
             if (params.get('own') === 'true') {
                 return 'my-submissions';
             }
+
+            const savedStatus = localStorage.getItem('prism_status_filter');
+            if (savedStatus) return savedStatus;
 
             const triggerStaged = localStorage.getItem('prism_activate_staged_filter');
             if (triggerStaged === 'true') {
@@ -180,8 +201,31 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
     });
 
     React.useEffect(() => {
+        try {
+            localStorage.setItem('prism_search_term', searchTerm);
+        } catch (e) { console.warn(e); }
+    }, [searchTerm]);
+
+    React.useEffect(() => {
+        try {
+            localStorage.setItem('prism_include_unlisted', includeUnlisted.toString());
+        } catch (e) { console.warn(e); }
+    }, [includeUnlisted]);
+
+    React.useEffect(() => {
+        try {
+            if (kpiFilter) {
+                localStorage.setItem('prism_status_filter', kpiFilter);
+            } else {
+                localStorage.removeItem('prism_status_filter');
+            }
+        } catch (e) { console.warn(e); }
+    }, [kpiFilter]);
+
+    React.useEffect(() => {
         const params = new URLSearchParams(window.location.search);
         if (kpiFilter) {
+            params.set('status', kpiFilter);
             params.set('kpiFilter', kpiFilter);
             if (['my-submissions', 'staged', 'unlisted', 'processing', 'in_review', 'approved', 'action'].includes(kpiFilter)) {
                 params.set('own', 'true');
@@ -189,21 +233,31 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                 params.delete('own');
             }
         } else {
+            params.delete('status');
             params.delete('kpiFilter');
             params.delete('own');
         }
 
         if (includeUnlisted) {
+            params.set('unlisted', '1');
             params.set('includeUnlisted', '1');
         } else {
+            params.delete('unlisted');
             params.delete('includeUnlisted');
+        }
+
+        if (searchTerm) {
+            params.set('q', searchTerm);
+        } else {
+            params.delete('q');
+            params.delete('search');
         }
         
         const newUrl = `${window.location.pathname}?${params.toString()}`;
         if (window.location.search !== `?${params.toString()}`) {
             window.history.replaceState(null, '', newUrl);
         }
-    }, [kpiFilter, includeUnlisted]);
+    }, [kpiFilter, includeUnlisted, searchTerm]);
 
     React.useEffect(() => {
         const showSubmitFlow = sessionStorage.getItem('prism_show_submit_dialog_after_login');

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -203,8 +203,43 @@ export const useDashboardData = (initialState, dashboardState) => {
         return new Set(['local', 'llm-d-results:google_drive', 'llmd_drive']);
     });
     const [selectedSources, setSelectedSources] = useState(() => {
+        if (initialState?.sources && initialState.sources.size > 0) {
+            return initialState.sources;
+        }
+        try {
+            const savedStr = localStorage.getItem('prism_selected_sources');
+            if (savedStr) {
+                const saved = JSON.parse(savedStr);
+                if (Array.isArray(saved) && saved.length > 0) {
+                    return new Set(saved);
+                }
+            }
+        } catch (e) {
+            console.warn("Failed to load selected sources from local storage", e);
+        }
         return new Set(['local', 'llm-d-results:google_drive', 'llmd_drive']);
     });
+
+    useEffect(() => {
+        try {
+            localStorage.setItem('prism_selected_sources', JSON.stringify(Array.from(selectedSources)));
+
+            if (typeof window !== 'undefined') {
+                const params = new URLSearchParams(window.location.search);
+                params.delete('src');
+                if (selectedSources && selectedSources.size > 0) {
+                    Array.from(selectedSources).forEach(val => params.append('src', val));
+                }
+                const newSearch = params.toString();
+                const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}`;
+                if (window.location.search !== (newSearch ? `?${newSearch}` : '')) {
+                    window.history.replaceState(null, '', newUrl);
+                }
+            }
+        } catch (e) {
+            console.warn("Failed to save selected sources to local storage or sync URL", e);
+        }
+    }, [selectedSources]);
     const [bucketConfigs, setBucketConfigs] = useState(() => {
         try {
             const saved = JSON.parse(localStorage.getItem('prism_saved_sources') || '{}');

--- a/src/hooks/useDashboardState.js
+++ b/src/hooks/useDashboardState.js
@@ -18,7 +18,7 @@ import { defaultState } from '../config/defaultState';
 export const getSharedState = () => {
     if (typeof window === 'undefined') return null;
     const params = new URLSearchParams(window.location.search);
-    if (!params.has('share')) return null;
+    if (Array.from(params.keys()).length === 0) return null;
 
     try {
         const parseSet = (key) => new Set(params.getAll(key));
@@ -26,29 +26,33 @@ export const getSharedState = () => {
         const parseBool = (key, def) => params.has(key) ? params.get(key) === 'true' : def;
 
         return {
+            status: params.get('status') || params.get('kpiFilter') || null,
+            own: params.has('own') ? params.get('own') === 'true' : null,
+            q: params.get('q') || params.get('search') || null,
+            unlisted: params.has('unlisted') ? params.get('unlisted') === 'true' || params.get('unlisted') === '1' : (params.has('includeUnlisted') ? params.get('includeUnlisted') === 'true' || params.get('includeUnlisted') === '1' : null),
             chartMode: params.get('c_mode') || 'tpot',
             tputType: params.get('t_type') || 'output',
             costMode: params.get('cost_mode') || 'spot',
             latType: params.get('l_type') || 'e2e',
             // Normalize Aggregated keys to use double colons (only if not already double)
-            selectedModels: new Set([...parseSet('models')].map(k => k.includes('::Aggregated') ? k : k.replace(':Aggregated', '::Aggregated'))),
-            modelsFilter: parseSet('f_models'),
-            hwFilter: parseSet('f_hw'),
-            machFilter: parseSet('f_mach'),
-            precFilter: parseSet('f_prec'),
-            tpFilter: parseSet('f_tp'),
-            islFilter: parseSet('f_isl'),
-            oslFilter: parseSet('f_osl'),
-            ratioFilter: parseSet('f_ratio'),
-            pdRatioFilter: parseSet('f_pd_ratio'),
-            msFilter: parseSet('f_ms'),
-            ssFilter: parseSet('f_ss'),
-            originFilter: parseSet('f_origin'),
-            accFilter: parseSet('f_acc'),
-            ucFilter: parseSet('f_uc'),
-            optFilter: parseSet('f_opt'),
-            compFilter: parseSet('f_comp'),
-            sources: parseSet('src'),
+            selectedModels: params.has('models') ? new Set([...parseSet('models')].map(k => k.includes('::Aggregated') ? k : k.replace(':Aggregated', '::Aggregated'))) : null,
+            modelsFilter: params.has('f_models') ? parseSet('f_models') : null,
+            hwFilter: params.has('f_hw') ? parseSet('f_hw') : null,
+            machFilter: params.has('f_mach') ? parseSet('f_mach') : null,
+            precFilter: params.has('f_prec') ? parseSet('f_prec') : null,
+            tpFilter: params.has('f_tp') ? parseSet('f_tp') : null,
+            islFilter: params.has('f_isl') ? parseSet('f_isl') : null,
+            oslFilter: params.has('f_osl') ? parseSet('f_osl') : null,
+            ratioFilter: params.has('f_ratio') ? parseSet('f_ratio') : null,
+            pdRatioFilter: params.has('f_pd_ratio') ? parseSet('f_pd_ratio') : null,
+            msFilter: params.has('f_ms') ? parseSet('f_ms') : null,
+            ssFilter: params.has('f_ss') ? parseSet('f_ss') : null,
+            originFilter: params.has('f_origin') ? parseSet('f_origin') : null,
+            accFilter: params.has('f_acc') ? parseSet('f_acc') : null,
+            ucFilter: params.has('f_uc') ? parseSet('f_uc') : null,
+            optFilter: params.has('f_opt') ? parseSet('f_opt') : null,
+            compFilter: params.has('f_comp') ? parseSet('f_comp') : null,
+            sources: params.has('src') ? parseSet('src') : null,
             buckets: params.getAll('buckets'),
             giqProjects: params.getAll('apis'),
             baselineKey: params.get('baseline') || null,
@@ -195,46 +199,45 @@ export const useDashboardState = () => {
 
     // Active Filters
     const [activeFilters, setActiveFilters] = useState(() => {
-        const defaultFilters = {
-            models: deriveInitialModelsFilter(),
-            hardware: initialState.hwFilter || new Set(),
-            machines: initialState.machFilter || new Set(),
-            tp: initialState.tpFilter || new Set(),
-            precisions: initialState.precFilter || new Set(),
-            isl: initialState.islFilter || new Set(),
-            osl: initialState.oslFilter || new Set(),
-            ratio: initialState.ratioFilter || new Set(),
-            modelServer: initialState.msFilter || new Set(),
-            servingStack: initialState.ssFilter || new Set(),
-            components: initialState.compFilter || new Set(),
-            origins: initialState.originFilter || new Set(),
-            connectionNames: new Set(),
-            pdRatio: initialState.pdRatioFilter || new Set(),
-            acc_count: initialState.accFilter || new Set(),
-            useCase: initialState.ucFilter || new Set(),
-            optimizations: initialState.optFilter || new Set()
-        };
-        
-        // If there are no initial state filters (e.g. from URL), try loading from local storage
-        if (!initialState.hwFilter && !initialState.machFilter && !initialState.tpFilter) {
-            try {
-                const savedStr = localStorage.getItem('prism_active_filters');
-                if (savedStr) {
-                    const saved = JSON.parse(savedStr);
-                    const loadedFilters = { ...defaultFilters };
-                    for (const key of Object.keys(saved)) {
-                        if (Array.isArray(saved[key])) {
-                            loadedFilters[key] = new Set(saved[key]);
-                        }
-                    }
-                    return loadedFilters;
-                }
-            } catch (e) {
-                console.warn("Failed to load active filters from local storage", e);
+        let savedFilters = {};
+        try {
+            const savedStr = localStorage.getItem('prism_active_filters');
+            if (savedStr) {
+                savedFilters = JSON.parse(savedStr);
             }
+        } catch (e) {
+            console.warn("Failed to load active filters from local storage", e);
         }
-        
-        return defaultFilters;
+
+        const resolveFilterSet = (urlFilterSet, savedArray) => {
+            if (urlFilterSet && urlFilterSet.size > 0) {
+                return urlFilterSet;
+            }
+            if (Array.isArray(savedArray)) {
+                return new Set(savedArray);
+            }
+            return new Set();
+        };
+
+        return {
+            models: initialState.modelsFilter && initialState.modelsFilter.size > 0 ? initialState.modelsFilter : resolveFilterSet(null, savedFilters.models),
+            hardware: resolveFilterSet(initialState.hwFilter, savedFilters.hardware),
+            machines: resolveFilterSet(initialState.machFilter, savedFilters.machines),
+            tp: resolveFilterSet(initialState.tpFilter, savedFilters.tp),
+            precisions: resolveFilterSet(initialState.precFilter, savedFilters.precisions),
+            isl: resolveFilterSet(initialState.islFilter, savedFilters.isl),
+            osl: resolveFilterSet(initialState.oslFilter, savedFilters.osl),
+            ratio: resolveFilterSet(initialState.ratioFilter, savedFilters.ratio),
+            modelServer: resolveFilterSet(initialState.msFilter, savedFilters.modelServer),
+            servingStack: resolveFilterSet(initialState.ssFilter, savedFilters.servingStack),
+            components: resolveFilterSet(initialState.compFilter, savedFilters.components),
+            origins: resolveFilterSet(initialState.originFilter, savedFilters.origins),
+            connectionNames: new Set(),
+            pdRatio: resolveFilterSet(initialState.pdRatioFilter, savedFilters.pdRatio),
+            acc_count: resolveFilterSet(initialState.accFilter, savedFilters.acc_count),
+            useCase: resolveFilterSet(initialState.ucFilter, savedFilters.useCase),
+            optimizations: resolveFilterSet(initialState.optFilter, savedFilters.optimizations)
+        };
     });
 
     useEffect(() => {
@@ -244,8 +247,45 @@ export const useDashboardState = () => {
                 filtersToSave[key] = Array.from(activeFilters[key]);
             }
             localStorage.setItem('prism_active_filters', JSON.stringify(filtersToSave));
+
+            if (typeof window !== 'undefined') {
+                const params = new URLSearchParams(window.location.search);
+                const filterKeysMap = {
+                    hardware: 'f_hw',
+                    machines: 'f_mach',
+                    tp: 'f_tp',
+                    precisions: 'f_prec',
+                    isl: 'f_isl',
+                    osl: 'f_osl',
+                    ratio: 'f_ratio',
+                    pdRatio: 'f_pd_ratio',
+                    modelServer: 'f_ms',
+                    servingStack: 'f_ss',
+                    origins: 'f_origin',
+                    acc_count: 'f_acc',
+                    useCase: 'f_uc',
+                    optimizations: 'f_opt',
+                    components: 'f_comp',
+                    models: 'f_models'
+                };
+
+                Object.values(filterKeysMap).forEach(paramKey => params.delete(paramKey));
+
+                Object.entries(filterKeysMap).forEach(([filterKey, paramKey]) => {
+                    const setVal = activeFilters[filterKey];
+                    if (setVal && setVal.size > 0) {
+                        Array.from(setVal).forEach(val => params.append(paramKey, val));
+                    }
+                });
+
+                const newSearch = params.toString();
+                const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}`;
+                if (window.location.search !== (newSearch ? `?${newSearch}` : '')) {
+                    window.history.replaceState(null, '', newUrl);
+                }
+            }
         } catch (e) {
-            console.warn("Failed to save active filters to local storage", e);
+            console.warn("Failed to save active filters to local storage or sync URL", e);
         }
     }, [activeFilters]);
 


### PR DESCRIPTION
## What does this PR do?

- Enforces the filter resolution order (`URL Parameter` -> `LocalStorage` -> `Default Value`) across all benchmark filters (`status`, `own`, search term `q`, `unlisted`, data sources `src`, and facet filters).
- Dynamically updates the browser address bar (`window.history.replaceState`) in real time as filter options change.
- Updates the Advanced Filters sidebar drawer to apply filter toggles immediately and instantly without draft state buffering or bottom action buttons.
- Adds a prominent "Reset All Active Filters" button at the top of the Advanced Filters drawer to clear active facets, search queries, and status selections back to default state.

## Why is this change needed?

Previously, URL parameters were ignored unless `?share=1` was present, preventing direct shareable links with filter options (such as pre-filtering by hardware/accelerators). Additionally, the Advanced Filters sidebar buffered changes into draft state requiring a manual "Apply" click, and URL search parameters did not update live as filters changed.

## How was this tested?

- [x] Manual testing performed (navigating via URLs with `?status=...`, `?f_hw=...`, `?q=...`, verifying URL search params update live, and testing instant filter toggles and reset button).
- [x] Linters pass (`npm run lint`).

## Checklist

- [x] Commits are signed off (`git commit -s`) per DCO
- [x] Code follows project contributing guidelines
- [x] Linters pass (`npm run lint`)
- [ ] Documentation updated (if applicable)

## Related Issues

N/A