### PR TITLE
Reconcile Cloud Run deploys on a schedule

### DIFF
--- a/.github/workflows/deploy-cloud-run.yaml
+++ b/.github/workflows/deploy-cloud-run.yaml
@@ -4,6 +4,9 @@ on:
   push:
     branches:
       - main
+  schedule:
+    # Run periodically to reconcile any commits merged via Prow or bot automations
+    - cron: "*/30 * * * *"
   workflow_dispatch: # Allow manual triggers
 
 permissions:
@@ -28,16 +31,43 @@ jobs:
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v3
 
+      - name: Check deployed commit
+        id: check-diff
+        run: |
+          source deploy/prod.env
+          CURRENT_SHA="${{ github.sha }}"
+          echo "Current commit SHA: $CURRENT_SHA"
+
+          # Fetch the deployed commit SHA label from Cloud Run
+          DEPLOYED_SHA=$(gcloud run services describe "$SERVICE_NAME" \
+            --platform managed \
+            --region "$REGION" \
+            --project "$PROJECT_ID" \
+            --format='value(metadata.labels["git-commit"])' || echo "")
+
+          echo "Currently deployed commit SHA: $DEPLOYED_SHA"
+
+          # Skip deployment if SHAs match and not a manual workflow_dispatch
+          if [ "${{ github.event_name }}" != "workflow_dispatch" ] && [ -n "$DEPLOYED_SHA" ] && [ "$DEPLOYED_SHA" = "$CURRENT_SHA" ]; then
+            echo "Cloud Run is already running commit $CURRENT_SHA. Skipping deployment."
+            echo "skip_deploy=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Deployment needed. Proceeding with deployment..."
+            echo "skip_deploy=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Deploy to Cloud Run
+        if: steps.check-diff.outputs.skip_deploy != 'true'
         run: |
           chmod +x ./deploy.sh
-          ./deploy.sh --config deploy/prod.env
+          ./deploy.sh --config deploy/prod.env --commit "${{ github.sha }}"
         env:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           GITHUB_CLIENT_ID: ${{ secrets.PRISM_GITHUB_CLIENT_ID }}
           GITHUB_CLIENT_SECRET: ${{ secrets.PRISM_GITHUB_CLIENT_SECRET }}
 
       - name: Verify deployment
+        if: steps.check-diff.outputs.skip_deploy != 'true'
         run: |
           source deploy/prod.env
           SERVICE_URL=$(gcloud run services describe "$SERVICE_NAME" \

--- a/.github/workflows/deploy-cloud-run.yaml
+++ b/.github/workflows/deploy-cloud-run.yaml
@@ -9,6 +9,10 @@ on:
     - cron: "*/30 * * * *"
   workflow_dispatch: # Allow manual triggers
 
+concurrency:
+    group: deploy-cloud-run
+    cancel-in-progress: false
+
 permissions:
   contents: read
   id-token: write # Required for Workload Identity Federation

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,6 +14,7 @@ GITHUB_CLIENT_ID="${GITHUB_CLIENT_ID:-}"
 GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-}"
 ALLOW_UNAUTHENTICATED="true"
 PUBLIC_URL=""
+COMMIT_SHA="${COMMIT_SHA:-}"
 
 # Helper function to print usage
 usage() {
@@ -27,6 +28,7 @@ usage() {
   echo "  -c, --contact <URL>           Contact Us URL/Email"
   echo "  -giq, --giq-projects <IDS>    Comma-separated list of GIQ project IDs"
   echo "  -b, --gcs-buckets <NAMES>     Comma-separated list of GCS buckets"
+  echo "  -k, --commit <SHA>            Git commit SHA to label the deployment with"
   echo "  --[no-]allow-unauthenticated Control whether the service is publicly accessible"
   echo "  -h, --help                    Show this help message"
   exit 1
@@ -65,6 +67,7 @@ while [[ "$#" -gt 0 ]]; do
         -giq|--giq-projects) GIQ_PROJECTS="$2"; shift ;;
         -b|--gcs-buckets) GCS_BUCKETS="$2"; shift ;;
         -u|--public-url) PUBLIC_URL="$2"; shift ;;
+        -k|--commit) COMMIT_SHA="$2"; shift ;;
         --no-allow-unauthenticated) ALLOW_UNAUTHENTICATED="false" ;;
         --allow-unauthenticated) ALLOW_UNAUTHENTICATED="true" ;;
         -h|--help) usage ;;
@@ -72,6 +75,11 @@ while [[ "$#" -gt 0 ]]; do
     esac
     shift
 done
+
+# Auto-detect commit SHA from git if not explicitly passed
+if [ -z "$COMMIT_SHA" ]; then
+    COMMIT_SHA=$(git rev-parse HEAD || echo "")
+fi
 
 # Auto-detect API Key from .env.local if not set
 if [ -z "$GOOGLE_API_KEY" ] && [ -f ".env.local" ]; then
@@ -138,6 +146,7 @@ fi
 [ -n "$MIN_INSTANCES" ] && DEPLOY_ARGS+=(--min-instances "$MIN_INSTANCES")
 [ -n "$MAX_INSTANCES" ] && DEPLOY_ARGS+=(--max-instances "$MAX_INSTANCES")
 [ -n "$CONCURRENCY" ] && DEPLOY_ARGS+=(--concurrency "$CONCURRENCY")
+[ -n "$COMMIT_SHA" ] && DEPLOY_ARGS+=(--update-labels "git-commit=$COMMIT_SHA")
 
 gcloud "${DEPLOY_ARGS[@]}"
 

--- a/specs/changes/scheduled-reconciliation-deploy-spec.md
+++ b/specs/changes/scheduled-reconciliation-deploy-spec.md
@@ -1,0 +1,60 @@
+# Spec: Scheduled Reconciliation Deployment for Cloud Run
+
+- **Status**: Implemented
+- **Author**: diamondburned, Jetski
+- **Date**: August 13, 2026
+- **Feature Name**: `scheduled-reconciliation-deploy`
+
+## Objective & Problem Statement
+
+Pull requests merged via Prow's `/lgtm` auto-merge workflow ([`.github/workflows/prow-pr-automerge.yml`](../../.github/workflows/prow-pr-automerge.yml)) rely on the default GitHub Actions `GITHUB_TOKEN`. By design, GitHub suppresses downstream `on: push` workflow triggers from actions executed with `GITHUB_TOKEN` to prevent recursive workflow loops.
+
+As a result, production Prism deployments to Cloud Run ([`.github/workflows/deploy-cloud-run.yaml`](../../.github/workflows/deploy-cloud-run.yaml)) were only triggered when maintainers manually merged PRs through the GitHub web UI or CLI, leaving the live service commits behind `main` whenever Prow performed automated merges.
+
+## Evaluated Solutions
+
+1. **GitHub App Installation Token**: Configure a GitHub App in the `llm-d` organization to generate ephemeral bot tokens for Prow merges. Triggers immediate pushes, but requires org-level administration and updates across reusable workflows in `llm-d/llm-d-infra`.
+2. **Personal Access Token (PAT)**: Store a maintainer or bot PAT in repository secrets. Fragile and high-maintenance due to token expiration and coupling to personal user accounts.
+3. **Scheduled Reconciliation with Commit Diffing (Selected)**: Run the deployment workflow on a periodic schedule (every 30 minutes) alongside existing `push` and `workflow_dispatch` triggers, with an idempotent pre-check comparing `HEAD` against the deployed Cloud Run revision label.
+
+## Technical Implementation Details
+
+### 1. Cloud Run Commit Labeling in `deploy.sh`
+
+Updated [`deploy.sh`](../../deploy.sh) to accept a `-k` / `--commit <SHA>` argument (falling back to auto-detecting `git rev-parse HEAD` if inside a git repository):
+
+```bash
+# Auto-detect commit SHA from git if not explicitly passed
+if [ -z "$COMMIT_SHA" ]; then
+    COMMIT_SHA=$(git rev-parse HEAD || echo "")
+fi
+
+# Attach commit label to Cloud Run revision
+[ -n "$COMMIT_SHA" ] && DEPLOY_ARGS+=(--update-labels "git-commit=$COMMIT_SHA")
+```
+
+### 2. Idempotent Workflow Reconciliation in `deploy-cloud-run.yaml`
+
+Updated [`.github/workflows/deploy-cloud-run.yaml`](../../.github/workflows/deploy-cloud-run.yaml) to:
+- Run on a 30-minute cron schedule (`*/30 * * * *`) in addition to `push` and `workflow_dispatch`.
+- Add a `check-diff` step before invoking `./deploy.sh`:
+  - Retrieves the `git-commit` label from the live Cloud Run service via `gcloud run services describe "$SERVICE_NAME" --format='value(metadata.labels["git-commit"])'`.
+  - Compares the deployed SHA with `${{ github.sha }}`.
+  - If they match (and the run is not a manual `workflow_dispatch`), sets `skip_deploy=true` to skip Cloud Build and deployment steps.
+  - If they differ (or on manual dispatch), proceeds with building and deploying the new commit.
+
+```yaml
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+```
+
+## Success Criteria
+
+1. **Self-Healing Sync**: Any commit merged into `main` (whether by Prow auto-merge, API, or human merge) is deployed to production Cloud Run within at most 30 minutes.
+2. **Zero Wasted Cloud Build Quota**: Scheduled runs where no new commits were merged exit cleanly in seconds without triggering Cloud Build.
+3. **Manual Overrides Preserved**: `workflow_dispatch` always forces a fresh deployment regardless of whether commit SHAs match.


### PR DESCRIPTION
## What does this PR do?

1. Adds a 30-minute cron schedule (`*/30 * * * *`) to `.github/workflows/deploy-cloud-run.yaml` alongside `push` and `workflow_dispatch`.
2. Adds a `check-diff` step in `.github/workflows/deploy-cloud-run.yaml` that queries the live Cloud Run service's `git-commit` label against `${{ github.sha }}` and skips building/deploying if production is already on the latest commit.
3. Updates `deploy.sh` to accept a `-k` / `--commit <SHA>` argument (with fallback to `git rev-parse HEAD`) and attach `--update-labels "git-commit=$COMMIT_SHA"` to the Cloud Run deployment command.
4. Adds the feature specification under `specs/changes/scheduled-reconciliation-deploy-spec.md`.

## Why is this change needed?

Pull requests merged via Prow's `/lgtm` command use GitHub Actions' default `GITHUB_TOKEN`. GitHub suppresses downstream `on: push` workflow triggers from `GITHUB_TOKEN` actions to prevent recursive loops. As a result, production Prism did not deploy when PRs were automatically merged by Prow and fell commits behind `main` until a maintainer manually merged a PR.

This scheduled reconciliation approach ensures production is periodically kept in sync without consuming Cloud Build quota on unchanged commits.

## How was this tested?

- [ ] Manual testing -- not done due to permission issues
- [x] Linters pass

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues
