### PR TITLE
Fix rejection dialog on built-in benchmarks

### DIFF
--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -2921,9 +2921,7 @@ const BenchmarkRow = React.memo(({
                                                                                     <div className="flex items-center gap-2">
                                                                                         {renderSubmissionActions()}
                                                                                     </div>
-                                                                                </div>
-                                                                            )}
-                                                                                    {rejectingRunId === runId && (
+                                                                                    {Boolean(rejectingRunId) && rejectingRunId === runId && (
                                                                                         <div onClick={e => e.stopPropagation()} className="p-2.5 bg-slate-100 dark:bg-slate-800 border border-slate-200 dark:border-slate-700/60 rounded-lg shadow-inner w-64 flex flex-col gap-2 mt-1 z-30">
                                                                                             <div className="text-xs font-bold text-red-500 dark:text-red-400 uppercase tracking-wider">Reason for Rejecting Run</div>
                                                                                             <Textarea
@@ -2961,6 +2959,8 @@ const BenchmarkRow = React.memo(({
                                                                                             </div>
                                                                                         </div>
                                                                                     )}
+                                                                                </div>
+                                                                            )}
                                                                                 </div>
                                                                         <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 flex-shrink-0">
                                                                             {(() => {


### PR DESCRIPTION
## What does this PR do?

Fixes a regression where official and built-in benchmarks incorrectly showed a "Reason for Rejecting Run" prompt by default, and prevents non-community benchmarks from displaying rejection actions.

## Why is this change needed?

Official and built-in llm-d benchmarks are not part of the community submission review flow and should never show a rejection prompt or dialog.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)