### PR TITLE
Preserve URL hash across history replacements

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -151,7 +151,7 @@ function App() {
     }
     setNavigationParams(resolvedParams);
 
-    window.history.pushState({}, '', `${window.location.pathname}?${params.toString()}`);
+    window.history.pushState({}, '', `${window.location.pathname}?${params.toString()}${window.location.hash || ''}`);
     
     // Reset scroll position on navigation
     window.scrollTo(0, 0);

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -2075,7 +2075,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
         try {
             const params = new URLSearchParams(window.location.search);
             params.delete('intent');
-            window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+            window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}${window.location.hash || ''}`);
         } catch { /* ignore */ }
     };
 

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -253,7 +253,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
             params.delete('search');
         }
         
-        const newUrl = `${window.location.pathname}?${params.toString()}`;
+        const newUrl = `${window.location.pathname}?${params.toString()}${window.location.hash || ''}`;
         if (window.location.search !== `?${params.toString()}`) {
             window.history.replaceState(null, '', newUrl);
         }
@@ -279,7 +279,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
 
             if (benchmarksParam === '') {
                 params.delete('benchmarks');
-                const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+                const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}${window.location.hash || ''}`;
                 window.history.replaceState(null, '', newUrl);
                 return;
             }
@@ -293,14 +293,14 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                     dashboardData.addToast('Invalid share link format', 'error');
                 }
                 params.delete('benchmarks');
-                const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+                const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}${window.location.hash || ''}`;
                 window.history.replaceState(null, '', newUrl);
                 return;
             }
 
             if (targetUuids.length === 0) {
                 params.delete('benchmarks');
-                const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+                const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}${window.location.hash || ''}`;
                 window.history.replaceState(null, '', newUrl);
                 return;
             }
@@ -410,7 +410,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
             }
 
             params.delete('benchmarks');
-            const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}`;
+            const newUrl = `${window.location.pathname}${params.toString() ? '?' + params.toString() : ''}${window.location.hash || ''}`;
             window.history.replaceState(null, '', newUrl);
         };
 

--- a/src/components/WorkloadCatalog.jsx
+++ b/src/components/WorkloadCatalog.jsx
@@ -32,7 +32,7 @@ const WorkloadCatalog = ({ onNavigateBack }) => {
                 } else {
                     params.delete('workload');
                 }
-                window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}`);
+                window.history.replaceState({}, '', `${window.location.pathname}?${params.toString()}${window.location.hash || ''}`);
             }
         };
 

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -231,7 +231,7 @@ export const useDashboardData = (initialState, dashboardState) => {
                     Array.from(selectedSources).forEach(val => params.append('src', val));
                 }
                 const newSearch = params.toString();
-                const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}`;
+                const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}${window.location.hash || ''}`;
                 if (window.location.search !== (newSearch ? `?${newSearch}` : '')) {
                     window.history.replaceState(null, '', newUrl);
                 }

--- a/src/hooks/useDashboardState.js
+++ b/src/hooks/useDashboardState.js
@@ -279,7 +279,7 @@ export const useDashboardState = () => {
                 });
 
                 const newSearch = params.toString();
-                const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}`;
+                const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}${window.location.hash || ''}`;
                 if (window.location.search !== (newSearch ? `?${newSearch}` : '')) {
                     window.history.replaceState(null, '', newUrl);
                 }


### PR DESCRIPTION
Fix a regression introduced in df2532b141ca ("Sync filter state with URL and apply instantly (#129)").

Retain window.location.hash in new URL strings when updating search parameters or route state via window.history.replaceState and pushState.