### PR TITLE
Add Results Store playground mode and benchmark forking

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ The following environment variables can be set via `--set-env-vars` in the `gclo
 - **`SITE_NAME`**: Custom text appended to "Prism".
 - **`CONTACT_US_URL`**: URL or email for the support link.
 - **`DEFAULT_PROJECTS`**: Comma-separated list of Project IDs for GIQ data.
-- **`DEFAULT_BUCKETS`**: Comma-separated list of GCS buckets for results. An entry may be scoped to a subdirectory with a `bucket/path/to/dir` suffix, restricting the scan to objects under that prefix (e.g. `my-bucket/team-a/results`).
+- **`RESULTS_STORE_BUCKET`**: Primary GCS bucket used for reading and writing benchmark submissions in the Results Store (and IAM allowlists). Defaults to `llm-d-benchmarks`.
+- **`DEFAULT_BUCKETS`**: Comma-separated list of GCS buckets for results. An entry may be scoped to a subdirectory with a `bucket/path/to/dir` suffix, restricting the scan to objects under that prefix (e.g. `my-bucket/team-a/results`). Defaults to `RESULTS_STORE_BUCKET` (or `llm-d-benchmarks`).
 - **`DEFAULT_S3_BUCKETS`**: Comma-separated list of public AWS S3 buckets.
 - **`GOOGLE_API_KEY`**: API Key for Google Drive/Sheets (auto-detected from `.env.local` if present).
 - **`GITHUB_CLIENT_ID`**: The Client ID of your registered GitHub OAuth App (used for authentication).

--- a/deploy.sh
+++ b/deploy.sh
@@ -15,6 +15,7 @@ GITHUB_CLIENT_SECRET="${GITHUB_CLIENT_SECRET:-}"
 ALLOW_UNAUTHENTICATED="true"
 PUBLIC_URL=""
 COMMIT_SHA="${COMMIT_SHA:-}"
+RESULTS_STORE_BUCKET="${RESULTS_STORE_BUCKET:-llm-d-benchmarks}"
 
 # Helper function to print usage
 usage() {
@@ -27,6 +28,7 @@ usage() {
   echo "  -g, --ga-id <ID>              Google Analytics Tracking ID (e.g. 'G-XXXX')"
   echo "  -c, --contact <URL>           Contact Us URL/Email"
   echo "  -giq, --giq-projects <IDS>    Comma-separated list of GIQ project IDs"
+  echo "  -rsb, --results-store-bucket <NAME> Bucket name for the Results Store (default: 'llm-d-benchmarks')"
   echo "  -b, --gcs-buckets <NAMES>     Comma-separated list of GCS buckets"
   echo "  -k, --commit <SHA>            Git commit SHA to label the deployment with"
   echo "  --[no-]allow-unauthenticated Control whether the service is publicly accessible"
@@ -65,6 +67,7 @@ while [[ "$#" -gt 0 ]]; do
         -g|--ga-id) GA_TRACKING_ID="$2"; shift ;;
         -c|--contact) CONTACT_US_URL="$2"; shift ;;
         -giq|--giq-projects) GIQ_PROJECTS="$2"; shift ;;
+        -rsb|--results-store-bucket) RESULTS_STORE_BUCKET="$2"; shift ;;
         -b|--gcs-buckets) GCS_BUCKETS="$2"; shift ;;
         -u|--public-url) PUBLIC_URL="$2"; shift ;;
         -k|--commit) COMMIT_SHA="$2"; shift ;;
@@ -102,7 +105,8 @@ GA_TRACKING_ID="$GA_TRACKING_ID"
 REGION="$REGION"
 CONTACT_US_URL="$CONTACT_US_URL"
 GIQ_PROJECTS="${GIQ_PROJECTS:-$PROJECT_ID}"
-GCS_BUCKETS="${GCS_BUCKETS:-prism-internal-results}"
+RESULTS_STORE_BUCKET="${RESULTS_STORE_BUCKET:-llm-d-benchmarks}"
+GCS_BUCKETS="${GCS_BUCKETS:-$RESULTS_STORE_BUCKET}"
 MIN_INSTANCES="$MIN_INSTANCES"
 MAX_INSTANCES="$MAX_INSTANCES"
 CONCURRENCY="$CONCURRENCY"
@@ -134,7 +138,7 @@ DEPLOY_ARGS=(
   --region $REGION
   --port 8080
   --project $PROJECT_ID
-  --set-env-vars GOOGLE_CLOUD_PROJECT="$PROJECT_ID",DEFAULT_PROJECTS="${GIQ_PROJECTS:-$PROJECT_ID}",DEFAULT_BUCKETS="${GCS_BUCKETS:-prism-internal-results}",SITE_NAME="$SITE_NAME",GA_TRACKING_ID="$GA_TRACKING_ID",CONTACT_US_URL="$CONTACT_US_URL",GOOGLE_API_KEY="$GOOGLE_API_KEY",GITHUB_CLIENT_ID="$GITHUB_CLIENT_ID",GITHUB_CLIENT_SECRET="$GITHUB_CLIENT_SECRET",PUBLIC_URL="$PUBLIC_URL"
+  --set-env-vars GOOGLE_CLOUD_PROJECT="$PROJECT_ID",DEFAULT_PROJECTS="${GIQ_PROJECTS:-$PROJECT_ID}",RESULTS_STORE_BUCKET="$RESULTS_STORE_BUCKET",DEFAULT_BUCKETS="${GCS_BUCKETS:-$RESULTS_STORE_BUCKET}",SITE_NAME="$SITE_NAME",GA_TRACKING_ID="$GA_TRACKING_ID",CONTACT_US_URL="$CONTACT_US_URL",GOOGLE_API_KEY="$GOOGLE_API_KEY",GITHUB_CLIENT_ID="$GITHUB_CLIENT_ID",GITHUB_CLIENT_SECRET="$GITHUB_CLIENT_SECRET",PUBLIC_URL="$PUBLIC_URL"
 )
 
 if [ "$ALLOW_UNAUTHENTICATED" = "false" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,8 @@ services:
     environment:
       - GOOGLE_APPLICATION_DEFAULT_CREDENTIALS=/tmp/adc.json
       - PORT=3000
-      - DEFAULT_BUCKETS=llm-d-benchmarks-staging,llm-d-benchmarks
+      - RESULTS_STORE_BUCKET=llm-d-benchmarks-staging
+      - DEFAULT_BUCKETS=llm-d-benchmarks,llm-d-benchmarks-staging
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
       - PUBLIC_URL=http://localhost:8081

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,7 @@ services:
       - PORT=3000
       - RESULTS_STORE_BUCKET=llm-d-benchmarks-staging
       - DEFAULT_BUCKETS=llm-d-benchmarks,llm-d-benchmarks-staging
+      - RESULTS_STORE_PLAYGROUND_MODE=${RESULTS_STORE_PLAYGROUND_MODE:-1}
       - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
       - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
       - PUBLIC_URL=http://localhost:8081

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@google-cloud/storage": "^7.21.0",
         "@tailwindcss/vite": "^4.1.17",
+        "boring-avatars": "^2.0.4",
         "clsx": "^2.1.1",
         "compression": "^1.7.4",
         "express": "^4.18.2",
@@ -2326,6 +2327,16 @@
     "node_modules/body-parser/node_modules/ms": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/boring-avatars": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/boring-avatars/-/boring-avatars-2.0.4.tgz",
+      "integrity": "sha512-xhZO/w/6aFmRfkaWohcl2NfyIy87gK5SBbys8kctZeTGF1Apjpv/10pfUuv+YEfVPkESU/h2Y6tt/Dwp+bIZPw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@google-cloud/storage": "^7.21.0",
     "@tailwindcss/vite": "^4.1.17",
+    "boring-avatars": "^2.0.4",
     "clsx": "^2.1.1",
     "compression": "^1.7.4",
     "express": "^4.18.2",

--- a/server/avatar.ts
+++ b/server/avatar.ts
@@ -1,0 +1,85 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { Router, Request, Response } from 'express';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import Avatar from 'boring-avatars';
+import { isPlaygroundMode } from './iam.ts';
+
+export const avatarRouter = Router();
+
+export const PRISM_AVATAR_COLORS = [
+    '#06b6d4', // Cyan
+    '#3b82f6', // Blue
+    '#8b5cf6', // Purple
+    '#ec4899', // Pink
+    '#f59e0b', // Amber
+];
+
+const VALID_VARIANTS = new Set(['marble', 'beam', 'pixel', 'sunset', 'ring', 'bauhaus']);
+
+/**
+ * Deterministically generates an SVG avatar for a given seed string using boring-avatars.
+ */
+export function generateSvgAvatar(
+    seed: string,
+    variant: 'marble' | 'beam' | 'pixel' | 'sunset' | 'ring' | 'bauhaus' = 'beam',
+    size = 80
+): string {
+    const cleanSeed = (seed || 'anonymous').trim();
+    const effectiveVariant = VALID_VARIANTS.has(variant) ? variant : 'beam';
+
+    return renderToStaticMarkup(
+        React.createElement(Avatar as any, {
+            size,
+            name: cleanSeed,
+            variant: effectiveVariant,
+            colors: PRISM_AVATAR_COLORS,
+        })
+    );
+}
+
+/**
+ * GET /api/avatar/:seed
+ * GET /api/avatar
+ * Returns a deterministic SVG avatar powered by boring-avatars.
+ * Only available when RESULTS_STORE_PLAYGROUND_MODE is active.
+ * In non-playground mode, returns HTTP 500.
+ */
+avatarRouter.get(['/api/avatar/:seed', '/api/avatar'], (req: Request, res: Response) => {
+    if (!isPlaygroundMode()) {
+        res.status(500).json({
+            error: 'Avatar generation is only available when Playground Mode is enabled.'
+        });
+        return;
+    }
+
+    const seed = (req.params.seed || (req.query.seed as string) || (req.query.name as string) || 'anonymous').trim();
+    const variantQuery = (req.query.variant as string) || 'beam';
+    const variant = (VALID_VARIANTS.has(variantQuery) ? variantQuery : 'beam') as
+        | 'marble'
+        | 'beam'
+        | 'pixel'
+        | 'sunset'
+        | 'ring'
+        | 'bauhaus';
+    const size = parseInt(req.query.size as string) || 80;
+
+    const svg = generateSvgAvatar(seed, variant, size);
+
+    res.setHeader('Content-Type', 'image/svg+xml');
+    res.setHeader('Cache-Control', 'public, max-age=86400, immutable');
+    res.status(200).send(svg);
+});

--- a/server/buckets.js
+++ b/server/buckets.js
@@ -12,10 +12,38 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-export const DEFAULT_RESULTS_BUCKETS = 'llm-d-benchmarks-staging,llm-d-benchmarks';
+export const DEFAULT_RESULTS_STORE_BUCKET = 'llm-d-benchmarks';
+export const DEFAULT_RESULTS_BUCKETS = 'llm-d-benchmarks';
 
 /**
- * Parses a single DEFAULT_BUCKETS entry of the form "bucket" or
+ * Returns the canonical bucket name used for the Prism Results Store (and IAM allowlists).
+ * Reads from RESULTS_STORE_BUCKET if configured; otherwise falls back to the first bucket
+ * in DEFAULT_BUCKETS (or DEFAULT_RESULTS_STORE_BUCKET).
+ *
+ * @param {string|undefined} [rawResultsBucket=process.env.RESULTS_STORE_BUCKET]
+ * @param {string|undefined} [rawDefaultBuckets=process.env.DEFAULT_BUCKETS]
+ * @returns {string}
+ */
+export function getResultsStoreBucket(
+    rawResultsBucket = process.env.RESULTS_STORE_BUCKET,
+    rawDefaultBuckets = process.env.DEFAULT_BUCKETS
+) {
+    if (rawResultsBucket) {
+        const parsed = parseBucketEntry(rawResultsBucket).bucket;
+        if (parsed) return parsed;
+    }
+    if (rawDefaultBuckets) {
+        const firstEntry = rawDefaultBuckets.split(',').map(e => e.trim()).filter(Boolean)[0];
+        if (firstEntry) {
+            const parsed = parseBucketEntry(firstEntry).bucket;
+            if (parsed) return parsed;
+        }
+    }
+    return DEFAULT_RESULTS_STORE_BUCKET;
+}
+
+/**
+ * Parses a single DEFAULT_BUCKETS or RESULTS_STORE_BUCKET entry of the form "bucket" or
  * "bucket/path/to/dir" (optionally scheme-prefixed) into its bucket name
  * and normalized object prefix ("" or "path/to/dir/").
  *
@@ -39,27 +67,41 @@ export function parseBucketEntry(entry) {
 }
 
 /**
- * Returns the raw (trimmed) entries configured via DEFAULT_BUCKETS,
- * which may include "bucket/path" scoped entries.
+ * Returns the raw (trimmed) entries configured via DEFAULT_BUCKETS.
+ * If DEFAULT_BUCKETS is not set, falls back to RESULTS_STORE_BUCKET
+ * or DEFAULT_RESULTS_BUCKETS.
  *
- * @param {string|undefined} rawBuckets - typically process.env.DEFAULT_BUCKETS
+ * @param {string|undefined} [rawBuckets=process.env.DEFAULT_BUCKETS]
+ * @param {string|undefined} [rawResultsStoreBucket=process.env.RESULTS_STORE_BUCKET]
  * @returns {string[]}
  */
-export function getConfiguredBucketEntries(rawBuckets) {
-    const raw = rawBuckets || DEFAULT_RESULTS_BUCKETS;
-    return raw.split(',').map(e => e.trim()).filter(Boolean);
+export function getConfiguredBucketEntries(
+    rawBuckets = process.env.DEFAULT_BUCKETS,
+    rawResultsStoreBucket = process.env.RESULTS_STORE_BUCKET
+) {
+    const defaultFallback = rawResultsStoreBucket || DEFAULT_RESULTS_BUCKETS;
+    const raw = rawBuckets !== undefined && rawBuckets !== ''
+        ? rawBuckets
+        : (process.env.DEFAULT_BUCKETS || defaultFallback);
+    return raw
+        .split(',')
+        .map(e => e.trim())
+        .filter(Boolean);
 }
 
 /**
  * Returns the bucket names configured via DEFAULT_BUCKETS with any
- * "/path" scoping suffixes stripped. Use this wherever an entry must be
- * compared against or used as a plain GCS bucket name.
+ * "/path" scoping suffixes stripped.
  *
- * @param {string|undefined} rawBuckets - typically process.env.DEFAULT_BUCKETS
+ * @param {string|undefined} [rawBuckets=process.env.DEFAULT_BUCKETS]
+ * @param {string|undefined} [rawResultsStoreBucket=process.env.RESULTS_STORE_BUCKET]
  * @returns {string[]}
  */
-export function getConfiguredBucketNames(rawBuckets) {
-    return getConfiguredBucketEntries(rawBuckets)
+export function getConfiguredBucketNames(
+    rawBuckets = process.env.DEFAULT_BUCKETS,
+    rawResultsStoreBucket = process.env.RESULTS_STORE_BUCKET
+) {
+    return getConfiguredBucketEntries(rawBuckets, rawResultsStoreBucket)
         .map(e => parseBucketEntry(e).bucket)
         .filter(Boolean);
 }

--- a/server/buckets.test.js
+++ b/server/buckets.test.js
@@ -12,7 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import { parseBucketEntry, getConfiguredBucketEntries, getConfiguredBucketNames, DEFAULT_RESULTS_BUCKETS } from './buckets.js';
+import {
+    parseBucketEntry,
+    getResultsStoreBucket,
+    getConfiguredBucketEntries,
+    getConfiguredBucketNames,
+    DEFAULT_RESULTS_STORE_BUCKET,
+    DEFAULT_RESULTS_BUCKETS
+} from './buckets.js';
 import assert from 'node:assert';
 
 console.log('Running buckets unit tests...');
@@ -30,35 +37,74 @@ assert.deepStrictEqual(parseBucketEntry('my-bucket/team-a/results/'), { bucket: 
 assert.deepStrictEqual(parseBucketEntry('gs://my-bucket/team-a/'), { bucket: 'my-bucket', prefix: 'team-a/' });
 assert.deepStrictEqual(parseBucketEntry('my-bucket//team-a//'), { bucket: 'my-bucket', prefix: 'team-a/' });
 
-// 3. getConfiguredBucketEntries: raw scoped entries pass through to clients
+// 3. getResultsStoreBucket: default and custom values
+assert.strictEqual(DEFAULT_RESULTS_STORE_BUCKET, 'llm-d-benchmarks');
+assert.strictEqual(getResultsStoreBucket(undefined), 'llm-d-benchmarks');
+assert.strictEqual(getResultsStoreBucket(''), 'llm-d-benchmarks');
+assert.strictEqual(getResultsStoreBucket('custom-results-bucket'), 'custom-results-bucket');
+assert.strictEqual(getResultsStoreBucket('gs://custom-results-bucket/'), 'custom-results-bucket');
+assert.strictEqual(getResultsStoreBucket('gs://custom-results-bucket/subpath'), 'custom-results-bucket');
+
+// 4. Dev config: RESULTS_STORE_BUCKET=llm-d-benchmarks, DEFAULT_BUCKETS=llm-d-benchmarks,llm-d-benchmarks-staging
 assert.deepStrictEqual(
-    getConfiguredBucketEntries('bucket-a, bucket-b/sub/dir ,,'),
+    getConfiguredBucketEntries('llm-d-benchmarks,llm-d-benchmarks-staging', 'llm-d-benchmarks'),
+    ['llm-d-benchmarks', 'llm-d-benchmarks-staging']
+);
+assert.deepStrictEqual(
+    getConfiguredBucketNames('llm-d-benchmarks,llm-d-benchmarks-staging', 'llm-d-benchmarks'),
+    ['llm-d-benchmarks', 'llm-d-benchmarks-staging']
+);
+
+// 5. Prod config: RESULTS_STORE_BUCKET=llm-d-benchmarks, DEFAULT_BUCKETS=llm-d-benchmarks
+assert.deepStrictEqual(
+    getConfiguredBucketEntries('llm-d-benchmarks', 'llm-d-benchmarks'),
+    ['llm-d-benchmarks']
+);
+assert.deepStrictEqual(
+    getConfiguredBucketNames('llm-d-benchmarks', 'llm-d-benchmarks'),
+    ['llm-d-benchmarks']
+);
+
+// 6. Path-scoped DEFAULT_BUCKETS are retained
+assert.deepStrictEqual(
+    getConfiguredBucketEntries('llm-d-benchmarks/team-a,llm-d-benchmarks-staging/team-b', 'llm-d-benchmarks'),
+    ['llm-d-benchmarks/team-a', 'llm-d-benchmarks-staging/team-b']
+);
+assert.deepStrictEqual(
+    getConfiguredBucketNames('llm-d-benchmarks/team-a,llm-d-benchmarks-staging/team-b', 'llm-d-benchmarks'),
+    ['llm-d-benchmarks', 'llm-d-benchmarks-staging']
+);
+
+// 7. Custom buckets pass through
+assert.deepStrictEqual(
+    getConfiguredBucketEntries('bucket-a, bucket-b/sub/dir ,,', 'llm-d-benchmarks'),
     ['bucket-a', 'bucket-b/sub/dir']
 );
-
-// 4. getConfiguredBucketEntries / getConfiguredBucketNames: default fallback
-assert.deepStrictEqual(getConfiguredBucketEntries(undefined), DEFAULT_RESULTS_BUCKETS.split(','));
-assert.deepStrictEqual(getConfiguredBucketNames(undefined), ['llm-d-benchmarks-staging', 'llm-d-benchmarks']);
-assert.deepStrictEqual(getConfiguredBucketNames(''), ['llm-d-benchmarks-staging', 'llm-d-benchmarks']);
-
-// 5. getConfiguredBucketNames: path scoping is stripped for bucket-name comparisons,
-// so results-store and IAM permission checks still recognize scoped entries.
 assert.deepStrictEqual(
-    getConfiguredBucketNames('llm-d-benchmarks-staging/team-a,other-bucket/sub/dir'),
-    ['llm-d-benchmarks-staging', 'other-bucket']
-);
-assert.deepStrictEqual(
-    getConfiguredBucketNames('gs://bucket-a/x, bucket-b'),
+    getConfiguredBucketNames('bucket-a, bucket-b/sub/dir ,,', 'llm-d-benchmarks'),
     ['bucket-a', 'bucket-b']
 );
 
-// 6. Multiple prefixes of the same bucket are independent entries
+// 8. Multiple prefixes of the same bucket are independent entries
 assert.deepStrictEqual(
-    getConfiguredBucketEntries('b1/p1,b1/p2,b2/p3'),
+    getConfiguredBucketEntries('b1/p1,b1/p2,b2/p3', 'llm-d-benchmarks'),
     ['b1/p1', 'b1/p2', 'b2/p3']
 );
-assert.deepStrictEqual(getConfiguredBucketNames('b1/p1,b1/p2,b2/p3'), ['b1', 'b1', 'b2']);
-assert.deepStrictEqual(parseBucketEntry('b1/p1'), { bucket: 'b1', prefix: 'p1/' });
-assert.deepStrictEqual(parseBucketEntry('b1/p2'), { bucket: 'b1', prefix: 'p2/' });
+assert.deepStrictEqual(
+    getConfiguredBucketNames('b1/p1,b1/p2,b2/p3', 'llm-d-benchmarks'),
+    ['b1', 'b1', 'b2']
+);
+
+// 9. Fallback to DEFAULT_BUCKETS[0] when RESULTS_STORE_BUCKET is not set
+assert.strictEqual(getResultsStoreBucket(undefined, 'custom-bucket,other-bucket'), 'custom-bucket');
+assert.strictEqual(getResultsStoreBucket('', 'custom-bucket,other-bucket'), 'custom-bucket');
+assert.strictEqual(getResultsStoreBucket(undefined, 'gs://scoped-bucket/sub/path, other-bucket'), 'scoped-bucket');
+assert.deepStrictEqual(getConfiguredBucketEntries('b1,b2', undefined), ['b1', 'b2']);
+assert.deepStrictEqual(getConfiguredBucketNames('b1/p1,b2/p2', undefined), ['b1', 'b2']);
+
+// 10. Default fallback with no args: DEFAULT_RESULTS_BUCKETS ('llm-d-benchmarks')
+assert.deepStrictEqual(getConfiguredBucketEntries(undefined, undefined), ['llm-d-benchmarks']);
+assert.deepStrictEqual(getConfiguredBucketNames(undefined, undefined), ['llm-d-benchmarks']);
+assert.deepStrictEqual(getConfiguredBucketNames('', undefined), ['llm-d-benchmarks']);
 
 console.log('All buckets unit tests passed successfully!');

--- a/server/iam.ts
+++ b/server/iam.ts
@@ -95,9 +95,21 @@ async function fetchAllowlist(filename: string): Promise<Set<string>> {
 }
 
 /**
+ * Resolves whether Results Store Playground Mode is active via environment variable.
+ */
+export function isPlaygroundMode(): boolean {
+    const val = String(process.env.RESULTS_STORE_PLAYGROUND_MODE || '').trim().toLowerCase();
+    return val === '1' || val === 'true' || val === 'yes' || val === 'on';
+}
+
+/**
  * Validates a GitHub user's permissions level based on the IAM bucket allowlists.
  */
 export async function validateGitHubUser(username: string): Promise<PermissionLevel> {
+    if (isPlaygroundMode()) {
+        return 'admin';
+    }
+
     const normalizedUsername = username.trim().toLowerCase();
     if (!normalizedUsername) {
         return 'none';

--- a/server/iam.ts
+++ b/server/iam.ts
@@ -14,7 +14,7 @@
 
 import { GoogleAuth, UserRefreshClient } from 'google-auth-library';
 import fs from 'fs';
-import { getConfiguredBucketNames } from './buckets.js';
+import { getResultsStoreBucket } from './buckets.js';
 
 const auth = new GoogleAuth();
 
@@ -22,14 +22,9 @@ export type PermissionLevel = 'none' | 'user' | 'admin';
 
 /**
  * Resolves the GCS bucket name to read IAM allowlist configurations from.
- * Uses staging bucket if staging is in DEFAULT_BUCKETS, otherwise defaults to production bucket.
  */
 function getIAMBucket(): string {
-    const buckets = getConfiguredBucketNames(process.env.DEFAULT_BUCKETS);
-    if (buckets.includes('llm-d-benchmarks-staging')) {
-        return 'llm-d-benchmarks-staging';
-    }
-    return buckets[0] || 'llm-d-benchmarks';
+    return getResultsStoreBucket();
 }
 
 /**

--- a/server/oauth.ts
+++ b/server/oauth.ts
@@ -14,7 +14,7 @@
 
 import { Router, Request, Response } from 'express';
 import crypto from 'crypto';
-import { validateGitHubUser, PermissionLevel } from './iam';
+import { validateGitHubUser, PermissionLevel, isPlaygroundMode } from './iam';
 
 export const oauthRouter = Router();
 
@@ -40,6 +40,17 @@ const isOAuthConfigured = (): boolean => {
 // Middleware to enforce configuration check
 oauthRouter.use((req: Request, res: Response, next) => {
     if (req.path.startsWith('/api/auth/github')) {
+        if (isPlaygroundMode() && req.path === '/api/auth/github/me') {
+            res.json({
+                authenticated: true,
+                configured: true,
+                username: 'anonymous',
+                permission: 'admin',
+                avatarUrl: null,
+                playgroundMode: true
+            });
+            return;
+        }
         if (!isOAuthConfigured()) {
             if (req.path === '/api/auth/github/me') {
                 res.json({
@@ -80,6 +91,9 @@ oauthRouter.get('/api/auth/github/login', (req: Request, res: Response) => {
  * Fetches the user profile and permissions directly from GitHub API.
  */
 export async function validateGitHubToken(token: string): Promise<{ username: string, permission: PermissionLevel, avatarUrl?: string }> {
+    if (isPlaygroundMode()) {
+        return { username: 'anonymous', permission: 'admin' };
+    }
     if (token === 'mock_token_prism') {
         return { username: 'test-user', permission: 'admin', avatarUrl: 'https://avatars.githubusercontent.com/u/9919?v=4' };
     }
@@ -266,6 +280,17 @@ oauthRouter.post('/api/auth/github/refresh', async (req: Request, res: Response)
  * Expects X-Prism-Github-Token header.
  */
 oauthRouter.get('/api/auth/github/me', async (req: Request, res: Response) => {
+    if (isPlaygroundMode()) {
+        return res.json({
+            authenticated: true,
+            configured: true,
+            username: 'anonymous',
+            permission: 'admin',
+            avatarUrl: '/api/avatar/anonymous',
+            playgroundMode: true
+        });
+    }
+
     const token = req.headers['x-prism-github-token'] as string;
     if (!token) {
         return res.json({

--- a/server/results/api.ts
+++ b/server/results/api.ts
@@ -47,6 +47,30 @@ export const PrismSubmissionStateSchema = z.enum([
 ]);
 
 /**
+ * Represents provenance tracking details when a benchmark is forked.
+ */
+export const ForkDetailSchema = z.object({
+    /** UUID of the benchmark run that was forked */
+    original_run_id: z.string(),
+    /** Human-readable label or description of the original run */
+    original_run_label: z.string(),
+    /** Original author/submitter of the source benchmark */
+    original_author: z.union([
+        z.object({
+            username: z.string(),
+            name: z.string().optional(),
+            email: z.string().optional(),
+            playground: z.boolean().optional(),
+        }).passthrough(),
+        z.string(),
+    ]).nullable().optional(),
+    /** GCS source bucket or prefix where the original benchmark was stored */
+    source_bucket: z.string(),
+    /** ISO 8601 timestamp when the fork was created */
+    forked_at: z.string(),
+}).passthrough();
+
+/**
  * Root container representing the JSON payload content stored inside a result file inside the bucket.
  * Verified by validatePrismUploadStructure.
  */
@@ -75,6 +99,16 @@ export const PrismResultPayloadSchema = z.object({
     }),
     /** Target upload and parsing schema format. Must be exactly "brv02". */
     format: z.literal("brv02"),
+    /**
+     * Provenance tracking. Single ForkDetail for direct forks,
+     * or an array of ForkDetails if forked multiple times or coalesced from multiple forks.
+     */
+    forked_from: z.union([
+        ForkDetailSchema,
+        z.array(ForkDetailSchema)
+    ]).nullable().optional(),
+    /** Summary boolean indicator for forked benchmark runs */
+    forked: z.boolean().optional(),
     /** Author metadata representing the GitHub user who submitted the benchmark. */
     github_author: z.object({
         /** GitHub username of the contributor. Example: "octocat" */
@@ -131,9 +165,11 @@ export const PrismResultContextSchema = z.object({
     feedback: ContextValueSchema.optional(),
     well_lit_path: ContextValueSchema.optional(),
     playground_submitted: ContextValueSchema.optional(),
+    forked: ContextValueSchema.optional(),
 });
 
 // TypeScript type inference definitions
+export type ForkDetail = z.infer<typeof ForkDetailSchema>;
 export type PrismStageEntry = z.infer<typeof PrismStageEntrySchema>;
 export type PrismSubmissionState = z.infer<typeof PrismSubmissionStateSchema>;
 export type PrismResultPayload = z.infer<typeof PrismResultPayloadSchema>;

--- a/server/results/api.ts
+++ b/server/results/api.ts
@@ -79,6 +79,8 @@ export const PrismResultPayloadSchema = z.object({
     github_author: z.object({
         /** GitHub username of the contributor. Example: "octocat" */
         username: z.string(),
+        /** Whether the submission was created under Playground Mode */
+        playground: z.boolean().optional(),
     }).nullable().optional(),
     /** Date and time when the benchmark run was submitted, formatted as an ISO 8601 string. Example: "2026-07-07T22:13:42.000Z" */
     submitted_at: z.string().datetime().nullable().optional(),
@@ -128,6 +130,7 @@ export const PrismResultContextSchema = z.object({
     run_label: ContextValueSchema,
     feedback: ContextValueSchema.optional(),
     well_lit_path: ContextValueSchema.optional(),
+    playground_submitted: ContextValueSchema.optional(),
 });
 
 // TypeScript type inference definitions

--- a/server/results/gcs.ts
+++ b/server/results/gcs.ts
@@ -14,7 +14,7 @@
 
 import type { PrismResultPayload, PrismSubmissionState, PrismResultContext } from './api.ts';
 import { Storage } from '@google-cloud/storage';
-import { getConfiguredBucketNames } from '../buckets.js';
+import { getResultsStoreBucket } from '../buckets.js';
 
 export function encodeContextValue(val: string): string {
     return 'e' + Buffer.from(val, 'utf8').toString('base64url');
@@ -38,11 +38,7 @@ export const storage = new Storage(
  * Resolves the primary Google Cloud Storage bucket for storing and listing Prism benchmark results.
  */
 export function getPrismResultsBucket(): string {
-    const buckets = getConfiguredBucketNames(process.env.DEFAULT_BUCKETS);
-    if (buckets.includes('llm-d-benchmarks-staging')) {
-        return 'llm-d-benchmarks-staging';
-    }
-    return buckets[0] || 'llm-d-benchmarks';
+    return getResultsStoreBucket();
 }
 
 export type ResultsListItem = Omit<PrismResultPayload, 'entries'> & {

--- a/server/results/gcs.ts
+++ b/server/results/gcs.ts
@@ -164,6 +164,8 @@ export async function listResults(options: ListResultsOptions): Promise<ListResu
             const feedback = decodeContextValue(String(customContexts.feedback?.value || ''));
             const well_lit_path = decodeContextValue(String(customContexts.well_lit_path?.value || ''));
 
+            const isForked = customContexts.forked?.value === 'true' || customContexts.forked_from?.value !== undefined;
+
             matchedItems.push({
                 runId,
                 runLabel,
@@ -179,7 +181,9 @@ export async function listResults(options: ListResultsOptions): Promise<ListResu
                 },
                 submitted_at: metadata?.timeCreated || metadata?.updated || null,
                 feedback: feedback || undefined,
-                well_lit_path: well_lit_path || undefined
+                well_lit_path: well_lit_path || undefined,
+                forked: isForked || undefined,
+                forked_from: isForked ? true : undefined
             });
         }
 
@@ -271,6 +275,10 @@ export async function writeResult(
 
     if (payload.well_lit_path) {
         contextsCustom.well_lit_path = { value: encodeContextValue(payload.well_lit_path) };
+    }
+
+    if (payload.forked_from || payload.forked) {
+        contextsCustom.forked = { value: 'true' };
     }
 
     if (isPlaygroundMode() || payload.github_author?.playground) {

--- a/server/results/gcs.ts
+++ b/server/results/gcs.ts
@@ -15,6 +15,7 @@
 import type { PrismResultPayload, PrismSubmissionState, PrismResultContext } from './api.ts';
 import { Storage } from '@google-cloud/storage';
 import { getResultsStoreBucket } from '../buckets.js';
+import { isPlaygroundMode } from '../iam.ts';
 
 export function encodeContextValue(val: string): string {
     return 'e' + Buffer.from(val, 'utf8').toString('base64url');
@@ -86,7 +87,7 @@ export async function listResults(options: ListResultsOptions): Promise<ListResu
     const filters: ((state: PrismSubmissionState, user: string) => boolean)[] = [];
 
     // 1. Permission check (non-admins can see public/promoted, explicit status=unlisted, or their own results)
-    if (permission !== 'admin') {
+    if (permission !== 'admin' && !isPlaygroundMode()) {
         filters.push((state, user) => {
             const isApproved = state === 'public' || state === 'promoted';
             const isExplicitUnlisted = state === 'unlisted' && statusFilter === 'unlisted';
@@ -270,6 +271,10 @@ export async function writeResult(
 
     if (payload.well_lit_path) {
         contextsCustom.well_lit_path = { value: encodeContextValue(payload.well_lit_path) };
+    }
+
+    if (isPlaygroundMode() || payload.github_author?.playground) {
+        contextsCustom.playground_submitted = { value: 'true' };
     }
 
     try {

--- a/server/results/routes/delete.ts
+++ b/server/results/routes/delete.ts
@@ -14,6 +14,7 @@
 
 import { Request, Response } from 'express';
 import { validateGitHubToken } from '../../oauth.ts';
+import { isPlaygroundMode } from '../../iam.ts';
 import { readResultMetadata, deleteResult } from '../gcs.ts';
 
 export interface DeleteResultsResponse {
@@ -24,16 +25,17 @@ export interface DeleteResultsResponse {
 /**
  * DELETE /api/results/:runId
  *
- * Permanently deletes a rejected benchmark result run bundle from the GCS Results Store.
+ * Permanently deletes a benchmark result run bundle from the GCS Results Store.
  *
- * - **Headers:** `X-Prism-Github-Token: <access_token>` (required)
+ * - **Headers:** `X-Prism-Github-Token: <access_token>` (required, optional in playground mode)
  * - **Authorization Rules:**
- *     - **Admin:** Full access, provided benchmark submission state is `rejected`.
+ *     - **Playground Mode:** Full access to delete any benchmark in RESULTS_STORE_BUCKET anonymously.
+ *     - **Admin:** Full access, provided benchmark submission state is `unlisted` or `rejected`.
+ *     - **Owner:** Full access if benchmark submission state is `unlisted`.
  *     - **Non-Admin Users / Guests:** `403 Forbidden`.
  * - **Benchmark Checks:**
  *     - `runId` must be a valid UUID.
  *     - Benchmark must exist in the GCS Results Store.
- *     - Benchmark state MUST be `rejected`. Deleting benchmarks in any other state returns `403 Forbidden`.
  */
 export async function deleteResultsHandler(
     req: Request<{ runId: string }, DeleteResultsResponse | { error: string; details?: unknown }>,
@@ -49,20 +51,32 @@ export async function deleteResultsHandler(
 
     // 1. Authenticate user
     const token = req.headers['x-prism-github-token'] as string | undefined;
-    if (!token) {
-        return res.status(401).json({ error: 'Authentication required. Missing session token.' });
-    }
-
     let username = '';
     let permission = 'none';
 
-    try {
-        const authResult = await validateGitHubToken(token);
-        username = authResult.username;
-        permission = authResult.permission;
-    } catch (error: unknown) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return res.status(401).json({ error: 'Invalid or expired session token.', details: msg });
+    if (isPlaygroundMode()) {
+        permission = 'admin';
+        if (token) {
+            try {
+                const authResult = await validateGitHubToken(token);
+                username = authResult.username;
+            } catch {
+                // Ignore token errors in playground mode
+            }
+        }
+    } else {
+        if (!token) {
+            return res.status(401).json({ error: 'Authentication required. Missing session token.' });
+        }
+
+        try {
+            const authResult = await validateGitHubToken(token);
+            username = authResult.username;
+            permission = authResult.permission;
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            return res.status(401).json({ error: 'Invalid or expired session token.', details: msg });
+        }
     }
 
     try {
@@ -76,7 +90,9 @@ export async function deleteResultsHandler(
         const isOwner = !!(username && itemUser.toLowerCase() === username.toLowerCase());
 
         let allowed = false;
-        if (isOwner && itemState === 'unlisted') {
+        if (isPlaygroundMode()) {
+            allowed = true;
+        } else if (isOwner && itemState === 'unlisted') {
             allowed = true;
         } else if (permission === 'admin' && (itemState === 'unlisted' || itemState === 'rejected')) {
             allowed = true;

--- a/server/results/routes/get.ts
+++ b/server/results/routes/get.ts
@@ -14,6 +14,7 @@
 
 import { Request, Response } from 'express';
 import { validateGitHubToken } from '../../oauth.ts';
+import { isPlaygroundMode } from '../../iam.ts';
 import { readResultPayload, readResultMetadata } from '../gcs.ts';
 import { PrismResultPayload } from '../api.ts';
 
@@ -26,6 +27,7 @@ export type ResultsGetResponse = PrismResultPayload;
  * 
  * - **Headers:** `X-Prism-Github-Token: <access_token>` (optional)
  * - **Authorization Rules:**
+ *     - **Playground Mode:** Full access for all callers.
  *     - **Admin:** Full access.
  *     - **Standard User/Guest:**
  *         - Can view their own benchmark run bundle in any state.
@@ -45,7 +47,7 @@ export async function getResultsHandler(req: Request, res: Response<ResultsGetRe
     // 1. Authenticate user
     const token = req.headers['x-prism-github-token'] as string | undefined;
     let username: string | null = null;
-    let permission = 'none';
+    let permission = isPlaygroundMode() ? 'admin' : 'none';
 
     if (token) {
         try {
@@ -55,6 +57,10 @@ export async function getResultsHandler(req: Request, res: Response<ResultsGetRe
         } catch (e: any) {
             console.warn('[Results API] Invalid session token:', e.message);
         }
+    }
+
+    if (isPlaygroundMode()) {
+        permission = 'admin';
     }
 
     try {

--- a/server/results/routes/list.ts
+++ b/server/results/routes/list.ts
@@ -27,7 +27,7 @@ export interface ResultsListQuery {
 /**
  * GET /api/results
  * 
- * Lists benchmark runs from the active Prism results store (defined in DEFAULT_BUCKETS).
+ * Lists benchmark runs from the active Prism results store (defined in RESULTS_STORE_BUCKET).
  * 
  * - **Headers:** `X-Prism-Github-Token: <access_token>` (optional)
  * - **Query Parameters:**

--- a/server/results/routes/list.ts
+++ b/server/results/routes/list.ts
@@ -14,6 +14,7 @@
 
 import { Request, Response } from 'express';
 import { validateGitHubToken } from '../../oauth.ts';
+import { isPlaygroundMode } from '../../iam.ts';
 import { listResults, ListResultsResult as ResultsListResponse } from '../gcs.ts';
 import { PrismSubmissionState } from '../api.ts';
 
@@ -36,6 +37,7 @@ export interface ResultsListQuery {
  *     - `status`: (Optional) Filter by submission status (staged | submitted_pending_processing | submitted_pending_review | public | promoted).
  *     - `own`: (Optional) Filter to retrieve only the logged-in user's submissions (true | false).
  * - **Authorization Rules:**
+ *     - **Playground Mode:** Default admin permissions for all callers.
  *     - **Admin:** Can list all benchmarks in all statuses.
  *     - **Standard User/Guest:**
  *         - Can list their own benchmarks in any status.
@@ -49,7 +51,7 @@ export async function listResultsHandler(
     // 1. Authenticate user
     const token = req.headers['x-prism-github-token'] as string | undefined;
     let username: string | null = null;
-    let permission = 'none';
+    let permission = isPlaygroundMode() ? 'admin' : 'none';
 
     if (token) {
         try {
@@ -59,6 +61,10 @@ export async function listResultsHandler(
         } catch (e: any) {
             console.warn('[Results API] Invalid session token:', e.message);
         }
+    }
+
+    if (isPlaygroundMode()) {
+        permission = 'admin';
     }
 
     // 2. Parse pagination options & filters

--- a/server/results/routes/review.ts
+++ b/server/results/routes/review.ts
@@ -14,6 +14,7 @@
 
 import { Request, Response } from 'express';
 import { validateGitHubToken } from '../../oauth.ts';
+import { isPlaygroundMode } from '../../iam.ts';
 import { readResultPayload, writeResult, readResultMetadata } from '../gcs.ts';
 import { processSubmission } from '../processing.ts';
 import { PrismSubmissionState } from '../api.ts';
@@ -36,8 +37,9 @@ export interface ReviewResultsResponse {
  *
  * Updates/reviews the status of a result store submission.
  *
- * - **Headers:** `X-Prism-Github-Token: <access_token>` (required)
+ * - **Headers:** `X-Prism-Github-Token: <access_token>` (required, optional in playground mode)
  * - **Authorization Rules:**
+ *     - **Playground Mode:** Full access for all operations anonymously.
  *     - **Admin:** Full access. Can approve (`public` / `promoted`), reject (`rejected`), or reset state.
  *     - **Owner of submission:** Can only submit/resubmit, i.e., set state to `submitted_pending_processing` or `submitted_pending_review`.
  *       Any attempt to set state to `public` or `rejected` returns `403 Forbidden`.
@@ -57,20 +59,32 @@ export async function reviewResultsHandler(
 
     // 1. Authenticate user
     const token = req.headers['x-prism-github-token'] as string | undefined;
-    if (!token) {
-        return res.status(401).json({ error: 'Authentication required. Missing session token.' });
-    }
-
-    let username = '';
+    let username = 'anonymous';
     let permission = 'none';
 
-    try {
-        const authResult = await validateGitHubToken(token);
-        username = authResult.username;
-        permission = authResult.permission;
-    } catch (error: unknown) {
-        const msg = error instanceof Error ? error.message : String(error);
-        return res.status(401).json({ error: 'Invalid or expired session token.', details: msg });
+    if (isPlaygroundMode()) {
+        permission = 'admin';
+        if (token) {
+            try {
+                const authResult = await validateGitHubToken(token);
+                username = authResult.username;
+            } catch {
+                // Ignore token errors in playground mode
+            }
+        }
+    } else {
+        if (!token) {
+            return res.status(401).json({ error: 'Authentication required. Missing session token.' });
+        }
+
+        try {
+            const authResult = await validateGitHubToken(token);
+            username = authResult.username;
+            permission = authResult.permission;
+        } catch (error: unknown) {
+            const msg = error instanceof Error ? error.message : String(error);
+            return res.status(401).json({ error: 'Invalid or expired session token.', details: msg });
+        }
     }
 
     const { status, feedback, reviewer } = req.body;
@@ -88,35 +102,37 @@ export async function reviewResultsHandler(
         const { user: itemUser, state: currentState } = metadata;
 
         // 3. Permission and authorization checks
-        if (currentState === 'unlisted') {
-            if (status !== 'submitted_pending_review') {
-                return res.status(403).json({ error: 'Forbidden. Unlisted benchmarks can only be promoted to submitted_pending_review.' });
-            }
-            const isOwner = username && itemUser.toLowerCase() === username.toLowerCase();
-            if (!isOwner) {
-                return res.status(403).json({ error: 'Forbidden. Only the owner of an unlisted benchmark can promote it.' });
-            }
-            if (feedback !== undefined || reviewer !== undefined) {
-                return res.status(400).json({ error: 'Feedback and reviewer fields are forbidden when promoting from unlisted to submitted_pending_review.' });
-            }
-        } else {
-            let allowed = false;
-            if (permission === 'admin') {
-                allowed = true;
+        if (!isPlaygroundMode()) {
+            if (currentState === 'unlisted') {
+                if (status !== 'submitted_pending_review') {
+                    return res.status(403).json({ error: 'Forbidden. Unlisted benchmarks can only be promoted to submitted_pending_review.' });
+                }
+                const isOwner = username && itemUser.toLowerCase() === username.toLowerCase();
+                if (!isOwner) {
+                    return res.status(403).json({ error: 'Forbidden. Only the owner of an unlisted benchmark can promote it.' });
+                }
+                if (feedback !== undefined || reviewer !== undefined) {
+                    return res.status(400).json({ error: 'Feedback and reviewer fields are forbidden when promoting from unlisted to submitted_pending_review.' });
+                }
             } else {
-                // Check if the current user is the owner/author of the submission
-                if (username && itemUser.toLowerCase() === username.toLowerCase()) {
-                    // Owners can only transition their own runs to 'submitted_pending_processing' or 'submitted_pending_review' (resubmission/promotion)
-                    if (status === 'submitted_pending_processing' || status === 'submitted_pending_review') {
-                        allowed = true;
-                    } else {
-                        return res.status(403).json({ error: 'Forbidden. Non-admin users cannot approve, reject, or promote benchmarks of other status values.' });
+                let allowed = false;
+                if (permission === 'admin') {
+                    allowed = true;
+                } else {
+                    // Check if the current user is the owner/author of the submission
+                    if (username && itemUser.toLowerCase() === username.toLowerCase()) {
+                        // Owners can only transition their own runs to 'submitted_pending_processing' or 'submitted_pending_review' (resubmission/promotion)
+                        if (status === 'submitted_pending_processing' || status === 'submitted_pending_review') {
+                            allowed = true;
+                        } else {
+                            return res.status(403).json({ error: 'Forbidden. Non-admin users cannot approve, reject, or promote benchmarks of other status values.' });
+                        }
                     }
                 }
-            }
 
-            if (!allowed) {
-                return res.status(403).json({ error: 'Access denied. You do not have permissions to modify this result.' });
+                if (!allowed) {
+                    return res.status(403).json({ error: 'Access denied. You do not have permissions to modify this result.' });
+                }
             }
         }
 

--- a/server/results/routes/submit.ts
+++ b/server/results/routes/submit.ts
@@ -15,6 +15,7 @@
 import { Request, Response } from 'express';
 import crypto from 'crypto';
 import { validateGitHubToken } from '../../oauth.ts';
+import { isPlaygroundMode } from '../../iam.ts';
 import { writeResult, deleteResult } from '../gcs.ts';
 import { processSubmission } from '../processing.ts';
 import { PrismSubmissionState, PrismResultPayload } from '../api.ts';
@@ -32,8 +33,8 @@ export interface ResultsSubmitResponse {
  *
  * Submits a benchmark result bundle to the active results store.
  *
- * - **Headers:** `X-Prism-Github-Token: <access_token>` (required)
- * - **Authorization Rules:** Only allowlisted contributors (with role `user` or `admin`) can submit benchmark results.
+ * - **Headers:** `X-Prism-Github-Token: <access_token>` (required, optional in playground mode)
+ * - **Authorization Rules:** Only allowlisted contributors (with role `user` or `admin`) can submit benchmark results (bypassed in playground mode).
  * - **Request Format:** A JSON object representing the benchmark run upload payload matching the `PrismResultPayload` interface (see api.ts).
  * - **Response Format:** A JSON object confirming the submission status. All internal IDs (including top-level `runId` and nested entry `run_id`s) are regenerated on the server to prevent ID collisions. The response includes the new server-generated `runId`, the client-supplied `oldRunId` (if one was sent), the final promoted state (`submitted_pending_review`), and a success message.
  */
@@ -41,34 +42,41 @@ export async function submitResultsHandler(
     req: Request<{}, ResultsSubmitResponse | { error: string; details?: any; warnings?: any; state?: PrismSubmissionState }, PrismResultPayload>,
     res: Response<ResultsSubmitResponse | { error: string; details?: any; warnings?: any; state?: PrismSubmissionState }>
 ) {
-    // 1. Authenticate user
-    const token = req.headers['x-prism-github-token'] as string | undefined;
-    if (!token) {
-        return res.status(401).json({ error: 'Authentication required. Missing session token.' });
-    }
-
-    let username = '';
-    let permission = 'none';
-
-    try {
-        const authResult = await validateGitHubToken(token);
-        username = authResult.username;
-        permission = authResult.permission;
-    } catch (e: any) {
-        return res.status(401).json({ error: 'Invalid or expired session token.', details: e.message });
-    }
-
-    // 2. Authorization check
-    if (permission !== 'user' && permission !== 'admin') {
-        return res.status(403).json({ error: 'Forbidden. Contributor is not allowlisted to submit benchmarks.' });
-    }
-
-    // 3. Prepare request payload
     const uploadData = req.body;
     if (!uploadData) {
         return res.status(400).json({ error: 'Missing upload payload.' });
     }
 
+    // 1. Authenticate user
+    const token = req.headers['x-prism-github-token'] as string | undefined;
+    let username = 'anonymous';
+    let permission = 'none';
+
+    if (isPlaygroundMode()) {
+        permission = 'admin';
+        if (uploadData.github_author?.username) {
+            username = uploadData.github_author.username.trim() || 'anonymous';
+        }
+    } else {
+        if (!token) {
+            return res.status(401).json({ error: 'Authentication required. Missing session token.' });
+        }
+
+        try {
+            const authResult = await validateGitHubToken(token);
+            username = authResult.username;
+            permission = authResult.permission;
+        } catch (e: any) {
+            return res.status(401).json({ error: 'Invalid or expired session token.', details: e.message });
+        }
+
+        // 2. Authorization check
+        if (permission !== 'user' && permission !== 'admin') {
+            return res.status(403).json({ error: 'Forbidden. Contributor is not allowlisted to submit benchmarks.' });
+        }
+    }
+
+    // 3. Prepare request payload
     const clientRunId = uploadData.runId || '';
 
     // Now generate Prism server-side internal IDs (replacing client-supplied IDs)
@@ -86,7 +94,16 @@ export async function submitResultsHandler(
     const rawTargetState = (req.query.targetState as string) || (uploadData as any).targetState;
     const targetState: PrismSubmissionState = rawTargetState === 'unlisted' ? 'unlisted' : 'submitted_pending_review';
 
-    uploadData.github_author = { username };
+    if (isPlaygroundMode()) {
+        uploadData.github_author = {
+            username: (uploadData.github_author?.username && uploadData.github_author.username.trim())
+                ? uploadData.github_author.username.trim()
+                : username,
+            playground: true
+        };
+    } else {
+        uploadData.github_author = { username };
+    }
     uploadData.submitted_at = new Date().toISOString();
 
     try {

--- a/server/server.js
+++ b/server/server.js
@@ -22,7 +22,9 @@ import rateLimit from 'express-rate-limit';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { oauthRouter, validateGitHubToken } from './oauth.ts';
+import { isPlaygroundMode } from './iam.ts';
 import { resultsRouter } from './results/index.ts';
+import { avatarRouter } from './avatar.ts';
 import { storage } from './results/gcs.ts';
 import { getConfiguredBucketEntries, getConfiguredBucketNames, getResultsStoreBucket } from './buckets.js';
 const __filename = fileURLToPath(import.meta.url);
@@ -42,6 +44,7 @@ app.use(express.json({ limit: '50mb' }));
 app.use(express.urlencoded({ limit: '50mb', extended: true }));
 app.use(oauthRouter);
 app.use(resultsRouter);
+app.use(avatarRouter);
 
 // Trust the first proxy (Cloud Run Load Balancer) to properly resolve X-Forwarded-For
 app.set('trust proxy', 1);
@@ -72,7 +75,8 @@ app.get('/api/config', (req, res) => {
         siteName: process.env.SITE_NAME || null,
         gaTrackingId: process.env.GA_TRACKING_ID || null,
         contactUrl: process.env.CONTACT_US_URL || null,
-        localDir: !!process.env.PRISM_LOCAL_DIR
+        localDir: !!process.env.PRISM_LOCAL_DIR,
+        playgroundMode: isPlaygroundMode()
     });
 });
 
@@ -581,55 +585,81 @@ app.all('/api/gcs/*', async (req, res) => {
             }
         }
 
-        const parsed = parseGcsPath(req.params[0]);
-        const resultsBuckets = getConfiguredBucketNames(process.env.DEFAULT_BUCKETS, process.env.RESULTS_STORE_BUCKET);
-        const resultsStoreBucket = getResultsStoreBucket();
-        const isTargetBucket = parsed && (parsed.bucket === resultsStoreBucket || resultsBuckets.includes(parsed.bucket));
-
-        let isResultsStore = false;
-        let isIam = false;
-
-        if (parsed && isTargetBucket) {
-            const prefix = (parsed.isList ? req.query.prefix : parsed.object) || '';
-            if (prefix.startsWith('prism-results-store/')) {
-                isResultsStore = true;
-            } else if (prefix.startsWith('prism-iam/')) {
-                isIam = true;
+        if (isPlaygroundMode()) {
+            permission = 'admin';
+            if (!username) {
+                username = 'anonymous';
             }
         }
 
-        // Enforce IAM role check
-        if (isIam && permission !== 'admin') {
-            return res.status(403).json({ error: 'Access denied. Only administrators can access IAM allowlists.' });
+        const parsed = parseGcsPath(req.params[0]);
+        if (!parsed) {
+            return res.status(400).json({ error: 'Invalid GCS path format' });
         }
 
-        // Restrict non-read methods to administrators only
+        const resultsBuckets = getConfiguredBucketNames(process.env.DEFAULT_BUCKETS, process.env.RESULTS_STORE_BUCKET);
+        const resultsStoreBucket = getResultsStoreBucket();
+        const isTargetBucket = (parsed.bucket === resultsStoreBucket || resultsBuckets.includes(parsed.bucket));
+
+        if (!isTargetBucket) {
+            return res.status(403).json({ error: 'Access denied. Bucket is not configured in Prism.' });
+        }
+
+        const prefix = (parsed.isList ? req.query.prefix : parsed.object) || '';
+        const isResultsStore = prefix.startsWith('prism-results-store/');
+        const isIam = prefix.startsWith('prism-iam/');
+
         const readMethods = ['GET', 'HEAD'];
-        if (!readMethods.includes(req.method) && permission !== 'admin') {
-            return res.status(403).json({ error: 'Access denied. Write and delete operations are restricted to administrators.' });
-        }
+        const isRead = readMethods.includes(req.method);
 
-        // Enforce results store read access check
-        if (isResultsStore && !parsed.isList && permission !== 'admin') {
-            try {
-                const file = storage.bucket(parsed.bucket).file(parsed.object);
-                const [metadata] = await file.getMetadata();
-                const customContexts = metadata.contexts?.custom || {};
-                const itemUser = String(customContexts.github_user?.value || '');
-                const itemState = String(customContexts.submission_state?.value || 'submitted_pending_processing');
+        // 2. Authorization and boundary enforcement
+        if (!isRead) {
+            // Check write/delete target boundaries
+            if (resultsBuckets.includes(parsed.bucket)) {
+                return res.status(403).json({ error: 'Forbidden. DEFAULT_BUCKETS is strictly read-only.' });
+            }
 
-                const isApproved = itemState === 'public' || itemState === 'promoted';
-                const isOwn = !!(username && itemUser.toLowerCase() === username.toLowerCase());
-
-                if (!isApproved && !isOwn) {
-                    return res.status(403).json({ error: 'Access denied. You do not have permissions to view this result.' });
+            if (parsed.bucket === resultsStoreBucket) {
+                if (isIam) {
+                    return res.status(403).json({ error: 'Access denied. IAM allowlists are protected and cannot be modified.' });
                 }
-            } catch (err) {
-                if (err.code === 404) {
-                    return res.status(404).json({ error: 'Result not found' });
+                if (isPlaygroundMode()) {
+                    if (!isResultsStore) {
+                        return res.status(403).json({ error: 'Access denied. Playground mode only permits modifications under prism-results-store/.' });
+                    }
+                } else if (permission !== 'admin') {
+                    return res.status(403).json({ error: 'Access denied. Write and delete operations are restricted to administrators.' });
                 }
-                console.error('[GCS Proxy Auth Error]', err);
-                return res.status(500).json({ error: 'Failed to authorize GCS access', details: err.message });
+            } else {
+                return res.status(403).json({ error: 'Access denied.' });
+            }
+        } else {
+            // Read operations (GET, HEAD)
+            if (isIam && !isPlaygroundMode() && permission !== 'admin') {
+                return res.status(403).json({ error: 'Access denied. Only administrators can access IAM allowlists.' });
+            }
+
+            if (isResultsStore && !parsed.isList && !isPlaygroundMode() && permission !== 'admin') {
+                try {
+                    const file = storage.bucket(parsed.bucket).file(parsed.object);
+                    const [metadata] = await file.getMetadata();
+                    const customContexts = metadata.contexts?.custom || {};
+                    const itemUser = String(customContexts.github_user?.value || '');
+                    const itemState = String(customContexts.submission_state?.value || 'submitted_pending_processing');
+
+                    const isApproved = itemState === 'public' || itemState === 'promoted';
+                    const isOwn = !!(username && itemUser.toLowerCase() === username.toLowerCase());
+
+                    if (!isApproved && !isOwn) {
+                        return res.status(403).json({ error: 'Access denied. You do not have permissions to view this result.' });
+                    }
+                } catch (err) {
+                    if (err.code === 404) {
+                        return res.status(404).json({ error: 'Result not found' });
+                    }
+                    console.error('[GCS Proxy Auth Error]', err);
+                    return res.status(500).json({ error: 'Failed to authorize GCS access', details: err.message });
+                }
             }
         }
 
@@ -690,7 +720,7 @@ app.all('/api/gcs/*', async (req, res) => {
              return res.status(response.status).send(errText);
         }
 
-        const shouldFilterList = isTargetBucket && parsed && parsed.isList && permission !== 'admin';
+        const shouldFilterList = isTargetBucket && parsed && parsed.isList && !isPlaygroundMode() && permission !== 'admin';
 
         if (shouldFilterList) {
              const data = await response.json();

--- a/server/server.js
+++ b/server/server.js
@@ -24,7 +24,7 @@ import { fileURLToPath } from 'url';
 import { oauthRouter, validateGitHubToken } from './oauth.ts';
 import { resultsRouter } from './results/index.ts';
 import { storage } from './results/gcs.ts';
-import { getConfiguredBucketEntries, getConfiguredBucketNames } from './buckets.js';
+import { getConfiguredBucketEntries, getConfiguredBucketNames, getResultsStoreBucket } from './buckets.js';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
@@ -61,11 +61,12 @@ const auth = new GoogleAuth();
 
 // --- API: Shared Configuration ---
 app.get('/api/config', (req, res) => {
-    const defaultBuckets = getConfiguredBucketEntries(process.env.DEFAULT_BUCKETS);
+    const defaultBuckets = getConfiguredBucketEntries(process.env.DEFAULT_BUCKETS, process.env.RESULTS_STORE_BUCKET);
     const defaultProjects = process.env.DEFAULT_PROJECTS ? process.env.DEFAULT_PROJECTS.split(',') : [];
 
     res.json({
         buckets: defaultBuckets,
+        resultsStoreBucket: getResultsStoreBucket(),
         projects: defaultProjects.map(p => p.trim()).filter(p => p),
         hostProject: process.env.GOOGLE_CLOUD_PROJECT || null,
         siteName: process.env.SITE_NAME || null,
@@ -581,8 +582,9 @@ app.all('/api/gcs/*', async (req, res) => {
         }
 
         const parsed = parseGcsPath(req.params[0]);
-        const resultsBuckets = getConfiguredBucketNames(process.env.DEFAULT_BUCKETS);
-        const isTargetBucket = parsed && resultsBuckets.includes(parsed.bucket);
+        const resultsBuckets = getConfiguredBucketNames(process.env.DEFAULT_BUCKETS, process.env.RESULTS_STORE_BUCKET);
+        const resultsStoreBucket = getResultsStoreBucket();
+        const isTargetBucket = parsed && (parsed.bucket === resultsStoreBucket || resultsBuckets.includes(parsed.bucket));
 
         let isResultsStore = false;
         let isIam = false;

--- a/specs/changes/benchmark-forking-spec.md
+++ b/specs/changes/benchmark-forking-spec.md
@@ -1,0 +1,220 @@
+# Spec: Benchmark Forking & Read-Only Source Republishing
+
+- **Status**: Implemented
+- **Author**: diamondburned, Jetski
+- **Date**: August 21, 2026
+- **Feature Name**: `benchmark-forking`
+
+---
+
+## 1. Objective & Problem Statement
+
+This specification defines the product requirements, UX architecture, and technical design for **Benchmark Forking** in Prism.
+
+Benchmark Forking allows users to take any benchmark run from the **Prism Results Store** (including read-only GCS catalog mirrors populated by automated CI pipelines or external teams), clone it directly into the browser-local **Staging Workspace**, and treat it as a locally staged benchmark. Users can then freely edit metadata, curate runs, coalesce related stages, and publish the refined benchmarks to a **writable Results Store bucket or prefix** (`RESULTS_STORE_BUCKET`).
+
+### The Core Problem: Read-Only Storage Enforcement & Incomplete Harness Metadata
+
+In team and enterprise deployments, benchmark datasets frequently originate from automated test runners or shared continuous benchmarking pipelines. These pipelines output directly into dedicated GCS buckets or directory prefixes (e.g., `gs://internal-prism/benchmarks-mirror/prism-results-store` or buckets declared in `DEFAULT_BUCKETS`).
+
+These catalog buckets are configured so that **GCS IAM enforces read-only access**. Prism writing directly to these buckets would fail with permission errors.
+
+However, automated harnesses typically do not collect enough contextual metadata or information for Prism to perform its automations to group relevant runs together, which requires human intervention before they can be effectively analyzed, shared, or compared:
+
+1. **Correlating & Grouping Related Runs**: Automated harness outputs often lack shared run identifiers or stage definitions required to automatically group multi-stage benchmarks into unified latency/throughput curves.
+2. **Metadata Inaccuracies or Gaps**: Automated outputs often have missing or generic model names, unpopulated accelerator counts, or imprecise serving stack tags.
+3. **Stage Pruning & Re-ordering**: Users may need to re-index, reorder, or remove outliers from runs.
+4. **Publishing for Team Visibility**: Users need to make these combined and corrected benchmarks visible to teammates and stakeholders on shared dashboards.
+
+Because read-only IAM makes in-place modifications impossible, users without forking have no in-app mechanism to bridge catalog data into their writable storage. They are forced to download raw YAML files, reorganize files on local disk, and manually re-upload them through the submission flow. Forking enables users to pull automated results into browser staging and curate them into useful, structured benchmark data entirely within Prism.
+
+### The Solution: Benchmark Forking
+
+**Forking** creates an instant, in-browser bridge between any existing Results Store benchmark and the staging workspace:
+
+1. Users select one or more benchmarks directly in the Results Store table and click **"Fork"**.
+2. Prism clones the canonical benchmark payload, generates a fresh staging UUID, attaches structured root provenance metadata (`$.forked_from`), and places the new benchmark directly into the local staging catalog alongside existing runs.
+3. A full-page informational dialog appears explaining that the benchmark has been forked into staging, where it can now be edited, coalesced, or submitted.
+4. The forked benchmark displays a small blue **"Forked"** badge to the left of its GCS status badge.
+5. The user handles the forked benchmark exactly like any other staged benchmark, including editing metadata, coalescing/reordering stages, and submitting it to the writable Results Store (`RESULTS_STORE_BUCKET`).
+
+### Writable Results Store & Prefix Scoping
+
+To support environments where read-only mirrors and custom writable submissions share the same physical GCS bucket, Prism utilizes bucket path prefix scoping (configured via `parseBucketEntry` in `server/buckets.js`). For example:
+
+- `DEFAULT_BUCKETS=internal-prism/benchmarks-mirror` (read-only mirror governed by GCS IAM)
+- `RESULTS_STORE_BUCKET=internal-prism/custom` (writable results store destination)
+
+> **Note**: This bucket prefix scoping infrastructure has already been implemented previously and will be shipped in the same pull request introducing this feature.
+
+### Goals
+
+1. **Any-Benchmark Forking**: Allow users to fork any Results Store benchmark into browser staging via single-card action panels or multi-select floating toolbars.
+2. **Clear In-App Feedback**: Provide 1-sentence hover popovers on Fork buttons and a full-page educational modal on fork completion.
+3. **Distinct Visual Identity**: Render a small, blue "Forked" button/badge to the left of the community/GCS status badge on every forked benchmark.
+4. **Root Provenance Tracking**: Store complete origin lineage and author attribution in a dedicated `$.forked_from` root property.
+5. **Decoupled Staging Lifecycle**: Forked runs immediately join the local staging catalog; editing, coalescing, and submission remain independent user-driven actions.
+
+### Non-Goals
+
+- Bypassing GCS IAM permissions or writing directly to read-only buckets.
+- Forcing users into immediate coalescing or submission wizards upon forking.
+
+---
+
+## 2. Data Model & Lineage (`$.forked_from`)
+
+Lineage and provenance are tracked directly at the root of the [`PrismResultPayload`](../main/completed/results-api/README.md#2-combined-api-payload-schema) object via the `forked_from` field.
+
+A benchmark payload is considered forked if and only if `$.forked_from` is non-null and defined. If `forked_from` is missing or `null`, the benchmark is an original upload.
+
+### TypeScript Definition
+
+```typescript
+export interface ForkDetail {
+    /** UUID of the benchmark run that was forked */
+    original_run_id: string;
+    /** Human-readable label or description of the original run */
+    original_run_label: string;
+    /** Original author/submitter of the source benchmark */
+    original_author?: {
+        username: string;
+        name?: string;
+        email?: string;
+    } | string | null;
+    /** GCS source bucket or prefix where the original benchmark was stored */
+    source_bucket: string;
+    /** ISO 8601 timestamp when the fork was created */
+    forked_at: string;
+}
+
+export interface PrismResultPayload {
+    runId: string;
+    runLabel: string;
+    model_name: string;
+    hardware: {
+        hardware_name: string;
+        accelerator_count?: number;
+    };
+    format: 'brv02' | string;
+    /**
+     * Provenance tracking. Single ForkDetail for direct forks,
+     * or an array of ForkDetails if forked multiple times or coalesced from multiple forks.
+     */
+    forked_from?: ForkDetail | ForkDetail[] | null;
+    entries: PrismStageEntry[];
+    // ... remaining standard payload properties
+}
+```
+
+### Transformation Rules
+
+1. **Root `$.forked_from` Injection**: The newly created staged payload contains `original_run_id`, `original_run_label`, `original_author`, `source_bucket`, and `forked_at`.
+2. **Multi-Fork / Coalesce Support**: If a forked benchmark is forked again, or if multiple forked runs are combined using the [Manual Benchmark Coalescing](manual-benchmark-coalescing.md) tool, `forked_from` becomes an array of `ForkDetail` objects representing all ancestral sources.
+3. **Payload Cloned, Raw Reports Untouched**: Constituent stage reports in `entries` are cloned into the new run. The underlying raw BRV0.2 report dictionaries (`entries[].raw_report`) remain strictly intact and unmodified.
+4. **Staging UUID**: A fresh UUID v4 is assigned to `runId` and synchronized across stage entries (`entries[].run_id`).
+
+---
+
+## 3. Frontend UI & User Experience (UX)
+
+### 3.1 Fork Action Entry Points & Hover Popovers
+
+Users can initiate a fork from two primary UI locations:
+
+1. **Multi-Select Floating Action Bar**:
+   - When one or more benchmark rows are checked in the table, a **"Fork"** button appears in the bottom floating toolbar.
+   - Hovering over the button reveals a short 1-sentence popover card:
+     *"Clone selected benchmarks into local staging to modify, coalesce, or republish."*
+2. **Benchmark Detail Card / Row Action Panel**:
+   - In each expanded benchmark row or detail panel, a **"Fork"** button is placed directly adjacent to the **Download ZIP** / **Download BRV0.2** button.
+   - Hovering over this button reveals a short 1-sentence popover card:
+     *"Clone this benchmark into local staging to modify, coalesce, or republish."*
+
+### 3.2 Post-Fork Educational Full-Page Dialog
+
+Clicking either "Fork" button immediately stages the selected benchmark(s) and displays an informational full-page modal/dialog:
+
+- **Purpose**: Explains what just happened, clarifies that the benchmark now exists in local browser staging, and outlines what forking allows the user to do (similar to the onboarding dialog displayed when staging or uploading benchmarks for the first time).
+- **Core Guidance in Dialog**:
+  - Explains that the benchmark was copied into local staging with a fresh identifier.
+  - Highlights that the user can now edit metadata, adjust labels, or coalesce multiple stages together on their own time.
+  - Notes that the benchmark remains local until the user explicitly chooses to submit it to the writable Results Store.
+- **Action**: A primary **"Got it"** / **"View in Results Store"** button dismisses the modal and returns focus to the table.
+
+### 3.3 Blue "Forked" Badge Indicator
+
+On every forked benchmark (both in the table and expanded cards):
+
+- A small, styled blue **"Forked"** button/badge is displayed directly to the left of the existing community/GCS status badge.
+- Clicking or hovering over the badge reveals origin details (original author, source bucket, and timestamp).
+
+### 3.4 Decoupled Staging Lifecycle
+
+Forking is strictly decoupled from editing and submission:
+
+- When forked, the new staged benchmark appears immediately in the Results Store / Benchmark list alongside the original run (highlighted with its staged status and blue "Forked" badge).
+- The user can choose to edit metadata, reorder stages, or coalesce runs later at their own discretion.
+
+---
+
+## 4. End-to-End Workflow & Execution Steps
+
+1. **Select Benchmark(s)**:
+   - The user browses the Results Store catalog and clicks "Fork" on a single benchmark card, or selects multiple benchmarks and clicks "Fork" in the floating action bar.
+2. **Stage & Hydrate**:
+   - Prism clones the canonical payload(s), assigns fresh staging UUIDs, records the original author and bucket in `$.forked_from`, and adds the item(s) to the local staging catalog.
+3. **Review Educational Dialog**:
+   - The full-page modal appears detailing the fork operation and explaining the available staging capabilities. The user dismisses the dialog.
+4. **View Staged Benchmark**:
+   - The user sees the forked benchmark in the table alongside existing runs, clearly marked with the blue "Forked" badge and staged accent styling.
+5. **Downstream Actions**:
+   - The user handles the forked benchmark the same as any other staged benchmark, including editing metadata, coalescing/reordering stages, or submitting it to the writable Results Store (`RESULTS_STORE_BUCKET`) as needed.
+
+---
+
+## 5. High-Level Implementation Plan
+
+### 5.1 Fork Utility & Payload Cloner
+
+- Implement a lightweight payload forker that accepts an existing benchmark run stat/payload, extracts the canonical payload, generates a new staging UUID, and populates `$.forked_from` with original run ID, label, author, source bucket, and timestamp.
+- Ensure `entries` are re-indexed to the new run ID while keeping `raw_report` contents intact.
+
+### 5.2 Results Store UI & Action Bars
+
+- Add the "Fork" button to the multi-select floating action bar and row action panel in the Results Store table.
+- Implement short 1-sentence hover popover cards for both buttons.
+- Render the blue "Forked" badge to the left of the community/GCS status badge on all runs with a non-null `$.forked_from`.
+
+### 5.3 Post-Fork Modal Dialog
+
+- Create the full-page explanation modal describing the fork operation and downstream staging actions.
+- Wire the modal to trigger upon completing a single or bulk fork action.
+
+### 5.4 Staging State & Coalescing Integration
+
+- Connect the forker output into the local staging state management hooks so forked runs appear immediately as staged benchmarks.
+- In the manual coalescing workflow, when combining runs with `forked_from` metadata, aggregate the individual provenance entries into an array under `$.forked_from`.
+
+### 5.5 Backend Schema & Validation
+
+- Update payload validation schemas to recognize optional `forked_from` (single object or array of objects) at the root level.
+- Ensure submissions containing `forked_from` metadata pass schema validation on upload.
+
+---
+
+## 6. Verification & Testing Plan
+
+### Automated Unit & Schema Tests
+
+1. **Fork Payload Extraction**: Verify that forking a benchmark creates a valid `PrismResultPayload` with a new UUID, staged status, intact `raw_report` entries, and populated root `$.forked_from`.
+2. **Author Attribution**: Verify that original author/submitter information is accurately captured inside `$.forked_from`.
+3. **Multi-Fork & Coalesce Aggregation**: Verify that coalescing multiple forked runs produces an array of `ForkDetail` objects under `$.forked_from`.
+4. **Schema Acceptance**: Verify that payloads with single and array `forked_from` blocks pass schema validation.
+
+### Browser & UI Verification
+
+1. Hover over the "Fork" button on a benchmark card and in the floating selection bar; verify 1-sentence popover cards appear.
+2. Click "Fork" on a benchmark; verify the full-page explanation modal appears with clear staging instructions.
+3. Dismiss the modal; verify the forked benchmark appears in the table with the blue "Forked" badge to the left of the community/GCS status badge.
+4. Verify the forked run can be edited, coalesced, and submitted through standard staging workflows.

--- a/specs/changes/results-store-playground-mode-spec.md
+++ b/specs/changes/results-store-playground-mode-spec.md
@@ -439,3 +439,17 @@ In the Results Store header navigation (`ResultsStore.jsx`), instead of renderin
 - Verify the yellow-outline "Playground Mode" button is displayed in the header.
 - Hover over the button and verify the tooltip explains the anonymous writable access.
 - Upload a benchmark bundle, verify it completes without login, and verify approval actions function in the Results Store table.
+
+---
+
+## 10. Related Features & Downstream Extensions
+
+### 10.1 Safe Forking & Republishing of Read-Only Catalog Benchmarks
+
+Playground Mode works synergistically with the **Benchmark Forking** feature ([benchmark-forking-spec.md](benchmark-forking-spec.md)). When Prism is configured with read-only catalog mirrors (such as continuous benchmark test mirrors from an internal Google team in `DEFAULT_BUCKETS` or scoped bucket prefixes like `gs://internal-prism/benchmarks-mirror/prism-results-store`) alongside a writable destination (`RESULTS_STORE_BUCKET=internal-prism/custom`), Playground Mode allows internal developers and analysts to:
+
+1. **Fork Read-Only Benchmarks**: Pull benchmark runs directly from immutable catalog sources into the local browser staging workspace without authentication barriers.
+2. **Modify, Combine, & Coalesce**: Combine related benchmark outputs into a single cohesive benchmark run, edit metadata, and reorder stages.
+3. **Publish to Writable Results Store**: Upload the resulting consolidated benchmark bundles directly into `RESULTS_STORE_BUCKET` anonymously or with custom author handles, making them immediately shareable and visible to teammates.
+
+

--- a/specs/changes/results-store-playground-mode-spec.md
+++ b/specs/changes/results-store-playground-mode-spec.md
@@ -1,0 +1,441 @@
+# Spec: Results Store Playground Mode (`RESULTS_STORE_PLAYGROUND_MODE=1`)
+
+- **Status**: Implemented
+- **Author**: diamondburned, Jetski
+- **Date**: August 19, 2026
+
+---
+
+## 1. Objective
+
+This proposal introduces a lightweight development configuration flag, `RESULTS_STORE_PLAYGROUND_MODE=1`, for Prism.
+
+When active, this mode disables authentication and access control restrictions for the **writable Prism Results Store** (`RESULTS_STORE_BUCKET`). Any user accessing the Prism web UI or REST API—including unauthenticated local or public visitors—can submit, review, approve, promote, reject, or delete benchmark result bundles anonymously without creating or configuring a GitHub OAuth Application.
+
+Crucially, **writes and deletions are strictly confined to `RESULTS_STORE_BUCKET`**. All catalog buckets defined in `DEFAULT_BUCKETS` remain permanently read-only.
+
+### Goals
+
+1. **Frictionless Local Development**: Allow developers to clone and run Prism locally (via Docker Compose or `npm run dev`) and test end-to-end benchmark workflows without needing a registered GitHub App, OAuth client credentials, or GCS IAM allowlist setup.
+2. **Enabled by Default in Docker Compose**: Set `RESULTS_STORE_PLAYGROUND_MODE=1` by default in `docker-compose.yml` (while respecting any explicit environment variable override) to provide an out-of-the-box working development environment.
+3. **Full UI & API Feature Parity**: Unlock all administrative capabilities in the UI (submitting runs, approving review queue items, promoting unlisted runs, rejecting runs, deleting runs) without requiring GitHub login.
+4. **Subtle & Clean UI Experience**: Replace the GitHub login button in the Results Store header with a styled yellow-outline disabled button labeled **"Playground Mode"** that displays an explanatory tooltip on hover, avoiding intrusive site-wide warning banners.
+5. **Strict Catalog Bucket Isolation**: Ensure buckets declared in `DEFAULT_BUCKETS` (e.g. `llm-d-benchmarks`) remain strictly read-only, preventing any accidental or intentional modification of reference catalog data.
+6. **Preserve Data Integrity & Validation**: Maintain all automated structural and schema validations (`validatePrismUploadStructure`, BRV0.2 parsing, UUID validation) so that only valid benchmark bundles can be stored.
+
+### Non-Goals
+
+- Making `DEFAULT_BUCKETS` writable or deletable. `DEFAULT_BUCKETS` is always read-only.
+- Disabling schema validation or structural checks. Badly formatted payloads will still be rejected with `400 Bad Request`.
+- Changing production Cloud Run defaults. In production deployments where `RESULTS_STORE_PLAYGROUND_MODE` is not explicitly enabled, Prism enforces GitHub OAuth and GCS IAM allowlists.
+
+---
+
+## 2. Background & Architecture Overview
+
+Currently, Prism enforces authentication and role-based access control (RBAC) on all mutating operations in the Results Store:
+
+```mermaid
+graph TD
+    A[Client Request] --> B{X-Prism-Github-Token<br>Header Provided?}
+    B -- No --> C[Permission: none / 401 Unauthorized]
+    B -- Yes --> D[Query GitHub API & llm-d Org]
+    D --> E{User in Org or<br>GCS Allowlist?}
+    E -- No --> F[Permission: none / 403 Forbidden]
+    E -- User --> G[Permission: user<br>Can Submit & Self-Promote]
+    E -- Admin --> H[Permission: admin<br>Full Approve / Reject / Delete]
+```
+
+This architecture is documented in:
+- [Prism Identity & Access Management (IAM)](../main/completed/results-api/iam.md)
+- [Prism Cloud API Route Reference](../main/completed/results-api/routes.md)
+- [Prism Results Store Specification](../main/completed/results-api/README.md)
+- [Unlisted Benchmarks Specification](unlisted-benchmarks-spec.md)
+
+Setting up GitHub OAuth requires creating a GitHub OAuth App, configuring redirect URLs (`http://localhost:8081/api/auth/github/callback`), providing client secrets, and provisioning test users in GCS allowlist files (`prism-iam/github-user-allowlist.txt`). For developers who simply want to test UI components, tune charts, or evaluate benchmark ingest pipelines, this creates unnecessary setup friction.
+
+`RESULTS_STORE_PLAYGROUND_MODE=1` bypasses the GitHub OAuth and IAM check, granting anonymous administrative permissions over `RESULTS_STORE_BUCKET`.
+
+---
+
+## 3. Configuration & Activation
+
+### Environment Variable
+
+The mode is controlled via the environment variable `RESULTS_STORE_PLAYGROUND_MODE`.
+
+| Value | Mode | Description |
+| :--- | :--- | :--- |
+| `1`, `true`, `yes`, `on` (case-insensitive) | **Playground Mode Active** | All ACL checks bypassed for `RESULTS_STORE_BUCKET`. Anonymous users granted administrative privileges in UI and API. |
+| `0`, `false`, `no`, `off`, unset, or empty | **Standard Auth Mode** | Default behavior in production. GitHub OAuth and GCS IAM allowlists are strictly enforced. |
+
+### Docker Compose Default
+
+In `docker-compose.yml`, `RESULTS_STORE_PLAYGROUND_MODE` is enabled by default to ensure local development works out-of-the-box:
+
+```yaml
+services:
+  app:
+    environment:
+      - GOOGLE_APPLICATION_DEFAULT_CREDENTIALS=/tmp/adc.json
+      - PORT=3000
+      - RESULTS_STORE_BUCKET=llm-d-benchmarks-staging
+      - DEFAULT_BUCKETS=llm-d-benchmarks,llm-d-benchmarks-staging
+      - RESULTS_STORE_PLAYGROUND_MODE=${RESULTS_STORE_PLAYGROUND_MODE:-1}
+      - GITHUB_CLIENT_ID=${GITHUB_CLIENT_ID}
+      - GITHUB_CLIENT_SECRET=${GITHUB_CLIENT_SECRET}
+      - PUBLIC_URL=http://localhost:8081
+```
+
+### Server-Side Helper
+
+A helper function in the backend resolves the mode:
+
+```typescript
+// server/iam.ts or server/buckets.js
+export function isPlaygroundMode(): boolean {
+    const val = String(process.env.RESULTS_STORE_PLAYGROUND_MODE || '').trim().toLowerCase();
+    return val === '1' || val === 'true' || val === 'yes' || val === 'on';
+}
+```
+
+---
+
+## 4. Security & Storage Boundaries
+
+The boundary between writable and read-only storage is strictly enforced at the API layer:
+
+```mermaid
+graph TD
+    Client[Client Request] --> Dispatcher{Endpoint Target}
+    Dispatcher -->|RESULTS_STORE_BUCKET| WritableCheck{isPlaygroundMode?}
+    WritableCheck -- Enabled --> AllowWrite[Allow Anonymous Write / Review / Delete]
+    WritableCheck -- Disabled --> AuthCheck[Enforce GitHub Token & Role]
+    
+    Dispatcher -->|DEFAULT_BUCKETS| ReadOnlyCheck{Request Method}
+    ReadOnlyCheck -- "GET / HEAD" --> AllowRead[Allow Read]
+    ReadOnlyCheck -- "POST / PUT / DELETE / PATCH" --> RejectDefault[403 Forbidden: DEFAULT_BUCKETS is strictly read-only]
+```
+
+### Bucket Permission Matrix
+
+| Bucket Category | Resolved Bucket | Read Operations (`GET`, `HEAD`, List) | Write Operations (`POST`, `PUT`, `PATCH`) | Delete Operations (`DELETE`) |
+| :--- | :--- | :---: | :---: | :---: |
+| **Prism Results Store** | `RESULTS_STORE_BUCKET` (e.g. `llm-d-benchmarks-staging`) | **Allowed** (Anonymous) | **Allowed** (Anonymous) | **Allowed** (Anonymous) |
+| **Catalog Buckets** | `DEFAULT_BUCKETS` (e.g. `llm-d-benchmarks`) | **Allowed** (Anonymous) | **Blocked (403 Forbidden)** | **Blocked (403 Forbidden)** |
+| **IAM Configurations** | `gs://<RESULTS_STORE_BUCKET>/prism-iam/*` | **Allowed** (Read-Only) | **Blocked (403 Forbidden)** | **Blocked (403 Forbidden)** |
+| **Arbitrary External Buckets** | Any other GCS bucket | **Blocked (403 Forbidden)** | **Blocked (403 Forbidden)** | **Blocked (403 Forbidden)** |
+
+---
+
+## 5. API Endpoint Specifications
+
+### 5.1 `GET /api/config`
+
+The configuration endpoint surfaces `playgroundMode` so the frontend knows to adapt its auth UI.
+
+- **Response (200 OK):**
+  ```json
+  {
+      "buckets": ["llm-d-benchmarks"],
+      "resultsStoreBucket": "llm-d-benchmarks-staging",
+      "projects": [],
+      "hostProject": "gke-gkit-dev",
+      "siteName": "Prism Benchmark Staging",
+      "gaTrackingId": null,
+      "contactUrl": null,
+      "localDir": false,
+      "playgroundMode": true
+  }
+  ```
+
+### 5.2 `GET /api/auth/github/me`
+
+When `RESULTS_STORE_PLAYGROUND_MODE=1` is active, session resolution immediately short-circuits and makes **zero external calls to the GitHub API**. It returns a synthesized active administrative session regardless of headers:
+
+- **Headers:** `X-Prism-Github-Token` (ignored)
+- **Response (200 OK):**
+  ```json
+  {
+      "authenticated": true,
+      "configured": true,
+      "username": "anonymous",
+      "permission": "admin",
+      "avatarUrl": null,
+      "playgroundMode": true
+  }
+  ```
+
+### 5.3 `POST /api/results` (Benchmark Submission)
+
+Submits a new benchmark bundle to `RESULTS_STORE_BUCKET`.
+
+- **Headers:** `X-Prism-Github-Token` (optional/ignored)
+- **In-Memory Staging vs Submission Attribution:**
+  - **Browser In-Memory Staging**: While staged locally in browser memory (`staged`), `github_author` is set to `null`.
+  - **Submission Prompt**: The submission UI asks the user for an arbitrary author/contributor name (e.g. `"alice"`, `"team-alpha"`, or defaults to `"anonymous"`).
+  - **Payload Server Mutation**: The server writes:
+    ```json
+    "github_author": {
+        "username": "<entered_name>",
+        "playground": true
+    }
+    ```
+    The `$.github_author.playground = true` boolean property explicitly records that the benchmark was submitted under Playground Mode.
+  - **GCS Custom Object Metadata Contexts**:
+    - `customContexts.github_user.value = "<entered_name>"`
+    - `customContexts.playground_submitted.value = "true"` (permanently marking the object in GCS as a playground upload).
+- **Authorization:** Bypassed when `RESULTS_STORE_PLAYGROUND_MODE=1`. Submissions succeed without requiring allowlist membership.
+- **Payload Validation:** Payload MUST strictly satisfy `PrismResultPayloadSchema` and BRV0.2 parsing rules.
+- **Response (201 Created):**
+  ```json
+  {
+      "success": true,
+      "runId": "a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d",
+      "oldRunId": "client-staged-id",
+      "state": "submitted_pending_review",
+      "message": "Benchmark result successfully submitted and promoted to review."
+  }
+  ```
+
+### 5.4 `GET /api/results` & `GET /api/results/:runId`
+
+Lists and retrieves benchmark submissions from `RESULTS_STORE_BUCKET`.
+
+- **Headers:** `X-Prism-Github-Token` (optional)
+- **Behavior when `RESULTS_STORE_PLAYGROUND_MODE=1`:**
+  - Anonymous callers are treated as administrators.
+  - Queries return benchmark runs across all submission states (`submitted_pending_processing`, `submitted_pending_review`, `unlisted`, `public`, `promoted`, `rejected`) without filtering out pending items.
+  - Single-run retrieval via `GET /api/results/:runId` succeeds for any benchmark run in `RESULTS_STORE_BUCKET`.
+
+### 5.5 `POST /api/results/:runId/status` (Review & State Transitions)
+
+Transitions the state of a benchmark result (e.g. approving, promoting, rejecting).
+
+- **Headers:** `X-Prism-Github-Token` (optional)
+- **Request Body:**
+  ```json
+  {
+      "status": "public",
+      "feedback": "Approved in Playground Mode",
+      "reviewer": "anonymous"
+  }
+  ```
+- **Authorization:** Bypassed when `RESULTS_STORE_PLAYGROUND_MODE=1`. Any caller can:
+  - Approve runs (`submitted_pending_review` $\rightarrow$ `public` / `promoted`).
+  - Reject runs (`submitted_pending_review` $\rightarrow$ `rejected`).
+  - Promote unlisted runs (`unlisted` $\rightarrow$ `submitted_pending_review`).
+  - Reset or resubmit runs (`rejected` $\rightarrow$ `submitted_pending_processing`).
+- **Audit History:** The `review.history` entry records `by: reviewer || "anonymous"` and timestamp.
+
+### 5.6 `DELETE /api/results/:runId` (Deletion)
+
+Permanently deletes a benchmark result bundle from `RESULTS_STORE_BUCKET`.
+
+- **Headers:** `X-Prism-Github-Token` (optional)
+- **Authorization:** Bypassed when `RESULTS_STORE_PLAYGROUND_MODE=1`.
+- **Target Restriction:** Deletes the corresponding JSON object in `RESULTS_STORE_BUCKET/prism-results-store/<runId>.v1.json`.
+- **Response (200 OK):**
+  ```json
+  {
+      "success": true,
+      "message": "Benchmark a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d successfully deleted."
+  }
+  ```
+
+### 5.7 `ALL /api/gcs/*` (Direct GCS Proxy Guard)
+
+The general GCS proxy handles raw storage requests. When `RESULTS_STORE_PLAYGROUND_MODE=1`:
+
+1. **Read Requests (`GET`, `HEAD`)**:
+   - Permitted for `RESULTS_STORE_BUCKET` and all `DEFAULT_BUCKETS`.
+   - Results store list filtering is bypassed (returns all custom object contexts).
+2. **Write / Delete Requests (`POST`, `PUT`, `DELETE`, `PATCH`)**:
+   - **Target is `RESULTS_STORE_BUCKET`**:
+     - Object path starts with `prism-results-store/`: **Permitted**.
+     - Object path starts with `prism-iam/`: **Blocked (403 Forbidden)** to prevent corruption of allowlist files.
+   - **Target is in `DEFAULT_BUCKETS`**:
+     - **Blocked (403 Forbidden)** with message: `"Forbidden. DEFAULT_BUCKETS is strictly read-only."`
+   - **Target is any other bucket**:
+     - **Blocked (403 Forbidden)**.
+
+### 5.8 `GET /api/avatar/:seed` (Playground Deterministic Avatar Endpoint)
+
+Generates a deterministic, unique SVG avatar based on a seed or username (e.g. `anonymous`, `alice`, `team-alpha`).
+
+- **Playground-Only Guard**: Only available when `RESULTS_STORE_PLAYGROUND_MODE=1`. When disabled (Standard Auth Mode), returns `500 Internal Server Error`.
+- **Response**: `200 OK` with `Content-Type: image/svg+xml` and `Cache-Control: public, max-age=86400, immutable`.
+- **Determinism**: The same username or seed string always yields the identical SVG avatar design.
+
+---
+
+## 6. Frontend & User Experience
+
+### 6.1 Authentication State Hydration
+
+In `GitHubAuthProvider.jsx`:
+
+1. On mount, the provider calls `GET /api/auth/github/me` and `GET /api/config`.
+2. When `playgroundMode: true` is returned:
+   - `user` is set to `{ username: 'anonymous', permission: 'admin', avatarUrl: null }`.
+   - `isAuthenticated` is set to `true`.
+   - `isConfigured` is set to `true`.
+   - `isPlaygroundMode` is set to `true`.
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor User as Developer / Visitor
+    participant App as React Frontend (GitHubAuthProvider)
+    participant API as Backend (/api/auth/github/me)
+
+    User->>App: Open Prism Dashboard
+    App->>API: GET /api/auth/github/me (No token)
+    API-->>App: { authenticated: true, permission: "admin", username: "anonymous", playgroundMode: true }
+    App->>App: Set user={ permission: "admin" }, isPlaygroundMode=true
+    App-->>User: Render Full UI with Playground Mode Button & Unlocked Controls
+```
+
+### 6.2 "Playground Mode" Header Button
+
+In the Results Store header navigation (`ResultsStore.jsx`), instead of rendering a "Sign in with GitHub" button or unauthenticated placeholder:
+
+- A **yellow-outline disabled button** labeled **"Playground Mode"** is rendered:
+  ```jsx
+  <div className="relative group/tooltip inline-block">
+      <Button
+          variant="outline"
+          size="sm"
+          disabled
+          className="gap-2 select-none border-amber-500/40 text-amber-300 bg-amber-500/10 cursor-help disabled:opacity-100 font-semibold"
+      >
+          <Sparkles size={14} className="text-amber-400" />
+          Playground Mode
+      </Button>
+      <div className="absolute right-0 top-full mt-2 px-3 py-2 bg-slate-900 border border-slate-800 text-slate-200 text-xs font-medium rounded-xl opacity-0 invisible group-hover/tooltip:opacity-100 group-hover/tooltip:visible transition-all duration-200 shadow-2xl z-[9999] w-72 pointer-events-none leading-relaxed text-left">
+          <p className="font-semibold text-amber-300 mb-1">Playground Mode Active</p>
+          Authentication is disabled. You can submit, review, approve, promote, and delete benchmarks in the Results Store without signing in.
+      </div>
+  </div>
+  ```
+
+### 6.3 Frictionless Benchmark Ingestion & Contributor Attribution
+
+- **Browser In-Memory Staging**:
+  - While files are staged locally in the browser (`staged`), `github_author` is explicitly set to `null` if `playgroundMode` is active.
+- **Data Connections / Submit Validation Page**:
+  - The submission workflow does not gate the user behind GitHub OAuth login.
+  - Step 3 prompts the user with an input field for an arbitrary **Author / Contributor Name** (e.g. `"alice"`, `"team-alpha"`, defaulting to `"anonymous"` if left empty).
+  - **DCO Omission**: The Developer Certificate of Origin (DCO) requirement, disclaimer text, and sign-off checkbox are completely hidden and bypassed in Playground Mode. Because Playground Mode operates anonymously and is not enforced, DCO sign-off is unnecessary and omitted to streamline testing.
+  - The submit action is immediately enabled after passing automated validation without requiring DCO checkboxes or GitHub authentication.
+
+### 6.4 Results Store Table & Filter Renaming
+
+- **"Pending Benchmarks" KPI & Filter Tab**:
+  - Because Playground Mode operates without a personal GitHub identity, the `"My Benchmarks"` / `"My Submissions"` tab and KPI card in `FilterPanel.jsx` is dynamically renamed to **`"Pending Benchmarks"`**.
+  - Selecting `"Pending Benchmarks"` filters the catalog to show all benchmarks in non-public review states (`staged`, `unlisted`, `submitted_pending_processing`, `submitted_pending_review`, `rejected`).
+- **Plain Text Username Rendering & Custom Avatars**:
+  - Usernames in benchmark tables and cards are rendered as plain text rather than linked GitHub URLs (`<a>`), keeping the exact same typography and text color while removing link underlines and highlights.
+  - Avatar images for benchmark contributors use the deterministic `/api/avatar/:seed` endpoint instead of resolving against `github.com/<username>.png`.
+- **Results Store Actions & Review Drawer**:
+  - All action controls (**Approve**, **Reject**, **Delete**, **Promote to Review**, **Resubmit**) are fully interactive for all visitors.
+  - Reviewer attribution defaults to `anonymous`.
+
+---
+
+## 7. Comparative Feature Matrix
+
+| Feature / Behavior | Standard Auth Mode (`RESULTS_STORE_PLAYGROUND_MODE=0`) | Playground Mode (`RESULTS_STORE_PLAYGROUND_MODE=1`) |
+| :--- | :--- | :--- |
+| **GitHub OAuth Requirement** | Mandatory for submissions and reviews | **Disabled (Zero external GitHub calls)** |
+| **Default Visitor Role** | `permission: 'none'` | **`permission: 'admin'`** |
+| **Header Button** | "Sign in with GitHub" / User Profile Avatar | **"Playground Mode" (Tag + Tooltip)** |
+| **Filter Tab Name** | `"My Benchmarks"` | **`"Pending Benchmarks"`** |
+| **Username Rendering** | GitHub profile link (`https://github.com/<user>`) | **Plain text (Identical color, no link)** |
+| **Contributor Avatar Source** | `https://github.com/<user>.png` | **`/api/avatar/:seed` (Custom SVG generator)** |
+| **`/api/avatar/:seed` Endpoint** | **Disabled (500 Error)** | **Active (Deterministic SVG avatars)** |
+| **Staged `github_author`** | Logged-in GitHub username | **`null` in browser memory** |
+| **Submission Attribution** | Enforced GitHub username | **Arbitrary name (`playground: true`)** |
+| **Developer Certificate of Origin (DCO)** | Mandatory checkbox & signature required | **Completely hidden & omitted** |
+| **GCS Metadata Tracking** | `github_user: <username>` | `github_user: <name>`, `playground_submitted: "true"` |
+| **Submit to Results Store** | Allowlisted `user` or `admin` only | **Any visitor (Anonymous / Custom Name)** |
+| **Approve / Reject Benchmarks** | `admin` only | **Any visitor (Anonymous)** |
+| **Delete from Results Store** | Owner (`unlisted`) or Admin (`unlisted`/`rejected`) | **Any visitor (Anonymous)** |
+| **List Pending Review Benchmarks** | Admin (all) or Submitter (own) | **All visitors (All runs visible)** |
+| **`RESULTS_STORE_BUCKET` Mutability** | Authorized GitHub users only | **Anonymous writes allowed** |
+| **`DEFAULT_BUCKETS` Mutability** | **Read-Only** | **Read-Only (Strictly Enforced)** |
+| **`prism-iam/*` Mutability** | Admin only | **Read-Only Protected** |
+| **Schema Validation Checks** | Enforced (`400 Bad Request` on failure) | **Enforced (`400 Bad Request` on failure)** |
+
+---
+
+## 8. Implementation Details
+
+### File Modifications
+
+1. **`server/iam.ts`**:
+   - Add `isPlaygroundMode(): boolean`.
+   - In `validateGitHubUser()`, if `isPlaygroundMode()` is true, return `'admin'` without checking GCS allowlists.
+2. **`server/oauth.ts`**:
+   - In `/api/auth/github/me`, check `isPlaygroundMode()`. If active, immediately return `{ authenticated: true, configured: true, username: 'anonymous', permission: 'admin', avatarUrl: '/api/avatar/anonymous', playgroundMode: true }` without making any calls to the GitHub API.
+3. **`server/avatar.ts`**:
+   - Add `generateSvgAvatar(seed: string): string` generating deterministic 5x5 identicons with vibrant gradients.
+   - Register `GET /api/avatar/:seed` returning SVG; rejects with 500 error if playground mode is disabled.
+4. **`server/results/api.ts`**:
+   - Extend `github_author` schema with optional `playground: z.boolean().optional()`.
+   - Extend `PrismResultContextSchema` with optional `playground_submitted: ContextValueSchema.optional()`.
+5. **`server/results/gcs.ts`**:
+   - When writing a submission in playground mode, write `playground_submitted: { value: 'true' }` to GCS object custom contexts.
+6. **`server/server.js`**:
+   - In `GET /api/config`, include `playgroundMode: isPlaygroundMode()`.
+   - Mount `avatarRouter` for `/api/avatar/:seed`.
+   - In `ALL /api/gcs/*`, allow anonymous writes only to `RESULTS_STORE_BUCKET` under `prism-results-store/*`; strictly forbid non-read methods on `DEFAULT_BUCKETS` or `prism-iam/*`.
+7. **`server/results/routes/submit.ts`**:
+   - If `isPlaygroundMode()`, allow missing token and set `uploadData.github_author = { username: uploadData.github_author?.username || 'anonymous', playground: true }`.
+8. **`server/results/routes/review.ts`**:
+   - If `isPlaygroundMode()`, allow missing token and permit any state transition. Default reviewer to `'anonymous'`.
+9. **`server/results/routes/delete.ts`**:
+   - If `isPlaygroundMode()`, allow missing token and permit deletion of any benchmark in `RESULTS_STORE_BUCKET`.
+10. **`server/results/routes/list.ts` & `get.ts`**:
+    - If `isPlaygroundMode()`, default unauthenticated permission to `'admin'`.
+11. **`docker-compose.yml`**:
+    - Add `RESULTS_STORE_PLAYGROUND_MODE=${RESULTS_STORE_PLAYGROUND_MODE:-1}`.
+12. **`src/components/GitHubAuthProvider.jsx`**:
+    - Set `isPlaygroundMode: true` and hydrate anonymous admin when `playgroundMode` is reported by the server.
+13. **`src/components/ResultsStore.jsx`**:
+    - Render the yellow-tag "Playground Mode" indicator with tooltip in place of the login button.
+14. **`src/components/ManageBenchmarks/FilterPanel.jsx`**:
+    - When `isPlaygroundMode` is true, rename `"My Benchmarks"` tab to `"Pending Benchmarks"` and show pending review runs.
+15. **`src/components/ManageBenchmarks/UnifiedDataTable.jsx` & `src/components/Dashboard/UnifiedDataTable.jsx`**:
+    - In playground mode, render usernames as plain text (no GitHub links) and load custom SVG avatars from `/api/avatar/:seed`.
+16. **`src/components/DataConnections/SubmitValidationPage.jsx`**:
+    - Set `github_author: null` while staged in memory; prompt for arbitrary author handle on submission; hide DCO checkbox and section completely in playground mode.
+
+---
+
+## 9. Verification & Testing Plan
+
+### Automated Backend Tests
+
+1. **Configuration & Role Resolution Tests**:
+   - Set `RESULTS_STORE_PLAYGROUND_MODE=1`.
+   - Verify `GET /api/config` returns `playgroundMode: true`.
+   - Verify `GET /api/auth/github/me` (without `X-Prism-Github-Token`) returns `authenticated: true`, `permission: "admin"`, `playgroundMode: true`.
+2. **Anonymous Submission & Review Workflow**:
+   - Send `POST /api/results` with valid BRV0.2 payload and no token $\rightarrow$ verify `201 Created` and state `submitted_pending_review`.
+   - Send `POST /api/results/:runId/status` with `{ "status": "public" }` and no token $\rightarrow$ verify `200 OK` and updated status.
+   - Send `DELETE /api/results/:runId` with no token $\rightarrow$ verify `200 OK` and object removal.
+3. **Storage Boundary Enforcement Tests**:
+   - Send `PUT /api/gcs/<DEFAULT_BUCKET>/test.json` $\rightarrow$ verify `403 Forbidden`.
+   - Send `DELETE /api/gcs/<DEFAULT_BUCKET>/test.json` $\rightarrow$ verify `403 Forbidden`.
+   - Send `POST /api/gcs/<RESULTS_STORE_BUCKET>/prism-iam/github-admin-allowlist.txt` $\rightarrow$ verify `403 Forbidden`.
+   - Send `PUT /api/gcs/<RESULTS_STORE_BUCKET>/prism-results-store/<runId>.v1.json` $\rightarrow$ verify `200 OK`.
+4. **Data Validation Integrity**:
+   - Send malformed payload to `POST /api/results` $\rightarrow$ verify `400 Bad Request`.
+
+### Frontend E2E / Browser Verification
+
+- Navigate to `http://localhost:8081` with Docker Compose default settings.
+- Verify the yellow-outline "Playground Mode" button is displayed in the header.
+- Hover over the button and verify the tooltip explains the anonymous writable access.
+- Upload a benchmark bundle, verify it completes without login, and verify approval actions function in the Results Store table.

--- a/specs/main/completed/results-api/README.md
+++ b/specs/main/completed/results-api/README.md
@@ -259,17 +259,22 @@ This section describes the storage backend using Google Cloud Storage (GCS).
 
 ### 7.1 Bucket Architecture
 
-- **Staging Bucket (`gs://llm-d-benchmarks-staging/prism-results-store/*`):**
-    - **Local Dev/Staging Environment:** Managed wholly inside this bucket.
-      Stores all benchmark uploads AND approvals (across all states).
-    - **Production Environment:** Never touched.
+The Results Store bucket is configured via the `RESULTS_STORE_BUCKET`
+environment variable (falling back to the first entry of `DEFAULT_BUCKETS` or
+`llm-d-benchmarks` if unset):
+
+- **Staging / Development Bucket
+  (`gs://llm-d-benchmarks-staging/prism-results-store/*`):**
+    - **Local Dev / Staging Environment
+      (`RESULTS_STORE_BUCKET=llm-d-benchmarks-staging`):** Managed wholly inside
+      this bucket. Stores all benchmark uploads AND approvals (across all
+      states).
 - **Production Bucket (`gs://llm-d-benchmarks/prism-results-store/*`):**
-    - **Local Dev/Staging Environment:** Read-only (never written to). Used for
-      reading data and configurations.
-    - **Production Environment:** Managed wholly inside this bucket. Stores all
-      benchmark uploads AND approvals (across all states).
-- **IAM configuration files (`gs://llm-d-benchmarks/prism-iam/*`):**
-    - Dedicated bucket for access control files.
+    - **Production Environment (`RESULTS_STORE_BUCKET=llm-d-benchmarks`):**
+      Managed wholly inside this bucket. Stores all benchmark uploads AND
+      approvals (across all states).
+- **IAM Configuration Files (`gs://<RESULTS_STORE_BUCKET>/prism-iam/*`):**
+    - Stored within the active Results Store bucket for access control files.
 
 ### 7.2 File Pathing
 

--- a/specs/main/completed/results-api/iam.md
+++ b/specs/main/completed/results-api/iam.md
@@ -71,15 +71,23 @@ user against allowlist text files stored in Google Cloud Storage (GCS). These
 files contain line-separated GitHub usernames.
 
 Depending on the environment configuration, these allowlist files are read from
-the following GCS paths:
+the bucket configured via `RESULTS_STORE_BUCKET` (defaulting to
+`llm-d-benchmarks`):
 
-- **Local Development / Staging Mode** (when `llm-d-benchmarks-staging` is
-  present in `DEFAULT_BUCKETS`):
+- **User Allowlist**:
+  `gs://<RESULTS_STORE_BUCKET>/prism-iam/github-user-allowlist.txt`
+- **Admin Allowlist**:
+  `gs://<RESULTS_STORE_BUCKET>/prism-iam/github-admin-allowlist.txt`
+
+For example:
+
+- **Development / Staging** (e.g.
+  `RESULTS_STORE_BUCKET=llm-d-benchmarks-staging`):
     - **User Allowlist**:
       `gs://llm-d-benchmarks-staging/prism-iam/github-user-allowlist.txt`
     - **Admin Allowlist**:
       `gs://llm-d-benchmarks-staging/prism-iam/github-admin-allowlist.txt`
-- **Production Mode**:
+- **Production** (`RESULTS_STORE_BUCKET=llm-d-benchmarks`):
     - **User Allowlist**:
       `gs://llm-d-benchmarks/prism-iam/github-user-allowlist.txt`
     - **Admin Allowlist**:

--- a/specs/main/completed/results-api/routes.md
+++ b/specs/main/completed/results-api/routes.md
@@ -73,7 +73,7 @@ are documented inline inside the implementation handler files.
 ### `GET /api/results`
 
 Lists benchmark runs from the active Prism results store (defined in
-`DEFAULT_BUCKETS`).
+`RESULTS_STORE_BUCKET`).
 
 - **Headers:** `X-Prism-Github-Token: <access_token>` (optional)
 - **Query Parameters:**

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1371,6 +1371,8 @@ const Dashboard = ({ mode = 'browser', onNavigateBack, onNavigate, dashboardStat
             });
 
             const payload = groupingData[0]?.payload;
+            const forked_from = payload?.forked_from || groupingData.find(d => d.forked_from)?.forked_from || null;
+            const github_author = payload?.github_author || groupingData.find(d => d.github_author)?.github_author || null;
 
             stats.push({
                 benchmarkKey,
@@ -1387,6 +1389,8 @@ const Dashboard = ({ mode = 'browser', onNavigateBack, onNavigate, dashboardStat
                 tp: tensor_parallelism,
                 sourceLinks,
                 payload,
+                forked_from,
+                github_author,
                 // Store reference to the actual data for this benchmark
                 // Fix Duplicates & Sort by QPS
                 data: (() => {

--- a/src/components/Dashboard/UnifiedDataTable.jsx
+++ b/src/components/Dashboard/UnifiedDataTable.jsx
@@ -20,7 +20,7 @@ import { getEffectiveTp, getBucket, getSourceTag, getSubmissionStatusDetails } f
 import { useGitHubAuth } from '../../hooks/useGitHubAuth';
 
 export const UnifiedDataTable = (props) => {
-    const { user } = useGitHubAuth();
+    const { user, isPlaygroundMode } = useGitHubAuth();
     const {
         modelStats, selectedModels, filteredBySource, showSelectedOnly, setShowSelectedOnly,
         selectedBenchmarks, setSelectedBenchmarks, setActiveFilters, expandedModels,
@@ -381,19 +381,27 @@ export const UnifiedDataTable = (props) => {
                                                                       {benchmarkData[0]?.github_author?.username && (
                                                                           <span className="flex items-center gap-1 bg-slate-200/50 dark:bg-slate-800/50 px-1.5 py-0.5 rounded ml-1">
                                                                               <img 
-                                                                                  src={`https://github.com/${benchmarkData[0].github_author.username}.png`} 
+                                                                                  src={isPlaygroundMode
+                                                                                      ? `/api/avatar/${encodeURIComponent(benchmarkData[0].github_author.username)}`
+                                                                                      : `https://github.com/${benchmarkData[0].github_author.username}.png`} 
                                                                                   alt={benchmarkData[0].github_author.username} 
                                                                                   className="w-4 h-4 rounded-full border border-slate-300 dark:border-slate-600"
                                                                                   onError={(e) => { e.target.style.display = 'none'; }}
                                                                               />
-                                                                              <a 
-                                                                                  href={`https://github.com/${benchmarkData[0].github_author.username}`} 
-                                                                                  target="_blank" 
-                                                                                  rel="noopener noreferrer" 
-                                                                                  className="text-indigo-600 dark:text-indigo-400 hover:underline font-semibold"
-                                                                              >
-                                                                                  {benchmarkData[0].github_author.username}
-                                                                              </a>
+                                                                              {isPlaygroundMode ? (
+                                                                                  <span className="text-indigo-600 dark:text-indigo-400 font-semibold">
+                                                                                      {benchmarkData[0].github_author.username}
+                                                                                  </span>
+                                                                              ) : (
+                                                                                  <a 
+                                                                                      href={`https://github.com/${benchmarkData[0].github_author.username}`} 
+                                                                                      target="_blank" 
+                                                                                      rel="noopener noreferrer" 
+                                                                                      className="text-indigo-600 dark:text-indigo-400 hover:underline font-semibold"
+                                                                                  >
+                                                                                      {benchmarkData[0].github_author.username}
+                                                                                  </a>
+                                                                              )}
                                                                           </span>
                                                                       )}
                                                                   </div>

--- a/src/components/Dashboard/UnifiedDataTable.jsx
+++ b/src/components/Dashboard/UnifiedDataTable.jsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React from 'react';
-import { RotateCcw, ChevronDown, ChevronUp, Star, Pin } from 'lucide-react';
+import { RotateCcw, ChevronDown, ChevronUp, Star, Pin, GitFork } from 'lucide-react';
 import { Badge, Button, EmptyState, Panel } from '../ui';
 import { cn } from '../../utils/cn';
 import { getEffectiveTp, getBucket, getSourceTag, getSubmissionStatusDetails } from '../../utils/dashboardHelpers';
@@ -339,6 +339,54 @@ export const UnifiedDataTable = (props) => {
                                            </td>
                                             <td className="px-2 py-2 text-center">
                                                 <div className="flex items-center justify-center gap-1.5">
+                                                    {(() => {
+                                                        const forkedFrom = stat.payload?.forked_from || stat.forked_from || benchmarkData[0]?.payload?.forked_from || benchmarkData[0]?.forked_from;
+                                                        if (!forkedFrom) return null;
+                                                        const forkList = Array.isArray(forkedFrom) ? forkedFrom : (typeof forkedFrom === 'object' && forkedFrom !== null ? [forkedFrom] : []);
+                                                        return (
+                                                            <div className="relative group/forked-badge inline-flex items-center">
+                                                                <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-bold bg-blue-500/10 text-blue-400 border border-blue-500/30 cursor-help">
+                                                                    <GitFork className="w-2.5 h-2.5" />
+                                                                    <span>Forked</span>
+                                                                </span>
+                                                                {forkList.length > 0 ? (
+                                                                    <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1.5 px-3 py-2.5 bg-slate-900 border border-slate-800 text-[11px] text-slate-300 font-medium rounded-xl opacity-0 invisible group-hover/forked-badge:opacity-100 group-hover/forked-badge:visible transition-all duration-150 shadow-2xl z-[9999] w-72 pointer-events-none leading-relaxed text-left normal-case tracking-normal space-y-2">
+                                                                        <div className="text-[10px] font-black uppercase tracking-wider text-blue-400 border-b border-slate-800 pb-1 flex items-center justify-between">
+                                                                            <span>Forked Benchmark Provenance</span>
+                                                                            <span className="text-slate-500">{forkList.length} {forkList.length === 1 ? 'origin' : 'origins'}</span>
+                                                                        </div>
+                                                                        <div className="space-y-2 max-h-48 overflow-y-auto">
+                                                                            {forkList.map((f, i) => (
+                                                                                <div key={i} className="text-[10px] space-y-0.5 border-b border-slate-800/50 pb-1.5 last:border-0 last:pb-0">
+                                                                                    <div className="text-white font-semibold truncate">{f.original_run_label || f.original_run_id}</div>
+                                                                                    <div className="text-slate-400 flex items-center justify-between">
+                                                                                        <span>Author:</span>
+                                                                                        <span className="text-slate-200 font-mono">
+                                                                                            {typeof f.original_author === 'object' ? f.original_author?.username || 'Unknown' : f.original_author || 'Unknown'}
+                                                                                        </span>
+                                                                                    </div>
+                                                                                    <div className="text-slate-400 flex items-center justify-between">
+                                                                                        <span>Source Bucket:</span>
+                                                                                        <span className="text-blue-300 font-mono truncate max-w-[140px]">{f.source_bucket || 'Unknown'}</span>
+                                                                                    </div>
+                                                                                    {f.forked_at && (
+                                                                                        <div className="text-slate-400 flex items-center justify-between">
+                                                                                        <span>Forked At:</span>
+                                                                                        <span className="text-slate-300">{f.forked_at ? new Date(f.forked_at).toLocaleString() : 'Unknown'}</span>
+                                                                                    </div>
+                                                                                    )}
+                                                                                </div>
+                                                                            ))}
+                                                                        </div>
+                                                                    </div>
+                                                                ) : (
+                                                                    <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1.5 px-2.5 py-1 bg-slate-900 border border-slate-800 text-[10px] text-slate-300 font-medium rounded-lg opacity-0 invisible group-hover/forked-badge:opacity-100 group-hover/forked-badge:visible transition-all duration-150 shadow-xl z-[9999] whitespace-nowrap pointer-events-none">
+                                                                        Forked benchmark run
+                                                                    </div>
+                                                                )}
+                                                            </div>
+                                                        );
+                                                    })()}
                                                     {(() => {
                                                         const isResultsStore = benchmarkData[0]?.source_info?.type === 'benchmark_report_v02';
                                                         const isMine = isResultsStore && user && benchmarkData[0]?.github_author?.username === user.username;

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -133,8 +133,9 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
 
 
     // Wizard navigation & Attribution states
-    const { isAuthenticated, isConfigured, user, login, logout, accessToken } = useGitHubAuth();
+    const { isAuthenticated, isConfigured, isPlaygroundMode, user, login, logout, accessToken } = useGitHubAuth();
     const [wizardStep, setWizardStep] = useState(1);
+    const [customAuthorName, setCustomAuthorName] = useState('');
     const [dcoSigned, setDcoSigned] = useState(false);
     const [selectedReviewers, setSelectedReviewers] = useState([]);
     const [isSubmitting, setIsSubmitting] = useState(false);
@@ -1996,7 +1997,18 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
     };
 
     const handleStageLocally = async () => {
-        const validBundles = stagedFiles.filter(b => !b.isSkipped && b.validation.format && b.validation.errors.length === 0);
+        const validBundles = stagedFiles.filter(b => !b.isSkipped && b.validation.format && b.validation.errors.length === 0).map(b => {
+            if (isPlaygroundMode) {
+                return {
+                    ...b,
+                    payload: {
+                        ...b.payload,
+                        github_author: null
+                    }
+                };
+            }
+            return b;
+        });
         localStorage.setItem('prism_active_staged_bundles', JSON.stringify(validBundles));
         await onCommit(validBundles);
         
@@ -2033,10 +2045,15 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             
             // Post each run package to the production Results Store API `/api/results`
             for (const bundle of validBundles) {
+                const effectiveAuthor = isPlaygroundMode
+                    ? { username: customAuthorName.trim() || 'anonymous', playground: true }
+                    : (user?.username ? { username: user.username } : undefined);
+
                 const payload = {
                     runId: bundle.payload.runId || bundle.id || uuidv4(),
                     runLabel: bundle.name || bundle.payload.runLabel || 'Unnamed Run',
                     model_name: bundle.payload.model_name || "Custom Model",
+                    ...(effectiveAuthor ? { github_author: effectiveAuthor } : {}),
                     hardware: {
                         hardware_name: bundle.payload.hardware?.hardware_name || "Unknown Hardware",
                         accelerator_count: bundle.payload.hardware?.accelerator_count
@@ -2094,7 +2111,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',
-                        'X-Prism-Github-Token': accessToken
+                        ...(accessToken ? { 'X-Prism-Github-Token': accessToken } : {})
                     },
                     body: JSON.stringify(payload)
                 });
@@ -2153,6 +2170,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
     const resetWizard = () => {
         setStagedFiles([]);
         setWizardStep(1);
+        setCustomAuthorName('');
         setDcoSigned(false);
         setSelectedReviewers([]);
         try {
@@ -2178,12 +2196,38 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                 <div className="max-w-3xl mx-auto w-full space-y-6 text-slate-200">
                     <div>
                         <h3 className="text-base font-extrabold text-slate-100 flex items-center gap-2 select-none">
-                            Contributor Attribution & DCO
+                            {isPlaygroundMode ? 'Contributor Attribution' : 'Contributor Attribution & DCO'}
                         </h3>
-                        <p className="text-xs text-slate-500 mt-1 select-none">Accept the Developer Certificate of Origin (DCO) and verify your identity using GitHub.</p>
+                        <p className="text-xs text-slate-500 mt-1 select-none">
+                            {isPlaygroundMode ? 'Specify author identity for this submission.' : 'Accept the Developer Certificate of Origin (DCO) and verify your identity.'}
+                        </p>
                     </div>
 
-                    {!isAuthenticated ? (
+                    {isPlaygroundMode ? (
+                        <div className="border border-amber-500/30 bg-amber-500/[0.03] rounded-2xl p-5 shadow-sm space-y-4">
+                            <div className="flex items-center justify-between">
+                                <div className="flex items-center gap-2 select-none">
+                                    <Sparkles className="text-amber-400" size={16} />
+                                    <span className="text-xs font-bold text-amber-300 uppercase tracking-wider">Playground Mode Active</span>
+                                </div>
+                                <span className="text-[10px] text-slate-400 font-mono">Authentication Bypassed</span>
+                            </div>
+
+                            <div className="space-y-2">
+                                <Label className="uppercase tracking-wider mb-0.5 select-none">Author / Contributor Name</Label>
+                                <Input
+                                    type="text"
+                                    value={customAuthorName}
+                                    onChange={(e) => setCustomAuthorName(e.target.value)}
+                                    placeholder="anonymous"
+                                    className="text-xs font-semibold bg-slate-950/60 border-slate-800"
+                                />
+                                <p className="text-[11px] text-slate-400">
+                                    In Playground Mode, enter an author/contributor name or leave blank to submit as <code className="text-amber-300">anonymous</code>.
+                                </p>
+                            </div>
+                        </div>
+                    ) : !isAuthenticated ? (
                         <div className="border border-slate-900 bg-slate-950/40 rounded-2xl p-8 shadow-inner flex flex-col items-center text-center space-y-4 max-w-xl mx-auto">
                             <div className="p-3.5 bg-slate-900 rounded-full text-slate-400">
                                 <svg className="w-8 h-8" fill="currentColor" viewBox="0 0 24 24">
@@ -2247,28 +2291,30 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     )}
 
                     {/* DCO Block */}
-                    <div className="space-y-2">
-                        <Label className="uppercase tracking-wider mb-0 select-none">Developer Certificate of Origin (DCO)</Label>
-                        <div className="border border-slate-900/60 bg-slate-950/65 p-4 rounded-xl h-36 overflow-y-auto text-[10px] font-mono leading-relaxed text-slate-400 shadow-inner">
-                            <p className="font-bold mb-2">Developer Certificate of Origin Version 1.1</p>
-                            <p className="mb-2">By making a contribution to this project, I certify that:</p>
-                            <p className="mb-2">(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or</p>
-                            <p className="mb-2">(b) The contribution is based upon previous work that, to the best of my knowledge, I have the right to submit it under the same open source license; or</p>
-                            <p className="mb-2">(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.</p>
-                            <p>(d) I understand and agree that this project and the contribution are public and that a record of the contribution is maintained indefinitely.</p>
+                    {!isPlaygroundMode && (
+                        <div className="space-y-2">
+                            <Label className="uppercase tracking-wider mb-0 select-none">Developer Certificate of Origin (DCO)</Label>
+                            <div className="border border-slate-900/60 bg-slate-950/65 p-4 rounded-xl h-36 overflow-y-auto text-[10px] font-mono leading-relaxed text-slate-400 shadow-inner">
+                                <p className="font-bold mb-2">Developer Certificate of Origin Version 1.1</p>
+                                <p className="mb-2">By making a contribution to this project, I certify that:</p>
+                                <p className="mb-2">(a) The contribution was created in whole or in part by me and I have the right to submit it under the open source license indicated in the file; or</p>
+                                <p className="mb-2">(b) The contribution is based upon previous work that, to the best of my knowledge, I have the right to submit it under the same open source license; or</p>
+                                <p className="mb-2">(c) The contribution was provided directly to me by some other person who certified (a), (b) or (c) and I have not modified it.</p>
+                                <p>(d) I understand and agree that this project and the contribution are public and that a record of the contribution is maintained indefinitely.</p>
+                            </div>
+                            <label className="flex items-start gap-2.5 mt-2 cursor-pointer select-none">
+                                <Checkbox
+                                    checked={dcoSigned}
+                                    disabled={!isAuthenticated}
+                                    onChange={(e) => setDcoSigned(e.target.checked)}
+                                    className="mt-1 cursor-pointer disabled:opacity-40"
+                                />
+                                <span className={cn('text-xs leading-normal', !isAuthenticated ? 'text-slate-600' : 'text-slate-400')}>
+                                    I sign off on the Developer Certificate of Origin (DCO) and certify that these benchmark runs comply with community standards.
+                                </span>
+                            </label>
                         </div>
-                        <label className="flex items-start gap-2.5 mt-2 cursor-pointer select-none">
-                            <Checkbox
-                                checked={dcoSigned}
-                                disabled={!isAuthenticated}
-                                onChange={(e) => setDcoSigned(e.target.checked)}
-                                className="mt-1 cursor-pointer disabled:opacity-40"
-                            />
-                            <span className={cn('text-xs leading-normal', !isAuthenticated ? 'text-slate-600' : 'text-slate-400')}>
-                                I sign off on the Developer Certificate of Origin (DCO) and certify that these benchmark runs comply with community standards.
-                            </span>
-                        </label>
-                    </div>
+                    )}
 
                     {/* Reviewers Selection */}
                     <div>
@@ -2276,7 +2322,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                         <Input
                             type="text"
                             value={selectedReviewers.join(', ')}
-                            disabled={!isAuthenticated}
+                            disabled={!isPlaygroundMode && !isAuthenticated}
                             onChange={(e) => setSelectedReviewers(e.target.value.split(',').map(s => s.trim()).filter(Boolean))}
                             placeholder="username1, username2 (comma separated)"
                             className="text-xs font-semibold"
@@ -2321,18 +2367,28 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                             <div className="grid grid-cols-2 gap-4 text-xs">
                                 <div>
                                     <span className="text-slate-550 block mb-0.5 select-none">Contributor</span>
-                                    <span className="font-semibold text-slate-300">@{user?.username || 'Contributor'}</span>
+                                    <span className="font-semibold text-slate-300">
+                                        @{isPlaygroundMode ? (customAuthorName.trim() || 'anonymous') : (user?.username || 'Contributor')}
+                                    </span>
                                 </div>
                                 <div>
                                     <span className="text-slate-550 block mb-0.5 select-none">GitHub User</span>
-                                    <span className="font-semibold text-slate-300">@{user?.username || 'Not specified'}</span>
-                                </div>
-                                <div className="col-span-2">
-                                    <span className="text-slate-550 block mb-0.5 select-none">DCO Signature</span>
-                                    <span className="text-emerald-400 font-bold flex items-center gap-1 text-[11px]">
-                                        <Check size={13} className="text-emerald-500" /> Signed and Verified
+                                    <span className="font-semibold text-slate-300">
+                                        {isPlaygroundMode ? (
+                                            <span className="text-amber-300/90 font-mono text-[11px]">Playground ({customAuthorName.trim() || 'anonymous'})</span>
+                                        ) : (
+                                            `@${user?.username || 'Not specified'}`
+                                        )}
                                     </span>
                                 </div>
+                                {!isPlaygroundMode && (
+                                    <div className="col-span-2">
+                                        <span className="text-slate-550 block mb-0.5 select-none">DCO Signature</span>
+                                        <span className="text-emerald-400 font-bold flex items-center gap-1 text-[11px]">
+                                            <Check size={13} className="text-emerald-500" /> Signed and Verified
+                                        </span>
+                                    </div>
+                                )}
                             </div>
                         </div>
                     </div>
@@ -2396,7 +2452,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                         </div>
                     </div>
 
-                    {user?.permission === 'none' ? (
+                    {user?.permission === 'none' && !isPlaygroundMode ? (
                         <div className="bg-amber-500/10 border border-amber-500/20 text-amber-400 rounded-xl p-4 flex gap-3 text-xs leading-normal shadow-[0_4px_20px_rgba(245,158,11,0.05)] animate-in fade-in duration-200">
                             <AlertCircle className="text-amber-500 shrink-0 mt-0.5" size={16} />
                             <div className="space-y-1 font-medium">
@@ -2644,7 +2700,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                             <ChevronRight size={14} className="text-slate-700 shrink-0" />
                             <span className={cn('flex items-center gap-2 transition-all', wizardStep === 3 ? 'text-cyan-400 font-extrabold scale-105' : 'text-slate-400')}>
                                 <span className={cn('w-7 h-7 rounded-full flex items-center justify-center text-[11px] font-mono font-bold transition-all', wizardStep === 3 ? 'bg-cyan-500/10 text-cyan-400 border-2 border-cyan-500/40 shadow-[0_0_12px_rgba(6,182,212,0.25)]' : 'bg-slate-950/60 border border-slate-900 text-slate-500')}>3</span>
-                                Attribution & DCO
+                                {isPlaygroundMode ? 'Attribution' : 'Attribution & DCO'}
                             </span>
                             <ChevronRight size={14} className="text-slate-700 shrink-0" />
                             <span className={cn('flex items-center gap-2 transition-all', wizardStep === 4 ? 'text-cyan-400 font-extrabold scale-105' : 'text-slate-400')}>
@@ -4088,57 +4144,63 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                             </div>
                         )}
 
-                        {wizardStep === 3 && (
-                            <div className="flex items-center gap-3">
-                                {(!isAuthenticated || !user?.username || !dcoSigned) && (
-                                    <span className="text-[10px] text-amber-500 font-semibold max-w-[200px] text-right animate-pulse">
-                                        Please authenticate via GitHub and accept DCO to continue.
-                                    </span>
-                                )}
-                                <button 
-                                    onClick={() => setWizardStep(4)}
-                                    disabled={!isAuthenticated || !user?.username || !dcoSigned}
-                                    className={cn(
-                                        'px-5 py-2 text-xs font-bold rounded-xl flex items-center gap-1.5 transition-all cursor-pointer',
-                                        isAuthenticated && user?.username && dcoSigned
-                                        ? 'bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-500 hover:to-blue-500 text-white shadow-md'
-                                        : 'bg-slate-900/40 text-slate-500 border border-slate-900/50 cursor-not-allowed'
+                        {wizardStep === 3 && (() => {
+                            const canProceedStep3 = isPlaygroundMode ? true : (isAuthenticated && user?.username && dcoSigned);
+                            return (
+                                <div className="flex items-center gap-3">
+                                    {!canProceedStep3 && (
+                                        <span className="text-[10px] text-amber-500 font-semibold max-w-[200px] text-right animate-pulse">
+                                            Please authenticate via GitHub and accept DCO to continue.
+                                        </span>
                                     )}
-                                >
-                                    Next <ArrowRight size={14} />
-                                </button>
-                            </div>
-                        )}
+                                    <button 
+                                        onClick={() => setWizardStep(4)}
+                                        disabled={!canProceedStep3}
+                                        className={cn(
+                                            'px-5 py-2 text-xs font-bold rounded-xl flex items-center gap-1.5 transition-all cursor-pointer',
+                                            canProceedStep3
+                                            ? 'bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-500 hover:to-blue-500 text-white shadow-md'
+                                            : 'bg-slate-900/40 text-slate-500 border border-slate-900/50 cursor-not-allowed'
+                                        )}
+                                    >
+                                        Next <ArrowRight size={14} />
+                                    </button>
+                                </div>
+                            );
+                        })()}
 
-                        {wizardStep === 4 && (
-                            <div className="flex items-center gap-3">
-                                {user?.permission === 'none' && (
-                                    <span className="text-[10px] text-amber-500 font-semibold max-w-[240px] text-right">
-                                        You are not in the Results Store closed-beta. Check back later once the feature is released.
-                                    </span>
-                                )}
-                                <button 
-                                    onClick={() => handleSubmit(targetVisibility)}
-                                    disabled={isSubmitting || user?.permission === 'none'}
-                                    className={`px-5 py-2 text-xs font-bold rounded-xl flex items-center gap-1.5 transition-all ${
-                                        isSubmitting || user?.permission === 'none'
-                                        ? 'bg-slate-900/40 text-slate-500 border border-slate-900/50 cursor-not-allowed opacity-50 shadow-none'
-                                        : targetVisibility === 'unlisted'
-                                        ? 'bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-500 hover:to-blue-500 text-white shadow-md hover:shadow-cyan-500/10 cursor-pointer border border-cyan-500/20'
-                                        : 'bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-500 hover:to-teal-500 text-white shadow-md hover:shadow-emerald-500/10 cursor-pointer border border-emerald-500/20'
-                                    }`}
-                                >
-                                    {isSubmitting ? (
-                                        <Spinner size="xs" className="text-white dark:text-white" />
-                                    ) : targetVisibility === 'unlisted' ? (
-                                        <UploadCloud size={14} />
-                                    ) : (
-                                        <Check size={14} />
+                        {wizardStep === 4 && (() => {
+                            const isSubmitBlocked = isSubmitting || (!isPlaygroundMode && user?.permission === 'none');
+                            return (
+                                <div className="flex items-center gap-3">
+                                    {user?.permission === 'none' && !isPlaygroundMode && (
+                                        <span className="text-[10px] text-amber-500 font-semibold max-w-[240px] text-right">
+                                            You are not in the Results Store closed-beta. Check back later once the feature is released.
+                                        </span>
                                     )}
-                                    {targetVisibility === 'unlisted' ? 'Save as Unlisted' : 'Submit for Public Review'}
-                                </button>
-                            </div>
-                        )}
+                                    <button 
+                                        onClick={() => handleSubmit(targetVisibility)}
+                                        disabled={isSubmitBlocked}
+                                        className={`px-5 py-2 text-xs font-bold rounded-xl flex items-center gap-1.5 transition-all ${
+                                            isSubmitBlocked
+                                            ? 'bg-slate-900/40 text-slate-500 border border-slate-900/50 cursor-not-allowed opacity-50 shadow-none'
+                                            : targetVisibility === 'unlisted'
+                                            ? 'bg-gradient-to-r from-cyan-600 to-blue-600 hover:from-cyan-500 hover:to-blue-500 text-white shadow-md hover:shadow-cyan-500/10 cursor-pointer border border-cyan-500/20'
+                                            : 'bg-gradient-to-r from-emerald-600 to-teal-600 hover:from-emerald-500 hover:to-teal-500 text-white shadow-md hover:shadow-emerald-500/10 cursor-pointer border border-emerald-500/20'
+                                        }`}
+                                    >
+                                        {isSubmitting ? (
+                                            <Spinner size="xs" className="text-white dark:text-white" />
+                                        ) : targetVisibility === 'unlisted' ? (
+                                            <UploadCloud size={14} />
+                                        ) : (
+                                            <Check size={14} />
+                                        )}
+                                        {targetVisibility === 'unlisted' ? 'Save as Unlisted' : 'Submit for Public Review'}
+                                    </button>
+                                </div>
+                            );
+                        })()}
 
                         <button 
                             onClick={onNavigateBack}

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { X, UploadCloud, CheckCircle, AlertCircle, AlertOctagon, AlertTriangle, FileText, ChevronLeft, ChevronRight, ChevronDown, Trash2, Upload, ShieldAlert, Check, ArrowRight, ArrowLeft, GitCompare, Zap, Cpu, Pencil, Layers, Split, GripVertical, Sparkles, Info, RotateCcw } from 'lucide-react';
+import { X, UploadCloud, CheckCircle, AlertCircle, AlertOctagon, AlertTriangle, FileText, ChevronLeft, ChevronRight, ChevronDown, Trash2, Upload, ShieldAlert, Check, ArrowRight, ArrowLeft, GitCompare, Zap, Cpu, Pencil, Layers, Split, GripVertical, Sparkles, Info, RotateCcw, GitFork } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 import { ComposedChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Scatter } from 'recharts';
 import { validateBenchmark, validatePrismUploadStructure } from '../../utils/benchmarkValidator';
@@ -312,6 +312,18 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             entry.prism_stage_index = idx;
         });
 
+        const allForkedFrom = [];
+        targetBundles.forEach(bundle => {
+            const ff = bundle.payload?.forked_from || bundle.forked_from;
+            if (ff) {
+                if (Array.isArray(ff)) {
+                    allForkedFrom.push(...ff);
+                } else {
+                    allForkedFrom.push(ff);
+                }
+            }
+        });
+
         const newPayload = {
             runId: coalescedId,
             runLabel: resolvedMetadata.runLabel,
@@ -320,6 +332,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                 hardware_name: resolvedMetadata.hardware_name,
                 accelerator_count: resolvedMetadata.accelerator_count
             },
+            ...(allForkedFrom.length > 0 ? { forked_from: allForkedFrom } : {}),
             attribution: targetBundles[0].payload?.attribution || null,
             manifests: targetBundles.reduce((acc, b) => ({ ...acc, ...(b.payload?.manifests || {}) }), {}),
             evidence: targetBundles.reduce((acc, b) => ({ ...acc, ...(b.payload?.evidence || {}) }), {}),
@@ -2049,20 +2062,22 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     ? { username: customAuthorName.trim() || 'anonymous', playground: true }
                     : (user?.username ? { username: user.username } : undefined);
 
+                const forkedFromVal = bundle.payload?.forked_from || bundle.forked_from;
                 const payload = {
-                    runId: bundle.payload.runId || bundle.id || uuidv4(),
-                    runLabel: bundle.name || bundle.payload.runLabel || 'Unnamed Run',
-                    model_name: bundle.payload.model_name || "Custom Model",
+                    runId: bundle.payload?.runId || bundle.id || uuidv4(),
+                    runLabel: bundle.name || bundle.payload?.runLabel || 'Unnamed Run',
+                    model_name: bundle.payload?.model_name || "Custom Model",
                     ...(effectiveAuthor ? { github_author: effectiveAuthor } : {}),
                     hardware: {
-                        hardware_name: bundle.payload.hardware?.hardware_name || "Unknown Hardware",
-                        accelerator_count: bundle.payload.hardware?.accelerator_count
+                        hardware_name: bundle.payload?.hardware?.hardware_name || "Unknown Hardware",
+                        accelerator_count: bundle.payload?.hardware?.accelerator_count
                     },
-                    well_lit_path: bundle.payload.well_lit_path,
-                    inference_tool: bundle.payload.inference_tool,
-                    inference_tool_version: bundle.payload.inference_tool_version,
-                    run_metadata: bundle.payload.run_metadata,
-                    metadata: bundle.payload.metadata,
+                    ...(forkedFromVal ? { forked_from: forkedFromVal } : {}),
+                    well_lit_path: bundle.payload?.well_lit_path,
+                    inference_tool: bundle.payload?.inference_tool,
+                    inference_tool_version: bundle.payload?.inference_tool_version,
+                    run_metadata: bundle.payload?.run_metadata,
+                    metadata: bundle.payload?.metadata,
                     manifests: {
                         ...(bundle.payload.manifests || {}),
                         ...(bundle.attachedManifests ? Object.fromEntries(
@@ -2356,7 +2371,15 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                 {validBundles.map(b => (
                                     <div key={b.id} className="flex justify-between items-center text-xs bg-slate-950/60 border border-slate-900/40 px-3.5 py-2 rounded-xl">
                                         <span className="font-mono text-slate-400">{b.payload.runId || b.id}</span>
-                                        <span className="text-slate-300 font-semibold">{b.payload.model_name}</span>
+                                        <div className="flex items-center gap-2">
+                                            {Boolean(b.payload?.forked_from || b.forked_from) && (
+                                                <Badge tone="info" size="xs" className="px-1.5 py-0.2 font-bold flex items-center gap-1 text-[10px] bg-blue-500/10 text-blue-400 border-blue-500/30">
+                                                    <GitFork size={10} />
+                                                    <span>Forked</span>
+                                                </Badge>
+                                            )}
+                                            <span className="text-slate-300 font-semibold">{b.payload.model_name}</span>
+                                        </div>
                                     </div>
                                 ))}
                             </div>
@@ -3049,6 +3072,12 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                     <div className="flex flex-col">
                                                         <div className="flex items-center gap-2">
                                                             <span className="text-sm font-bold text-slate-800 dark:text-slate-200 select-all">{bundle.payload.model_name || <span className="text-red-400 italic font-normal">Missing</span>}</span>
+                                                            {Boolean(bundle.payload?.forked_from || bundle.forked_from) && (
+                                                                <Badge tone="info" size="xs" className="px-1.5 py-0.5 font-bold flex items-center gap-1 text-[10px] bg-blue-500/10 text-blue-400 border-blue-500/30">
+                                                                    <GitFork size={10} />
+                                                                    <span>Forked</span>
+                                                                </Badge>
+                                                            )}
                                                             {bundle.isCoalesced && !bundle.isAutoCoalesced && (
                                                                 <Badge tone="info" size="xs" className="px-1.5 py-0.5 font-bold flex items-center gap-1 text-[10px]">
                                                                     <Layers size={10} />

--- a/src/components/GitHubAuthProvider.jsx
+++ b/src/components/GitHubAuthProvider.jsx
@@ -21,6 +21,7 @@ export function GitHubAuthProvider({ children }) {
     const [user, setUser] = useState(null);
     const [isAuthenticated, setIsAuthenticated] = useState(false);
     const [isConfigured, setIsConfigured] = useState(true);
+    const [isPlaygroundMode, setIsPlaygroundMode] = useState(false);
     const [isLoading, setIsLoading] = useState(true);
     const refreshTimerRef = useRef(null);
 
@@ -91,17 +92,13 @@ export function GitHubAuthProvider({ children }) {
 
     const checkSession = useCallback(async (tokenToVerify) => {
         const token = tokenToVerify || accessToken;
-        if (!token) {
-            setUser(null);
-            setIsAuthenticated(false);
-            setIsLoading(false);
-            return;
-        }
 
         try {
-            const res = await fetch('/api/auth/github/me', {
-                headers: { 'X-Prism-Github-Token': token }
-            });
+            const headers = {};
+            if (token) {
+                headers['X-Prism-Github-Token'] = token;
+            }
+            const res = await fetch('/api/auth/github/me', { headers });
 
             if (res.status === 501) {
                 setIsConfigured(false);
@@ -125,10 +122,16 @@ export function GitHubAuthProvider({ children }) {
 
             const data = await res.json();
             setIsConfigured(data.configured !== false);
-            if (data.authenticated) {
+            if (data.playgroundMode) {
+                setIsPlaygroundMode(true);
+                setUser({ username: data.username || 'anonymous', permission: data.permission || 'admin', avatarUrl: data.avatarUrl || null });
+                setIsAuthenticated(true);
+            } else if (data.authenticated) {
+                setIsPlaygroundMode(false);
                 setUser({ username: data.username, permission: data.permission, avatarUrl: data.avatarUrl });
                 setIsAuthenticated(true);
             } else {
+                setIsPlaygroundMode(false);
                 setUser(null);
                 setIsAuthenticated(false);
             }
@@ -226,6 +229,11 @@ export function GitHubAuthProvider({ children }) {
                 } else if (res.ok) {
                     const data = await res.json();
                     setIsConfigured(data.configured !== false);
+                    if (data.playgroundMode) {
+                        setIsPlaygroundMode(true);
+                        setUser({ username: data.username || 'anonymous', permission: data.permission || 'admin', avatarUrl: data.avatarUrl || null });
+                        setIsAuthenticated(true);
+                    }
                 } else {
                     setIsConfigured(true);
                 }
@@ -251,6 +259,7 @@ export function GitHubAuthProvider({ children }) {
             user,
             isAuthenticated,
             isConfigured,
+            isPlaygroundMode,
             isLoading,
             login,
             logout,

--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -59,9 +59,9 @@ const FILTER_FIELD_LABELS = {
     acc_count: 'Accelerator Count'
 };
 
-const getKpiFilterLabel = (filter) => {
+const getKpiFilterLabel = (filter, isPlaygroundMode = false) => {
     switch (filter) {
-        case 'my-submissions': return 'My Benchmarks';
+        case 'my-submissions': return isPlaygroundMode ? 'Pending Benchmarks' : 'My Benchmarks';
         case 'staged': return 'Locally Staged';
         case 'unlisted': return 'Unlisted';
         case 'processing': return 'Processing';
@@ -113,7 +113,7 @@ export const FilterPanel = ({
     dashboardData
 }) => {
     const [isAdvancedExpanded, setIsAdvancedExpanded] = useState(false);
-    const { user } = useGitHubAuth();
+    const { user, isPlaygroundMode } = useGitHubAuth();
 
 
     const [openSections, setOpenSections] = useState({
@@ -397,20 +397,6 @@ export const FilterPanel = ({
     }, [visibleSpecs]);
 
     // Calculate totals for KPI category cards
-    const totalCount = modelStats.length;
-    
-    const verifiedCount = modelStats.filter(s => {
-        const firstEntry = s.data?.[0];
-        if (!firstEntry) return false;
-        const src = firstEntry.source || '';
-        const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
-        if (!isBrv02) return false;
-        const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
-        return isMine;
-    }).length;
-
-    const legacyCount = totalCount - verifiedCount;
-
     const statusCounts = React.useMemo(() => {
         let staged = 0;
         let unlisted = 0;
@@ -426,7 +412,9 @@ export const FilterPanel = ({
             const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
             
             if (isBrv02) {
-                const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
+                const isMine = isPlaygroundMode
+                    ? true
+                    : (src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username));
                 if (!isMine) return;
 
                 const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
@@ -443,7 +431,24 @@ export const FilterPanel = ({
         });
 
         return { staged, unlisted, processing, inReview, approved, rejected };
-    }, [modelStats, submissionsMap, user]);
+    }, [modelStats, submissionsMap, user, isPlaygroundMode]);
+
+    // Calculate totals for KPI category cards
+    const totalCount = modelStats.length;
+    
+    const verifiedCount = isPlaygroundMode
+        ? (statusCounts.staged + statusCounts.unlisted + statusCounts.processing + statusCounts.inReview + statusCounts.rejected)
+        : modelStats.filter(s => {
+            const firstEntry = s.data?.[0];
+            if (!firstEntry) return false;
+            const src = firstEntry.source || '';
+            const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
+            if (!isBrv02) return false;
+            const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
+            return isMine;
+        }).length;
+
+    const legacyCount = totalCount - verifiedCount;
 
     const allRuns = React.useMemo(() => {
         const runs = [];
@@ -665,7 +670,7 @@ export const FilterPanel = ({
                                             : 'bg-slate-900/40 border-slate-800/60 hover:border-slate-700/60 hover:bg-slate-800/40'
                                         )}
                                     >
-                                        <span className="text-[9px] font-bold text-slate-400 uppercase tracking-wider">My Benchmarks</span>
+                                        <span className="text-[9px] font-bold text-slate-400 uppercase tracking-wider">{isPlaygroundMode ? 'Pending Benchmarks' : 'My Benchmarks'}</span>
                                         <span className={cn(
                                             'text-sm font-black transition-colors duration-200',
                                             (kpiFilter === 'my-submissions' || ['staged', 'processing', 'in_review', 'approved', 'action'].includes(kpiFilter)) ? 'text-cyan-400' : 'text-slate-350'
@@ -685,7 +690,7 @@ export const FilterPanel = ({
                                         return (
                                             <div className="flex-1 flex flex-col justify-between bg-slate-900/40 border border-slate-900/80 px-3 py-2 rounded-xl">
                                                 <div className="text-[10px] font-bold text-slate-400/90 uppercase tracking-wider select-none leading-none pt-0.5">
-                                                    My Pipeline — Sub-Stage Tracking
+                                                    {isPlaygroundMode ? 'Pending Pipeline — Sub-Stage Tracking' : 'My Pipeline — Sub-Stage Tracking'}
                                                 </div>
                                                 <div className="flex items-center justify-between gap-1 border border-slate-900/60 p-1 rounded-lg select-none">
                                                     
@@ -1289,7 +1294,7 @@ export const FilterPanel = ({
                                                 <div className="flex items-center justify-between bg-slate-900/60 border border-slate-800/40 rounded-xl px-2.5 py-1 text-[10px]">
                                                     <div className="flex items-center gap-1.5 truncate">
                                                         <span className="text-[8px] text-slate-500 font-bold uppercase select-none">KPI Filter:</span>
-                                                        <span className="font-medium text-cyan-400 truncate">{getKpiFilterLabel(editPresetKpi)}</span>
+                                                        <span className="font-medium text-cyan-400 truncate">{getKpiFilterLabel(editPresetKpi, isPlaygroundMode)}</span>
                                                     </div>
                                                     <button 
                                                         onClick={() => setEditPresetKpi(null)}

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -88,9 +88,9 @@ const getCardStatusAccent = (isBrv02, runId, submissionsMap, gcsStatus = null) =
     };
 };
 
-const getKpiFilterLabel = (filter) => {
+const getKpiFilterLabel = (filter, isPlaygroundMode = false) => {
     switch (filter) {
-        case 'my-submissions': return 'My Benchmarks';
+        case 'my-submissions': return isPlaygroundMode ? 'Pending Benchmarks' : 'My Benchmarks';
         case 'verified': return 'Production Ready';
         case 'staged': return 'Locally Staged';
         case 'unlisted': return 'Unlisted';
@@ -107,7 +107,7 @@ const getKpiFilterLabel = (filter) => {
 
 export const UnifiedDataTable = (props) => {
     const { dashboardState, includeUnlisted = false, addToast, dashboardData } = props;
-    const { user } = useGitHubAuth();
+    const { user, isPlaygroundMode } = useGitHubAuth();
     const isAdmin = user?.permission === 'admin';
         const [rawYamlContent, setRawYamlContent] = useState(null);
     const [rawYamlTitle, setRawYamlTitle] = useState('');
@@ -969,6 +969,12 @@ export const UnifiedDataTable = (props) => {
                 const src = firstEntry.source || '';
                 const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
                 if (!isBrv02) return false;
+                if (isPlaygroundMode) {
+                    const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
+                    const sub = runId && submissionsMap ? submissionsMap[runId] : null;
+                    const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
+                    return status !== 'public' && status !== 'promoted' && status !== 'approved';
+                }
                 const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
                 return isMine;
             });
@@ -984,7 +990,7 @@ export const UnifiedDataTable = (props) => {
                 const src = firstEntry.source || '';
                 const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
                 if (!isBrv02) return false;
-                const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
+                const isMine = isPlaygroundMode ? true : (src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username));
                 const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
                 const sub = runId && submissionsMap ? submissionsMap[runId] : null;
                 const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
@@ -998,7 +1004,7 @@ export const UnifiedDataTable = (props) => {
                 const src = firstEntry.source || '';
                 const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
                 if (!isBrv02) return false;
-                const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
+                const isMine = isPlaygroundMode ? true : (src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username));
                 const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
                 const sub = runId && submissionsMap ? submissionsMap[runId] : null;
                 const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
@@ -1011,7 +1017,7 @@ export const UnifiedDataTable = (props) => {
                 const src = firstEntry.source || '';
                 const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
                 if (!isBrv02) return false;
-                const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
+                const isMine = isPlaygroundMode ? true : (src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username));
                 const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
                 const sub = runId && submissionsMap ? submissionsMap[runId] : null;
                 const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
@@ -1024,7 +1030,7 @@ export const UnifiedDataTable = (props) => {
                 const src = firstEntry.source || '';
                 const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
                 if (!isBrv02) return false;
-                const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
+                const isMine = isPlaygroundMode ? true : (src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username));
                 const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
                 const sub = runId && submissionsMap ? submissionsMap[runId] : null;
                 const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
@@ -1037,7 +1043,7 @@ export const UnifiedDataTable = (props) => {
                 const src = firstEntry.source || '';
                 const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
                 if (!isBrv02) return false;
-                const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
+                const isMine = isPlaygroundMode ? true : (src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username));
                 const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
                 const sub = runId && submissionsMap ? submissionsMap[runId] : null;
                 const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
@@ -1050,7 +1056,7 @@ export const UnifiedDataTable = (props) => {
                 const src = firstEntry.source || '';
                 const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
                 if (!isBrv02) return false;
-                const isMine = src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username);
+                const isMine = isPlaygroundMode ? true : (src.startsWith('brv02:') || (user && firstEntry.github_author?.username === user.username));
                 const runId = src.startsWith('brv02:') ? src.replace('brv02:', '') : firstEntry.run_id;
                 const sub = runId && submissionsMap ? submissionsMap[runId] : null;
                 const status = sub?.status || firstEntry.source_info?.submission_state || 'staged';
@@ -1093,7 +1099,7 @@ export const UnifiedDataTable = (props) => {
         }
 
         return stats;
-    }, [modelStats, showSelectedOnly, selectedBenchmarks, kpiFilter, includeUnlisted, searchTerm, paretoKeys, baselineBenchmarkKey, submissionsMap, user]);
+    }, [modelStats, showSelectedOnly, selectedBenchmarks, kpiFilter, includeUnlisted, searchTerm, paretoKeys, baselineBenchmarkKey, submissionsMap, user, isPlaygroundMode]);
 
     const sortedStats = React.useMemo(() => {
         return [...filteredStats].sort((a, b) => {
@@ -1346,8 +1352,10 @@ export const UnifiedDataTable = (props) => {
                     themeColor: 'cyan',
                     glowClass: 'shadow-[0_0_30px_rgba(34,211,238,0.2)] bg-cyan-500/10 border-cyan-500/30 text-cyan-400',
                     radialGlow: 'bg-cyan-500/10',
-                    title: 'No submitted benchmarks found',
-                    description: "You have not submitted any benchmark runs to the Results store yet. Staged and submitted benchmarks will appear here.",
+                    title: isPlaygroundMode ? 'No pending benchmarks found' : 'No submitted benchmarks found',
+                    description: isPlaygroundMode 
+                        ? 'There are currently no benchmark runs in pending, staged, or review states.'
+                        : "You have not submitted any benchmark runs to the Results store yet. Staged and submitted benchmarks will appear here.",
                     action: (
                         <button
                             onClick={() => onOpenSubmitDialog && onOpenSubmitDialog('submit-review')}
@@ -1528,7 +1536,7 @@ export const UnifiedDataTable = (props) => {
                                     kpiFilter === 'pareto' ? 'bg-purple-500/10 text-purple-400 border-purple-500/25' :
                                     kpiFilter === 'regressions' ? 'bg-amber-500/10 text-amber-400 border-amber-500/25' : 'bg-slate-800/60 text-slate-400 border-slate-700'
                                 )}>
-                                    <span>{getKpiFilterLabel(kpiFilter)}</span>
+                                    <span>{getKpiFilterLabel(kpiFilter, isPlaygroundMode)}</span>
                                     {setKpiFilter && (
                                         <button 
                                             onClick={() => setKpiFilter(null)}
@@ -1828,6 +1836,7 @@ export const UnifiedDataTable = (props) => {
                                             isBaseline={isBaseline}
                                             user={user}
                                             isAdmin={isAdmin}
+                                            isPlaygroundMode={isPlaygroundMode}
                                             submissionsMap={submissionsMap}
                                             brv02Runs={brv02Runs}
                                             visibleSpecs={visibleSpecs}
@@ -2152,6 +2161,7 @@ export const UnifiedDataTable = (props) => {
                                                 isBaseline={stat.benchmarkKey === baselineBenchmarkKey}
                                                 user={user}
                                                 isAdmin={isAdmin}
+                                                isPlaygroundMode={isPlaygroundMode}
                                                 submissionsMap={submissionsMap}
                                                 brv02Runs={brv02Runs}
                                                 visibleSpecs={visibleSpecs}
@@ -2249,6 +2259,7 @@ const BenchmarkRow = React.memo(({
     isBaseline,
     user,
     isAdmin,
+    isPlaygroundMode = false,
     submissionsMap,
     brv02Runs,
     visibleSpecs,
@@ -3122,19 +3133,27 @@ const BenchmarkRow = React.memo(({
                                                                  {benchmarkData[0]?.github_author?.username && (
                                                                      <span className="flex items-center gap-1 bg-slate-200/50 dark:bg-slate-800/50 px-1.5 py-0.5 rounded ml-1">
                                                                          <img 
-                                                                             src={`https://github.com/${benchmarkData[0].github_author.username}.png`} 
+                                                                             src={isPlaygroundMode
+                                                                                 ? `/api/avatar/${encodeURIComponent(benchmarkData[0].github_author.username)}`
+                                                                                 : `https://github.com/${benchmarkData[0].github_author.username}.png`} 
                                                                              alt={benchmarkData[0].github_author.username} 
                                                                              className="w-4 h-4 rounded-full border border-slate-300 dark:border-slate-600"
                                                                              onError={(e) => { e.target.style.display = 'none'; }}
                                                                          />
-                                                                         <a 
-                                                                             href={`https://github.com/${benchmarkData[0].github_author.username}`} 
-                                                                             target="_blank" 
-                                                                             rel="noopener noreferrer" 
-                                                                             className="text-indigo-600 dark:text-indigo-400 hover:underline font-semibold"
-                                                                         >
-                                                                             {benchmarkData[0].github_author.username}
-                                                                         </a>
+                                                                         {isPlaygroundMode ? (
+                                                                             <span className="text-indigo-600 dark:text-indigo-400 font-semibold">
+                                                                                 {benchmarkData[0].github_author.username}
+                                                                             </span>
+                                                                         ) : (
+                                                                             <a 
+                                                                                 href={`https://github.com/${benchmarkData[0].github_author.username}`} 
+                                                                                 target="_blank" 
+                                                                                 rel="noopener noreferrer" 
+                                                                                 className="text-indigo-600 dark:text-indigo-400 hover:underline font-semibold"
+                                                                             >
+                                                                                 {benchmarkData[0].github_author.username}
+                                                                             </a>
+                                                                         )}
                                                                      </span>
                                                                  )}
                                                              </div>

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -14,7 +14,7 @@
 
 import React, { useState } from 'react';
 import { createPortal } from 'react-dom';
-import { RotateCcw, ChevronDown, ChevronUp, Star, Pin, CheckSquare, Square, Check, Pencil, Trash2, Code2, Copy, Share2, X, Database, Eye, EyeOff, ShieldCheck, AlertCircle, TrendingUp, AlertTriangle, Search, FileText, FileClock, Sliders, Activity, Send, Play, Loader, Download, ExternalLink } from 'lucide-react';
+import { RotateCcw, ChevronDown, ChevronUp, Star, Pin, CheckSquare, Square, Check, Pencil, Trash2, Code2, Copy, Share2, X, Database, Eye, EyeOff, ShieldCheck, AlertCircle, TrendingUp, AlertTriangle, Search, FileText, FileClock, Sliders, Activity, Send, Play, Loader, Download, ExternalLink, GitFork, Info } from 'lucide-react';
 import { RunComparisonChart } from '../Dashboard/RunComparisonChart';
 import { ThroughputCostChart } from '../Dashboard/ThroughputCostChart';
 import { Button, Badge, StatusChip, Modal, Textarea } from '../ui';
@@ -27,6 +27,35 @@ import { encodeShareLink, isValidUuid } from '../../utils/shareLinkEncoder';
 import { v4 as uuidv4 } from 'uuid';
 import { downloadRunBRV02, downloadSingleStageYaml, getRawPrismCloudPayload } from '../../utils/brv02Exporter';
 import { parseDataUri } from '../../utils/dataParser';
+import { forkBenchmark } from '../../utils/benchmarkForker';
+
+const getStatusTooltipText = (status, sub) => {
+    switch (status) {
+        case 'staged':
+            return "Staged locally on your machine. Not yet submitted to the Results Store.";
+        case 'submitted_pending_processing':
+        case 'processing':
+            return "Staged in the GCS bucket. Automated formatting checks are running.";
+        case 'submitted_pending_review':
+        case 'in_review':
+            return "Pending admin review. Check back later once a reviewer approves it.";
+        case 'approved':
+        case 'approved_pending_publish':
+            return "Approved by admins. Waiting for the next scheduled sync to publish.";
+        case 'public':
+        case 'promoted':
+            return "Published in the Public Results Store and visible to all users.";
+        case 'rejected':
+        case 'changes_requested': {
+            const reason = sub?.feedback || sub?.rejectionFeedback;
+            return reason 
+                ? `Rejected by admins. Reason: "${reason}"`
+                : "Rejected by Results Store admins.";
+        }
+        default:
+            return "Status: " + status;
+    }
+};
 
 const getCleanModelName = (name) => {
     if (!name) return '';
@@ -495,6 +524,40 @@ export const UnifiedDataTable = (props) => {
             dcoChecked: true
         };
 
+        const forkedFromVal = run.forked_from 
+            || run.payload?.forked_from 
+            || run.bundle?.payload?.forked_from 
+            || run.stages?.[0]?.forked_from 
+            || run.stages?.[0]?.payload?.forked_from 
+            || null;
+
+        const githubAuthorVal = run.github_author 
+            || run.payload?.github_author 
+            || run.bundle?.payload?.github_author 
+            || run.stages?.[0]?.github_author 
+            || run.stages?.[0]?.payload?.github_author 
+            || null;
+
+        const inferenceToolVal = run.inference_tool 
+            || run.payload?.inference_tool 
+            || run.stages?.[0]?.inference_tool 
+            || null;
+
+        const inferenceToolVersionVal = run.inference_tool_version 
+            || run.payload?.inference_tool_version 
+            || run.stages?.[0]?.inference_tool_version 
+            || null;
+
+        const manifestsVal = run.manifests 
+            || run.payload?.manifests 
+            || run.bundle?.payload?.manifests 
+            || null;
+
+        const evidenceVal = run.evidence 
+            || run.payload?.evidence 
+            || run.bundle?.payload?.evidence 
+            || null;
+
         return {
             id: Math.random().toString(36).substring(7),
             dirKey: run.runId,
@@ -502,7 +565,9 @@ export const UnifiedDataTable = (props) => {
             stageFiles,
             metadataFiles,
             payload: {
+                ...(run.payload || {}),
                 runId: run.runId,
+                runLabel: run.runLabel,
                 format: 'brv02',
                 model_name: run.model_name || run.stages[0]?.scenario?.model || 'Unknown Model',
                 hardware: { 
@@ -517,7 +582,13 @@ export const UnifiedDataTable = (props) => {
                     stage: stage.stageIndex,
                     runUid: stage.runUid
                 })),
-                well_lit_path: run.wellLitPath
+                well_lit_path: run.wellLitPath || run.well_lit_path || null,
+                ...(forkedFromVal ? { forked_from: forkedFromVal } : {}),
+                ...(githubAuthorVal ? { github_author: githubAuthorVal } : {}),
+                ...(inferenceToolVal ? { inference_tool: inferenceToolVal } : {}),
+                ...(inferenceToolVersionVal ? { inference_tool_version: inferenceToolVersionVal } : {}),
+                ...(manifestsVal ? { manifests: manifestsVal } : {}),
+                ...(evidenceVal ? { evidence: evidenceVal } : {})
             },
             validation: bundleValidation,
             isExpanded: true,
@@ -585,6 +656,92 @@ export const UnifiedDataTable = (props) => {
 
         onOpenSubmitDialog && onOpenSubmitDialog('submit-review');
     }, [buildBundleForRun, onOpenSubmitDialog]);
+
+    const [showPostForkModal, setShowPostForkModal] = useState(false);
+    const [lastForkedCount, setLastForkedCount] = useState(1);
+    const [metadataModalRun, setMetadataModalRun] = useState(null);
+
+    const handleForkSingle = React.useCallback(async (stat, benchmarkData) => {
+        try {
+            const { bundle, newRunId } = forkBenchmark(stat, benchmarkData);
+            if (dashboardData?.handleValidatedUpload) {
+                await dashboardData.handleValidatedUpload([bundle]);
+            } else if (props.handleValidatedUpload) {
+                await props.handleValidatedUpload([bundle]);
+            }
+
+            const stagedKey = `brv02:${newRunId || bundle.payload?.runId}`;
+            if (setSelectedBenchmarks) {
+                setSelectedBenchmarks(new Set([stagedKey]));
+            }
+            if (setKpiFilter) {
+                setKpiFilter('staged');
+            }
+
+            setLastForkedCount(1);
+            setShowPostForkModal(true);
+
+            const msg = "Benchmark successfully forked into local staging.";
+            if (addToast) addToast(msg, 'success');
+            else if (dashboardData?.addToast) dashboardData.addToast(msg, 'success');
+        } catch (err) {
+            console.error("Failed to fork benchmark:", err);
+            const errMsg = "Failed to fork benchmark: " + (err.message || err);
+            if (addToast) addToast(errMsg, 'error');
+            else if (dashboardData?.addToast) dashboardData.addToast(errMsg, 'error');
+            else alert(errMsg);
+        }
+    }, [dashboardData, props, addToast, setSelectedBenchmarks, setKpiFilter]);
+
+    const handleBulkForkSelected = React.useCallback(async () => {
+        if (!selectedBenchmarks || selectedBenchmarks.size === 0) return;
+
+        try {
+            const bundles = [];
+            const newKeys = new Set();
+            for (const key of selectedBenchmarks) {
+                const stat = modelStats.find(s => s.benchmarkKey === key);
+                if (stat) {
+                    const { bundle, newRunId } = forkBenchmark(stat, stat.data || []);
+                    bundles.push(bundle);
+                    newKeys.add(`brv02:${newRunId || bundle.payload?.runId}`);
+                }
+            }
+
+            if (bundles.length === 0) {
+                const warnMsg = "No valid benchmarks found to fork.";
+                if (addToast) addToast(warnMsg, 'warning');
+                else if (dashboardData?.addToast) dashboardData.addToast(warnMsg, 'warning');
+                return;
+            }
+
+            if (dashboardData?.handleValidatedUpload) {
+                await dashboardData.handleValidatedUpload(bundles);
+            } else if (props.handleValidatedUpload) {
+                await props.handleValidatedUpload(bundles);
+            }
+
+            if (setSelectedBenchmarks) {
+                setSelectedBenchmarks(newKeys);
+            }
+            if (setKpiFilter) {
+                setKpiFilter('staged');
+            }
+
+            setLastForkedCount(bundles.length);
+            setShowPostForkModal(true);
+
+            const msg = `Successfully forked ${bundles.length} benchmark${bundles.length > 1 ? 's' : ''} into local staging.`;
+            if (addToast) addToast(msg, 'success');
+            else if (dashboardData?.addToast) dashboardData.addToast(msg, 'success');
+        } catch (err) {
+            console.error("Failed to bulk fork benchmarks:", err);
+            const errMsg = "Failed to bulk fork benchmarks: " + (err.message || err);
+            if (addToast) addToast(errMsg, 'error');
+            else if (dashboardData?.addToast) dashboardData.addToast(errMsg, 'error');
+            else alert(errMsg);
+        }
+    }, [selectedBenchmarks, modelStats, dashboardData, props, addToast, setSelectedBenchmarks, setKpiFilter]);
 
 
     const drawerMetricAvailability = React.useMemo(() => {
@@ -1663,6 +1820,23 @@ export const UnifiedDataTable = (props) => {
                             {hasPromotableSelected ? `Compare & Promote (${selectedBenchmarks.size})` : `Compare & Inspect (${selectedBenchmarks.size})`}
                         </button>
 
+                        {/* Fork Selected Benchmarks */}
+                        <div className="relative group/fork-selected-btn">
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => handleActionClick(handleBulkForkSelected)}
+                                disabled={selectedBenchmarks.size === 0 || isLocalActionPending}
+                                className="gap-1.5"
+                            >
+                                <GitFork className="w-3.5 h-3.5" />
+                                <span>Fork ({selectedBenchmarks.size})</span>
+                            </Button>
+                            <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-slate-900 border border-slate-800 text-slate-350 text-xs font-medium rounded-xl opacity-0 invisible group-hover/fork-selected-btn:opacity-100 group-hover/fork-selected-btn:visible transition-all duration-200 shadow-2xl z-[9999] w-64 pointer-events-none leading-relaxed text-center normal-case tracking-normal animate-in fade-in slide-in-from-top-2 duration-150">
+                                Clone selected benchmarks into local staging to modify, coalesce, or republish.
+                            </div>
+                        </div>
+
                         {/* Copy Link Button */}
                         <div className="relative group/share-link">
                             <Button
@@ -1861,6 +2035,8 @@ export const UnifiedDataTable = (props) => {
                                             handleCheckboxPointerDown={handleCheckboxPointerDown}
                                             brv02CustomLabels={brv02CustomLabels}
                                             handleEditStagedRun={handleEditStagedRun}
+                                            handleForkSingle={handleForkSingle}
+                                            onOpenMetadataModal={(s, d) => setMetadataModalRun({ stat: s, data: d })}
                                             defaultSources={defaultSources}
                                         />
                                     );
@@ -2028,6 +2204,328 @@ export const UnifiedDataTable = (props) => {
                 document.body
             )}
 
+            {/* Post-Fork Educational Dialog */}
+            {showPostForkModal && createPortal(
+                <Modal
+                    isOpen
+                    onClose={() => setShowPostForkModal(false)}
+                    title={
+                        <span className="flex items-center gap-2 text-slate-100 font-semibold">
+                            <div className="w-8 h-8 rounded-xl bg-blue-500/10 border border-blue-500/30 flex items-center justify-center text-blue-400">
+                                <GitFork className="w-4 h-4" />
+                            </div>
+                            Benchmark{lastForkedCount > 1 ? 's' : ''} Forked to Local Staging
+                        </span>
+                    }
+                    className="max-w-xl"
+                    footer={
+                        <div className="flex items-center justify-between w-full">
+                            <div className="text-xs text-slate-400">
+                                Ready to curate or coalesce.
+                            </div>
+                            <Button
+                                variant="primary"
+                                size="sm"
+                                onClick={() => setShowPostForkModal(false)}
+                                className="px-5 font-semibold bg-blue-600 hover:bg-blue-500 text-white"
+                            >
+                                Got it
+                            </Button>
+                        </div>
+                    }
+                >
+                    <div className="space-y-4 text-sm text-slate-300 leading-relaxed">
+                        <p>
+                            {lastForkedCount > 1 
+                                ? `${lastForkedCount} benchmarks have been successfully copied into your browser's local staging workspace with fresh identifiers.`
+                                : "The benchmark has been successfully copied into your browser's local staging workspace with a fresh identifier."}
+                        </p>
+
+                        <div className="p-4 rounded-xl bg-slate-900/80 border border-slate-800 space-y-3">
+                            <div className="text-xs font-bold text-blue-400 uppercase tracking-wider">
+                                What you can do next
+                            </div>
+                            <ul className="space-y-2 text-xs text-slate-300">
+                                <li className="flex items-start gap-2">
+                                    <span className="text-blue-400 font-bold">•</span>
+                                    <span><strong>Edit Metadata:</strong> Adjust model names, tags, configurations, or hardware descriptions without modifying the original source.</span>
+                                </li>
+                                <li className="flex items-start gap-2">
+                                    <span className="text-blue-400 font-bold">•</span>
+                                    <span><strong>Coalesce Stages:</strong> Combine disjoint multi-stage benchmark runs into unified performance curves.</span>
+                                </li>
+                                <li className="flex items-start gap-2">
+                                    <span className="text-blue-400 font-bold">•</span>
+                                    <span><strong>Republish:</strong> Submit the refined benchmarks to your writable Results Store bucket with original author provenance preserved.</span>
+                                </li>
+                            </ul>
+                        </div>
+
+                        <p className="text-xs text-slate-400 italic">
+                            Note: The forked run remains in your browser's local staging workspace until you submit it.
+                        </p>
+                    </div>
+                </Modal>,
+                document.body
+            )}
+
+            {/* Benchmark Run Metadata Dialog */}
+            {metadataModalRun && createPortal(
+                <Modal
+                    isOpen
+                    onClose={() => setMetadataModalRun(null)}
+                    title={
+                        <span className="flex items-center gap-2 text-slate-100 font-semibold">
+                            <div className="w-8 h-8 rounded-xl bg-cyan-500/10 border border-cyan-500/30 flex items-center justify-center text-cyan-400">
+                                <Info className="w-4 h-4" />
+                            </div>
+                            <span>Benchmark Run Metadata</span>
+                        </span>
+                    }
+                    className="max-w-2xl"
+                    footer={
+                        <div className="flex items-center justify-between w-full">
+                            <Button
+                                variant="secondary"
+                                size="sm"
+                                onClick={() => {
+                                    const runIdToCopy = metadataModalRun.data?.[0]?.run_id || metadataModalRun.stat?.runId || metadataModalRun.data?.[0]?.source_info?.run_id;
+                                    if (runIdToCopy) {
+                                        navigator.clipboard.writeText(runIdToCopy);
+                                        const copyMsg = 'Run UUID copied to clipboard';
+                                        if (addToast) addToast(copyMsg, 'info');
+                                        else if (dashboardData?.addToast) dashboardData.addToast(copyMsg, 'info');
+                                        else alert(copyMsg);
+                                    }
+                                }}
+                                className="gap-1.5"
+                            >
+                                <Copy size={12} />
+                                <span>Copy Run UUID</span>
+                            </Button>
+                            <Button
+                                variant="primary"
+                                size="sm"
+                                onClick={() => setMetadataModalRun(null)}
+                                className="px-5 font-semibold bg-cyan-600 hover:bg-cyan-500 text-white"
+                            >
+                                Close
+                            </Button>
+                        </div>
+                    }
+                >
+                    {(() => {
+                        const mStat = metadataModalRun.stat || metadataModalRun;
+                        const mData = metadataModalRun.data || mStat.data || [];
+                        const mFirst = mData[0] || {};
+                        const mPayload = getRawPrismCloudPayload(mStat, mData);
+                        const mSourceInfo = mFirst.source_info || {};
+                        const mRunId = mFirst.run_id || mStat.runId || mPayload?.runId;
+                        const mSourceStr = mFirst.source || mStat.source || "";
+                        const mIsBrv02 = mSourceStr.startsWith("brv02:") || mFirst.source_info?.type === "benchmark_report_v02";
+                        const mSub = mIsBrv02 && mRunId && submissionsMap ? submissionsMap[mRunId] : null;
+                        const mStatus = mSub?.status || mSourceInfo.submission_state || mPayload?.submission_state || 'staged';
+                        const mStatusDetails = getSubmissionStatusDetails(mStatus);
+                        const mStatusTooltip = getStatusTooltipText(mStatus, mSub);
+
+                        const mSubmittedAt = mSourceInfo.submitted_at || mFirst.timestamp || mStat.timestamp || mPayload?.submitted_at;
+                        const mApprovedAt = mSourceInfo.approved_at || mPayload?.approved_at;
+                        const mAuthorObj = mFirst.github_author || mStat.github_author || mPayload?.github_author || mSourceInfo.github_user;
+                        const mAuthorUsername = typeof mAuthorObj === 'object' ? mAuthorObj?.username : (typeof mAuthorObj === 'string' ? mAuthorObj : null);
+                        const mAuthorName = typeof mAuthorObj === 'object' ? mAuthorObj?.name : null;
+
+                        const mForkedFrom = mPayload?.forked_from || mStat.payload?.forked_from || mStat.forked_from || mFirst.payload?.forked_from || mFirst.forked_from || mSub?.forked_from;
+                        const mForkList = mForkedFrom ? (Array.isArray(mForkedFrom) ? mForkedFrom : [mForkedFrom]) : [];
+
+                        const mSourceBucket = mSourceInfo.bucket || (mSourceStr.startsWith('gcs:') ? mSourceStr.split(':')[1] : (mSourceStr.startsWith('brv02:') ? 'Browser Local Staging' : mSourceStr)) || 'Unknown';
+
+                        return (
+                            <div className="space-y-4 text-xs font-sans text-slate-300">
+                                {/* Header Summary Card */}
+                                <div className="p-3.5 rounded-2xl bg-slate-900/90 border border-slate-800 space-y-2.5">
+                                    <div className="flex items-center justify-between gap-2 border-b border-slate-800/80 pb-2">
+                                        <div className="flex items-center gap-2 min-w-0">
+                                            <span className="font-semibold text-white truncate text-sm">
+                                                {mStat.model || mPayload?.model_name || 'Benchmark Run'}
+                                            </span>
+                                            {mStat.hardware && (
+                                                <span className="text-slate-400 font-mono text-[11px] bg-slate-800/80 px-1.5 py-0.5 rounded shrink-0">
+                                                    {mStat.accelerator_count ? `${mStat.accelerator_count}x ` : ''}{mStat.hardware}
+                                                </span>
+                                            )}
+                                        </div>
+                                        <span className={cn('px-2 py-0.5 rounded-md border text-[11px] font-bold whitespace-nowrap shrink-0', mStatusDetails.bg, mStatusDetails.text, mStatusDetails.border)}>
+                                            {mStatusDetails.label}
+                                        </span>
+                                    </div>
+
+                                    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 text-xs">
+                                        <div className="space-y-1">
+                                            <div className="text-[10px] uppercase tracking-wider font-bold text-slate-500">Run UUID</div>
+                                            <div className="font-mono text-[11px] bg-slate-950/80 border border-slate-800/80 px-2 py-1 rounded-lg text-slate-200 select-all break-all">
+                                                {mRunId || 'N/A'}
+                                            </div>
+                                        </div>
+                                        <div className="space-y-1">
+                                            <div className="text-[10px] uppercase tracking-wider font-bold text-slate-500">Status Details</div>
+                                            <div className="text-[11px] text-slate-300 bg-slate-950/80 border border-slate-800/80 px-2 py-1 rounded-lg">
+                                                {mStatusTooltip}
+                                            </div>
+                                        </div>
+                                    </div>
+
+                                    {mSub?.feedback && (
+                                        <div className="p-2.5 rounded-xl bg-red-500/10 border border-red-500/20 text-red-300 text-[11px]">
+                                            <span className="font-bold uppercase tracking-wider text-[9px] mr-1 text-red-400">Rejection Feedback:</span>
+                                            <span>"{mSub.feedback}"</span>
+                                        </div>
+                                    )}
+                                </div>
+
+                                {/* Metadata Details Grid */}
+                                <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                                    {/* Submission Info */}
+                                    <div className="p-3 rounded-xl bg-slate-900/60 border border-slate-800/80 space-y-2">
+                                        <div className="text-[10px] font-black uppercase tracking-wider text-slate-400 flex items-center gap-1.5">
+                                            <FileClock size={12} className="text-cyan-400" />
+                                            <span>Submission Details</span>
+                                        </div>
+                                        <div className="space-y-1.5 text-[11px]">
+                                            <div className="flex items-center justify-between text-slate-400">
+                                                <span>Submitted At:</span>
+                                                <span className="text-slate-200 font-medium">
+                                                    {mSubmittedAt ? new Date(mSubmittedAt).toLocaleString() : 'Unknown'}
+                                                </span>
+                                            </div>
+                                            <div className="flex items-center justify-between text-slate-400">
+                                                <span>Author / Submitter:</span>
+                                                {mAuthorUsername ? (
+                                                    <span className="flex items-center gap-1.5 text-slate-200">
+                                                        <img
+                                                            src={isPlaygroundMode
+                                                                ? `/api/avatar/${encodeURIComponent(mAuthorUsername)}`
+                                                                : `https://github.com/${mAuthorUsername}.png`}
+                                                            alt={mAuthorUsername}
+                                                            className="w-3.5 h-3.5 rounded-full border border-slate-700 shrink-0"
+                                                            onError={(e) => { e.target.style.display = 'none'; }}
+                                                        />
+                                                        {isPlaygroundMode ? (
+                                                            <span className="font-semibold text-indigo-400">{mAuthorUsername}</span>
+                                                        ) : (
+                                                            <a
+                                                                href={`https://github.com/${mAuthorUsername}`}
+                                                                target="_blank"
+                                                                rel="noopener noreferrer"
+                                                                className="font-semibold text-indigo-400 hover:underline"
+                                                            >
+                                                                {mAuthorUsername}
+                                                            </a>
+                                                        )}
+                                                        {mAuthorName && <span className="text-slate-400 text-[10px]">({mAuthorName})</span>}
+                                                    </span>
+                                                ) : (
+                                                    <span className="text-slate-400 italic">Unknown</span>
+                                                )}
+                                            </div>
+                                            {(mStatus === 'public' || mStatus === 'promoted' || mApprovedAt) && (
+                                                <div className="flex items-center justify-between text-slate-400 pt-1 border-t border-slate-800/60">
+                                                    <span>Approved At:</span>
+                                                    <span className="text-emerald-400 font-medium">
+                                                        {mApprovedAt ? new Date(mApprovedAt).toLocaleString() : (mSubmittedAt ? new Date(mSubmittedAt).toLocaleString() : 'Unknown')}
+                                                    </span>
+                                                </div>
+                                            )}
+                                        </div>
+                                    </div>
+
+                                    {/* Storage Location & Source Info */}
+                                    <div className="p-3 rounded-xl bg-slate-900/60 border border-slate-800/80 space-y-2">
+                                        <div className="text-[10px] font-black uppercase tracking-wider text-slate-400 flex items-center gap-1.5">
+                                            <Database size={12} className="text-purple-400" />
+                                            <span>Storage & Location</span>
+                                        </div>
+                                        <div className="space-y-1.5 text-[11px]">
+                                            <div className="flex items-center justify-between text-slate-400">
+                                                <span>GCS Bucket / Origin:</span>
+                                                <span className="font-mono text-cyan-300 font-medium truncate max-w-[170px]" title={mSourceBucket}>
+                                                    {mSourceBucket.startsWith('gs://') ? mSourceBucket : (mSourceBucket === 'Browser Local Staging' ? mSourceBucket : `gs://${mSourceBucket}`)}
+                                                </span>
+                                            </div>
+                                            <div className="flex items-center justify-between text-slate-400">
+                                                <span>Source Format:</span>
+                                                <span className="font-mono text-slate-200">
+                                                    {mPayload?.format || (mSourceStr.startsWith('brv02:') ? 'brv02' : 'BRV0.2')}
+                                                </span>
+                                            </div>
+                                            <div className="flex items-center justify-between text-slate-400">
+                                                <span>Total Stages:</span>
+                                                <span className="text-slate-200 font-medium">
+                                                    {mData.length} stage{mData.length === 1 ? '' : 's'}
+                                                </span>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+
+                                {/* Forked Lineage Provenance (if forked) */}
+                                {mForkList.length > 0 ? (
+                                    <div className="p-3 rounded-xl bg-blue-500/10 border border-blue-500/20 space-y-2">
+                                        <div className="text-[10px] font-black uppercase tracking-wider text-blue-400 flex items-center justify-between">
+                                            <div className="flex items-center gap-1.5">
+                                                <GitFork size={12} className="text-blue-400" />
+                                                <span>Forked Provenance Lineage</span>
+                                            </div>
+                                            <span className="text-[10px] text-blue-300 font-normal">
+                                                {mForkList.length} origin{mForkList.length === 1 ? '' : 's'}
+                                            </span>
+                                        </div>
+                                        <div className="space-y-2 max-h-40 overflow-y-auto custom-scrollbar">
+                                            {mForkList.map((f, i) => (
+                                                <div key={i} className="text-[11px] space-y-1 bg-slate-900/80 p-2.5 rounded-lg border border-slate-800">
+                                                    <div className="text-white font-semibold flex items-center justify-between">
+                                                        <span>{f.original_run_label || 'Original Benchmark Run'}</span>
+                                                        <span className="font-mono text-[10px] text-slate-400 select-all">{f.original_run_id}</span>
+                                                    </div>
+                                                    <div className="grid grid-cols-2 gap-2 text-slate-400 text-[10px]">
+                                                        <div>
+                                                            <span>Author: </span>
+                                                            <span className="text-slate-200 font-mono">
+                                                                {typeof f.original_author === 'object' ? f.original_author?.username || 'Unknown' : f.original_author || 'Unknown'}
+                                                            </span>
+                                                        </div>
+                                                        <div>
+                                                            <span>Bucket: </span>
+                                                            <span className="text-blue-300 font-mono truncate">{f.source_bucket || 'Unknown'}</span>
+                                                        </div>
+                                                    </div>
+                                                    {f.forked_at && (
+                                                        <div className="text-[10px] text-slate-400">
+                                                            <span>Forked at: </span>
+                                                            <span className="text-slate-300">{new Date(f.forked_at).toLocaleString()}</span>
+                                                        </div>
+                                                    )}
+                                                </div>
+                                            ))}
+                                        </div>
+                                    </div>
+                                ) : (mForkedFrom && (
+                                    <div className="p-3 rounded-xl bg-blue-500/10 border border-blue-500/20 space-y-1">
+                                        <div className="text-[10px] font-black uppercase tracking-wider text-blue-400 flex items-center gap-1.5">
+                                            <GitFork size={12} className="text-blue-400" />
+                                            <span>Forked Benchmark Run</span>
+                                        </div>
+                                        <div className="text-[11px] text-slate-300">
+                                            This benchmark was forked and cloned into this Results Store.
+                                        </div>
+                                    </div>
+                                ))}
+                            </div>
+                        );
+                    })()}
+                </Modal>,
+                document.body
+            )}
+
             {/* Slide-Over Comparison Drawer Displayed from Right */}
             {showComparisonDrawer && createPortal(
                 <div 
@@ -2186,6 +2684,8 @@ export const UnifiedDataTable = (props) => {
                                                 handleCheckboxPointerDown={handleCheckboxPointerDown}
                                                 brv02CustomLabels={brv02CustomLabels}
                                                 handleEditStagedRun={handleEditStagedRun}
+                                                handleForkSingle={handleForkSingle}
+                                                onOpenMetadataModal={(s, d) => setMetadataModalRun({ stat: s, data: d })}
                                                 defaultSources={defaultSources}
                                                 readOnly={true}
                                                 canViewRaw={false}
@@ -2284,6 +2784,8 @@ const BenchmarkRow = React.memo(({
     handleCheckboxPointerDown,
     brv02CustomLabels,
     handleEditStagedRun,
+    handleForkSingle,
+    onOpenMetadataModal,
     defaultSources,
     readOnly = false,
     canViewRaw = true,
@@ -2334,33 +2836,7 @@ const BenchmarkRow = React.memo(({
         return `Source: ${src}`;
     };
 
-    const getStatusTooltipText = (status, sub) => {
-        switch (status) {
-            case 'staged':
-                return "Staged locally on your machine. Not yet submitted to the Results Store.";
-            case 'submitted_pending_processing':
-            case 'processing':
-                return "Staged in the GCS bucket. Automated formatting checks are running.";
-            case 'submitted_pending_review':
-            case 'in_review':
-                return "Pending admin review. Check back later once a reviewer approves it.";
-            case 'approved':
-            case 'approved_pending_publish':
-                return "Approved by admins. Waiting for the next scheduled sync to publish.";
-            case 'public':
-            case 'promoted':
-                return "Published in the Public Results Store and visible to all users.";
-            case 'rejected':
-            case 'changes_requested': {
-                const reason = sub?.feedback || sub?.rejectionFeedback;
-                return reason 
-                    ? `Rejected by admins. Reason: "${reason}"`
-                    : "Rejected by Results Store admins.";
-            }
-            default:
-                return `Status: ${status}`;
-        }
-    };
+
     const sourceStr = benchmarkData[0]?.source || '';
     const isBrv02 = sourceStr.startsWith('brv02:') || benchmarkData[0]?.source_info?.type === 'benchmark_report_v02';
     const runId = isBrv02 ? (sourceStr.startsWith('brv02:') ? sourceStr.replace('brv02:', '') : benchmarkData[0]?.run_id) : null;
@@ -2382,7 +2858,7 @@ const BenchmarkRow = React.memo(({
         ? 'border-blue-400 dark:border-blue-600 ring-1 ring-blue-400 dark:ring-blue-600/50' 
         : statusAccent.borderClass;
     const cardBgClass = statusAccent.bgClass || '';
-    const popoverTargetId = runId || stat.benchmarkKey || stat.model || key;
+    const popoverTargetId = runId || stat.benchmarkKey || stat.model || 'row';
     const rawPayload = getRawPrismCloudPayload(stat, benchmarkData);
     const manifestsObj = rawPayload?.manifests || stat.manifests || {};
     const evidenceObj = rawPayload?.evidence || stat.evidence || {};
@@ -2975,6 +3451,59 @@ const BenchmarkRow = React.memo(({
                                                                                 </div>
                                                                         <div className="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 flex-shrink-0">
                                                                             {(() => {
+                                                                                const forkedFrom = stat.payload?.forked_from || stat.forked_from || benchmarkData[0]?.payload?.forked_from || benchmarkData[0]?.forked_from || (runId && submissionsMap ? (submissionsMap[runId]?.forked_from || submissionsMap[runId]?.forked) : null);
+                                                                                if (!forkedFrom) return null;
+                                                                                const forkList = Array.isArray(forkedFrom) ? forkedFrom : (typeof forkedFrom === 'object' && forkedFrom !== null ? [forkedFrom] : []);
+                                                                                return (
+                                                                                    <div className="relative group/forked-badge inline-flex items-center">
+                                                                                        <button
+                                                                                            type="button"
+                                                                                            onClick={(e) => e.stopPropagation()}
+                                                                                            className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-bold bg-blue-500/10 text-blue-400 border border-blue-500/30 hover:bg-blue-500/20 transition-colors cursor-help"
+                                                                                        >
+                                                                                            <GitFork className="w-2.5 h-2.5" />
+                                                                                            <span>Forked</span>
+                                                                                        </button>
+                                                                                        {forkList.length > 0 ? (
+                                                                                            <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1.5 px-3 py-2.5 bg-slate-900 border border-slate-800 text-[11px] text-slate-300 font-medium rounded-xl opacity-0 invisible group-hover/forked-badge:opacity-100 group-hover/forked-badge:visible transition-all duration-150 shadow-2xl z-[9999] w-72 pointer-events-none leading-relaxed text-left normal-case tracking-normal space-y-2">
+                                                                                                <div className="text-[10px] font-black uppercase tracking-wider text-blue-400 border-b border-slate-800 pb-1 flex items-center justify-between">
+                                                                                                    <span>Forked Benchmark Provenance</span>
+                                                                                                    <span className="text-slate-500">{forkList.length} {forkList.length === 1 ? 'origin' : 'origins'}</span>
+                                                                                                </div>
+                                                                                                <div className="space-y-2 max-h-48 overflow-y-auto custom-scrollbar">
+                                                                                                    {forkList.map((f, i) => (
+                                                                                                        <div key={i} className="text-[10px] space-y-0.5 border-b border-slate-800/50 pb-1.5 last:border-0 last:pb-0">
+                                                                                                            <div className="text-white font-semibold truncate">{f.original_run_label || f.original_run_id}</div>
+                                                                                                            <div className="text-slate-400 flex items-center justify-between">
+                                                                                                                <span>Author:</span>
+                                                                                                                <span className="text-slate-200 font-mono">
+                                                                                                                    {typeof f.original_author === 'object' ? f.original_author?.username || 'Unknown' : f.original_author || 'Unknown'}
+                                                                                                                </span>
+                                                                                                            </div>
+                                                                                                            <div className="text-slate-400 flex items-center justify-between">
+                                                                                                                <span>Source Bucket:</span>
+                                                                                                                <span className="text-blue-300 font-mono truncate max-w-[140px]">{f.source_bucket || 'Unknown'}</span>
+                                                                                                            </div>
+                                                                                                            {f.forked_at && (
+                                                                                                                <div className="text-slate-400 flex items-center justify-between">
+                                                                                                                    <span>Forked At:</span>
+                                                                                                                    <span className="text-slate-300">{f.forked_at ? new Date(f.forked_at).toLocaleString() : 'Unknown'}</span>
+                                                                                                                </div>
+                                                                                                            )}
+                                                                                                        </div>
+                                                                                                    ))}
+                                                                                                </div>
+                                                                                            </div>
+                                                                                        ) : (
+                                                                                            <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-1.5 px-2.5 py-1 bg-slate-900 border border-slate-800 text-[10px] text-slate-300 font-medium rounded-lg opacity-0 invisible group-hover/forked-badge:opacity-100 group-hover/forked-badge:visible transition-all duration-150 shadow-xl z-[9999] whitespace-nowrap pointer-events-none">
+                                                                                                Forked benchmark run
+                                                                                            </div>
+                                                                                        )}
+                                                                                    </div>
+                                                                                );
+                                                                            })()}
+
+                                                                            {(() => {
                                                                                 const isResultsStore = benchmarkData[0]?.source_info?.type === 'benchmark_report_v02';
                                                                                 const isMine = isResultsStore && user && benchmarkData[0]?.github_author?.username === user.username;
                                                                                 if (isMine) {
@@ -3120,68 +3649,108 @@ const BenchmarkRow = React.memo(({
                                              {/* Expanded Table Details */}
                                              {isExpanded && (
                                                  <div className="border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/30 p-4 rounded-b-lg">
-                                                     <div className="flex justify-between items-stretch gap-4 mb-3 w-full">
-                                                         {benchmarkData[0]?.source_info?.type === 'benchmark_report_v02' ? (
-                                                             <div className="flex-1 p-2 bg-slate-100 dark:bg-slate-800/40 rounded border border-slate-200 dark:border-slate-700/80 font-sans flex flex-wrap gap-x-6 gap-y-2.5 text-xs text-slate-600 dark:text-slate-400">
-                                                             <div className="flex items-center gap-1.5">
-                                                                 <span className="font-semibold text-slate-700 dark:text-slate-300">Run UUID:</span>
-                                                                 <span className="font-mono bg-slate-200 dark:bg-slate-800/50 px-1.5 py-0.5 rounded text-[11px] select-all">{benchmarkData[0]?.run_id}</span>
-                                                             </div>
-                                                             <div className="flex items-center gap-1.5">
-                                                                 <span className="font-semibold text-slate-700 dark:text-slate-300">Submitted:</span>
-                                                                 <span>{benchmarkData[0]?.source_info?.submitted_at ? new Date(benchmarkData[0].source_info.submitted_at).toLocaleString() : 'Unknown'}</span>
-                                                                 {benchmarkData[0]?.github_author?.username && (
-                                                                     <span className="flex items-center gap-1 bg-slate-200/50 dark:bg-slate-800/50 px-1.5 py-0.5 rounded ml-1">
-                                                                         <img 
-                                                                             src={isPlaygroundMode
-                                                                                 ? `/api/avatar/${encodeURIComponent(benchmarkData[0].github_author.username)}`
-                                                                                 : `https://github.com/${benchmarkData[0].github_author.username}.png`} 
-                                                                             alt={benchmarkData[0].github_author.username} 
-                                                                             className="w-4 h-4 rounded-full border border-slate-300 dark:border-slate-600"
-                                                                             onError={(e) => { e.target.style.display = 'none'; }}
-                                                                         />
-                                                                         {isPlaygroundMode ? (
-                                                                             <span className="text-indigo-600 dark:text-indigo-400 font-semibold">
-                                                                                 {benchmarkData[0].github_author.username}
-                                                                             </span>
-                                                                         ) : (
-                                                                             <a 
-                                                                                 href={`https://github.com/${benchmarkData[0].github_author.username}`} 
-                                                                                 target="_blank" 
-                                                                                 rel="noopener noreferrer" 
-                                                                                 className="text-indigo-600 dark:text-indigo-400 hover:underline font-semibold"
-                                                                             >
-                                                                                 {benchmarkData[0].github_author.username}
-                                                                             </a>
-                                                                         )}
-                                                                     </span>
-                                                                 )}
-                                                             </div>
-                                                             <div className="flex items-center gap-1.5">
-                                                                 <span className="font-semibold text-slate-700 dark:text-slate-300">Status:</span>
-                                                                 {(() => {
-                                                                     const details = getSubmissionStatusDetails(benchmarkData[0]?.source_info?.submission_state);
-                                                                     return (
-                                                                         <span className={cn('px-1.5 py-0.5 rounded border text-[11px] font-bold whitespace-nowrap', details.bg, details.text, details.border)}>
-                                                                             {details.label}
-                                                                         </span>
-                                                                     );
-                                                                 })()}
-                                                             </div>
-                                                             {(benchmarkData[0]?.source_info?.submission_state === 'public' || benchmarkData[0]?.source_info?.submission_state === 'promoted' || benchmarkData[0]?.source_info?.approved_at) && (
-                                                                 <div className="flex items-center gap-1.5">
-                                                                     <span className="font-semibold text-slate-700 dark:text-slate-300">Approved:</span>
-                                                                     <span>{benchmarkData[0].source_info.approved_at ? new Date(benchmarkData[0].source_info.approved_at).toLocaleString() : (benchmarkData[0].source_info.submitted_at ? new Date(benchmarkData[0].source_info.submitted_at).toLocaleString() : 'Unknown')}</span>
-                                                                 </div>
-                                                             )}
-                                                         </div>
-                                                     ) : (
-                                                         <div className="flex-1" />
-                                                     )}
+                                                    <div className="flex justify-between items-center gap-4 mb-3 w-full">
+                                                        {(() => {
+                                                            const firstItem = benchmarkData[0] || {};
+                                                            const sourceInfo = firstItem.source_info || {};
+                                                            const rawSubmittedAt = sourceInfo.submitted_at || firstItem.timestamp || stat.timestamp;
+                                                            const formattedDate = (() => {
+                                                                if (!rawSubmittedAt) return null;
+                                                                const d = new Date(rawSubmittedAt);
+                                                                if (!isNaN(d.getTime())) {
+                                                                    return d.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+                                                                }
+                                                                const m = String(rawSubmittedAt).match(/(\d{4})(\d{2})(\d{2})-(\d{2})(\d{2})(\d{2})/);
+                                                                if (m) {
+                                                                    const parsedD = new Date(`${m[1]}-${m[2]}-${m[3]}T${m[4]}:${m[5]}:${m[6]}`);
+                                                                    if (!isNaN(parsedD.getTime())) {
+                                                                        return parsedD.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+                                                                    }
+                                                                }
+                                                                return String(rawSubmittedAt);
+                                                            })();
+
+                                                            const authorObj = firstItem.github_author || stat.github_author || sourceInfo.github_user;
+                                                            const authorUsername = typeof authorObj === 'object' ? authorObj?.username : (typeof authorObj === 'string' ? authorObj : null);
+
+                                                            return (
+                                                                <div className="inline-flex items-stretch rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-100/90 dark:bg-slate-900/60 text-xs text-slate-600 dark:text-slate-400 font-sans shadow-sm overflow-hidden h-8 flex-shrink-0">
+                                                                    <div className="px-2.5 py-1 flex items-center gap-2 whitespace-nowrap">
+                                                                        {formattedDate ? (
+                                                                            <span className="flex items-center gap-1">
+                                                                                <span className="text-slate-400 dark:text-slate-500 font-medium">Submitted</span>
+                                                                                <span className="font-semibold text-slate-700 dark:text-slate-300">{formattedDate}</span>
+                                                                            </span>
+                                                                        ) : (
+                                                                            <span className="text-slate-400 dark:text-slate-500 font-medium">Benchmark Run</span>
+                                                                        )}
+
+                                                                        {authorUsername && (
+                                                                            <span className="flex items-center gap-1 bg-slate-200/60 dark:bg-slate-800/80 px-1.5 py-0.5 rounded border border-slate-300/40 dark:border-slate-700/60">
+                                                                                <img 
+                                                                                    src={isPlaygroundMode
+                                                                                        ? `/api/avatar/${encodeURIComponent(authorUsername)}`
+                                                                                        : `https://github.com/${authorUsername}.png`} 
+                                                                                    alt={authorUsername} 
+                                                                                    className="w-3.5 h-3.5 rounded-full border border-slate-300 dark:border-slate-600 shrink-0"
+                                                                                    onError={(e) => { e.target.style.display = 'none'; }}
+                                                                                />
+                                                                                {isPlaygroundMode ? (
+                                                                                    <span className="text-indigo-600 dark:text-indigo-400 font-semibold text-[11px]">
+                                                                                        {authorUsername}
+                                                                                    </span>
+                                                                                ) : (
+                                                                                    <a 
+                                                                                        href={`https://github.com/${authorUsername}`}
+                                                                                        target="_blank" 
+                                                                                        rel="noopener noreferrer" 
+                                                                                        onClick={(e) => e.stopPropagation()}
+                                                                                        className="text-indigo-600 dark:text-indigo-400 hover:underline font-semibold text-[11px]"
+                                                                                    >
+                                                                                        {authorUsername}
+                                                                                    </a>
+                                                                                )}
+                                                                            </span>
+                                                                        )}
+                                                                    </div>
+                                                                    <button
+                                                                        type="button"
+                                                                        onClick={(e) => {
+                                                                            e.stopPropagation();
+                                                                            onOpenMetadataModal && onOpenMetadataModal(stat, benchmarkData);
+                                                                        }}
+                                                                        title="View full benchmark run metadata and lineage"
+                                                                        className="px-2.5 border-l border-slate-200 dark:border-slate-800 hover:bg-slate-200/80 dark:hover:bg-slate-800 text-slate-400 hover:text-cyan-400 transition-colors flex items-center justify-center cursor-pointer"
+                                                                    >
+                                                                        <Info size={13} />
+                                                                    </button>
+                                                                </div>
+                                                            );
+                                                        })()}
 
                                                      {canViewRaw && (
                                                          <div className="flex items-stretch gap-2 flex-shrink-0">
                                                              <div className="w-px bg-slate-300/70 dark:bg-slate-700/80 self-stretch my-0.5 mr-0.5" />
+                                                             {isBrv02 && (
+                                                                 <div className="relative group/fork-row-btn">
+                                                                     <Button
+                                                                         variant="secondary"
+                                                                         size="sm"
+                                                                         onClick={(e) => {
+                                                                             e.stopPropagation();
+                                                                             handleActionClick(() => handleForkSingle(stat, benchmarkData));
+                                                                         }}
+                                                                         disabled={isLocalActionPending}
+                                                                         className="h-full whitespace-nowrap animate-in fade-in duration-200 gap-1.5 flex items-center justify-center"
+                                                                     >
+                                                                         <GitFork size={13} />
+                                                                         Fork
+                                                                     </Button>
+                                                                     <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 px-3 py-2 bg-slate-900 border border-slate-800 text-slate-350 text-xs font-medium rounded-xl opacity-0 invisible group-hover/fork-row-btn:opacity-100 group-hover/fork-row-btn:visible transition-all duration-200 shadow-2xl z-[9999] w-64 pointer-events-none leading-relaxed text-center normal-case tracking-normal animate-in fade-in slide-in-from-bottom-2 duration-150">
+                                                                         Clone this benchmark into local staging to modify, coalesce, or republish.
+                                                                     </div>
+                                                                 </div>
+                                                             )}
                                                              {isBrv02 && (
                                                                  <Button
                                                                      variant="secondary"

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -368,10 +368,12 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                                         parsedStage.inference_tool = jsonPayload.inference_tool || null;
                                         parsedStage.inference_tool_version = jsonPayload.inference_tool_version || null;
                                         parsedStage.other_tools = jsonPayload.other_tools || null;
+                                        parsedStage.forked_from = jsonPayload.forked_from || null;
                                         parsedStage.payload = jsonPayload;
 
                                         const entry = stageToEntry(parsedStage);
                                         entry.run_id = jsonPayload.runId;
+                                        entry.forked_from = jsonPayload.forked_from || null;
                                         entry.manifests = jsonPayload.manifests || null;
                                         entry.evidence = jsonPayload.evidence || null;
                                         entry.run_metadata = jsonPayload.run_metadata || null;
@@ -644,6 +646,8 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
             }, groupingData[0] || {});
 
             const payload = groupingData[0]?.payload;
+            const forked_from = payload?.forked_from || groupingData.find(d => d.forked_from)?.forked_from || null;
+            const github_author = payload?.github_author || groupingData.find(d => d.github_author)?.github_author || null;
 
             stats.push({
                 benchmarkKey,
@@ -664,7 +668,9 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                 uniqueOsl,
                 peakRun,
                 nodesAndParallelismText,
-                payload
+                payload,
+                forked_from,
+                github_author
             });
         });
 

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import React, { useMemo } from 'react';
-import { Database, Eye, EyeOff, ArrowLeft, ArrowRight, MessageCircle, X, HelpCircle, Upload, UploadCloud, CheckCircle, Send, AlertCircle, Github, Shield, LogOut, ChevronDown, Trash2, Plus } from 'lucide-react';
+import { Database, Eye, EyeOff, ArrowLeft, ArrowRight, MessageCircle, X, HelpCircle, Upload, UploadCloud, CheckCircle, Send, AlertCircle, Github, Shield, LogOut, ChevronDown, Trash2, Plus, Sparkles } from 'lucide-react';
 import { FilterPanel } from './ManageBenchmarks/FilterPanel';
 import { UnifiedDataTable } from './ManageBenchmarks/UnifiedDataTable';
 import { INTEGRATIONS, getSourceTag, getBenchmarkKey, getBucket, getRatioType, getAcceleratorCount, getEffectiveTp, sortBuckets } from '../utils/dashboardHelpers';
@@ -49,7 +49,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
         setBaselineBenchmarkKey
     } = dashboardState;
 
-    const { isAuthenticated, user, login, logout, isConfigured, isLoading: authLoading } = useGitHubAuth();
+    const { isAuthenticated, user, login, logout, isConfigured, isPlaygroundMode, isLoading: authLoading } = useGitHubAuth();
     const [showUserDropdown, setShowUserDropdown] = React.useState(false);
     const userDropdownRef = React.useRef(null);
     const [showSourcesPopover, setShowSourcesPopover] = React.useState(false);
@@ -1129,6 +1129,17 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                     {authLoading ? (
                         <div className="flex items-center justify-center w-8 h-8 rounded-full border border-slate-850 bg-slate-900/40">
                             <Spinner size="sm" className="text-slate-400 dark:text-slate-400" />
+                        </div>
+                    ) : isPlaygroundMode ? (
+                        <div className="relative group/tooltip inline-flex items-center">
+                            <div className="inline-flex items-center gap-1.5 px-3.5 py-2 rounded-xl bg-amber-500/10 border border-transparent text-amber-300 text-xs font-semibold select-none cursor-help">
+                                <Sparkles size={13} className="text-amber-400 shrink-0" />
+                                <span>Playground Mode</span>
+                            </div>
+                            <div className="absolute right-0 top-full mt-2 px-3 py-2 bg-slate-900 border border-slate-800 text-slate-200 text-xs font-medium rounded-xl opacity-0 invisible group-hover/tooltip:opacity-100 group-hover/tooltip:visible transition-all duration-200 shadow-2xl z-[9999] w-72 pointer-events-none leading-relaxed text-left">
+                                <p className="font-semibold text-amber-300 mb-1">Playground Mode Active</p>
+                                Authentication is disabled. You can submit, review, approve, promote, and delete benchmarks in the Results Store without signing in.
+                            </div>
                         </div>
                     ) : !isConfigured ? (
                         <div className="relative group/tooltip inline-block">

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -2082,6 +2082,7 @@ export const useDashboardData = (initialState, dashboardState) => {
                             record.inference_tool = bundle.payload?.inference_tool || null;
                             record.inference_tool_version = bundle.payload?.inference_tool_version || null;
                             record.other_tools = bundle.payload?.other_tools || null;
+                            record.forked_from = bundle.payload?.forked_from || null;
                             record.bundle = bundle;
                             record.payload = bundle.payload || null;
                             record.targetDashboards = bundle.targetDashboards;
@@ -2117,6 +2118,7 @@ export const useDashboardData = (initialState, dashboardState) => {
                             record.inference_tool = bundle.payload?.inference_tool || null;
                             record.inference_tool_version = bundle.payload?.inference_tool_version || null;
                             record.other_tools = bundle.payload?.other_tools || null;
+                            record.forked_from = bundle.payload?.forked_from || null;
                             record.bundle = bundle;
                             record.payload = bundle.payload || null;
                             record.targetDashboards = bundle.targetDashboards;
@@ -2353,7 +2355,9 @@ export const useDashboardData = (initialState, dashboardState) => {
                 wellLitPath: item.well_lit_path || "none / custom",
                 submittedAt: item.submitted_at ? item.submitted_at.split('T')[0] : "Unknown",
                 status: mapStateToStatus(item.state),
-                feedback: item.feedback || ""
+                feedback: item.feedback || "",
+                forked_from: item.forked_from || null,
+                github_author: item.github_author || null
             }));
 
             const mergedList = [...serverSubmissions];
@@ -2373,7 +2377,9 @@ export const useDashboardData = (initialState, dashboardState) => {
                             wellLitPath: run.wellLitPath || "none / custom",
                             submittedAt: typeof submittedAt === 'string' ? submittedAt.split('T')[0] : new Date().toISOString().split('T')[0],
                             status: "staged",
-                            feedback: ""
+                            feedback: "",
+                            forked_from: run.forked_from || run.payload?.forked_from || null,
+                            github_author: run.github_author || run.payload?.github_author || null
                         });
                     }
                 });

--- a/src/hooks/useGCS.js
+++ b/src/hooks/useGCS.js
@@ -181,9 +181,11 @@ export const useGCS = ({ pendingRequests, addToast, accessToken }) => {
                                             parsedStage.inference_tool = jsonContent.inference_tool || null;
                                             parsedStage.inference_tool_version = jsonContent.inference_tool_version || null;
                                             parsedStage.other_tools = jsonContent.other_tools || null;
+                                            parsedStage.forked_from = jsonContent.forked_from || null;
                                             parsedStage.payload = jsonContent;
                                             const entry = stageToEntry(parsedStage);
                                             entry.payload = jsonContent;
+                                            entry.forked_from = jsonContent.forked_from || null;
                                             entry.manifests = jsonContent.manifests || null;
                                             entry.evidence = jsonContent.evidence || null;
                                             entry.run_metadata = jsonContent.run_metadata || null;

--- a/src/utils/benchmarkForker.js
+++ b/src/utils/benchmarkForker.js
@@ -1,0 +1,232 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { v4 as uuidv4 } from 'uuid';
+import { getRawPrismCloudPayload, resolveRunLabel } from './brv02Exporter.js';
+import { validateBenchmark } from './benchmarkValidator.js';
+
+/**
+ * Extracts and deep-clones a canonical PrismResultPayload from any benchmark stat/entry representation,
+ * generating a fresh staging UUID, attaching root provenance metadata in $.forked_from,
+ * re-indexing stage entries with unique UUIDs, and leaving raw_report dictionaries intact.
+ *
+ * @param {Object} runPayloadOrStat - A PrismResultPayload, table stat item, or local run object.
+ * @param {Array} [benchmarkData=[]] - Array of NormalizedBenchmarkEntry records for this benchmark.
+ * @param {Object} [options={}] - Optional overrides for original_run_id, source_bucket, etc.
+ * @returns {{ payload: Object, newRunId: string, forkDetail: Object }}
+ */
+export function forkBenchmarkPayload(runPayloadOrStat, benchmarkData = [], options = {}) {
+    if (!runPayloadOrStat && (!benchmarkData || benchmarkData.length === 0)) {
+        throw new Error('Missing benchmark data to fork.');
+    }
+
+    const rawPayload = getRawPrismCloudPayload(runPayloadOrStat, benchmarkData);
+    if (!rawPayload) {
+        throw new Error('Failed to extract canonical benchmark payload.');
+    }
+
+    // Deep clone canonical payload so original in-memory data is untouched
+    const payload = JSON.parse(JSON.stringify(rawPayload));
+
+    const firstEntry = Array.isArray(benchmarkData) && benchmarkData.length > 0 ? benchmarkData[0] : null;
+
+    // Resolve original run ID
+    const originalRunId = options.original_run_id ||
+        rawPayload.runId ||
+        runPayloadOrStat?.runId ||
+        runPayloadOrStat?.run_id ||
+        firstEntry?.run_id ||
+        firstEntry?.runId ||
+        firstEntry?.source_info?.run_id ||
+        uuidv4();
+
+    // Resolve original run label
+    const originalRunLabel = options.original_run_label ||
+        rawPayload.runLabel ||
+        resolveRunLabel(runPayloadOrStat, benchmarkData, []) ||
+        payload.model_name ||
+        'Benchmark Run';
+
+    // Resolve original author
+    const originalAuthor = options.original_author !== undefined
+        ? options.original_author
+        : (
+            rawPayload.github_author ||
+            firstEntry?.github_author ||
+            runPayloadOrStat?.github_author ||
+            runPayloadOrStat?.submitter ||
+            firstEntry?.source_info?.github_user ||
+            null
+        );
+
+    // Resolve original source bucket or prefix
+    const sourceBucket = options.source_bucket || (() => {
+        const rawSource = firstEntry?.source ||
+            runPayloadOrStat?.source ||
+            firstEntry?.source_info?.origin ||
+            rawPayload.source_bucket ||
+            '';
+
+        if (typeof rawSource === 'string') {
+            if (rawSource.startsWith('gcs:')) {
+                return rawSource.substring(4);
+            }
+            if (rawSource.startsWith('brv02:')) {
+                return 'staging';
+            }
+            if (rawSource) {
+                return rawSource;
+            }
+        }
+        return 'llm-d-benchmarks';
+    })();
+
+    const forkedAt = options.forked_at || new Date().toISOString();
+
+    /** @type {import('../../server/results/api').ForkDetail} */
+    const forkDetail = {
+        original_run_id: String(originalRunId),
+        original_run_label: String(originalRunLabel),
+        original_author: originalAuthor,
+        source_bucket: String(sourceBucket),
+        forked_at: String(forkedAt)
+    };
+
+    // Handle lineage chaining (multi-fork support)
+    const existingForked = payload.forked_from;
+    let nextForkedFrom;
+    if (existingForked) {
+        if (Array.isArray(existingForked)) {
+            nextForkedFrom = [...existingForked, forkDetail];
+        } else {
+            nextForkedFrom = [existingForked, forkDetail];
+        }
+    } else {
+        nextForkedFrom = forkDetail;
+    }
+    payload.forked_from = nextForkedFrom;
+
+    // Generate fresh staging UUID
+    const newRunId = options.newRunId || uuidv4();
+    payload.runId = newRunId;
+
+    // Ensure format is brv02
+    payload.format = 'brv02';
+
+    // Ensure entries have fresh run_id, synchronized description, but intact raw_report
+    if (Array.isArray(payload.entries)) {
+        payload.entries = payload.entries.map((entry, idx) => ({
+            ...entry,
+            run_id: uuidv4(),
+            run_description: payload.runLabel || originalRunLabel,
+            filename: entry.filename || `benchmark_report_v0.2,_stage_${entry.prism_stage_index ?? idx}_lifecycle_metrics.json.yaml`,
+            prism_stage_index: entry.prism_stage_index !== undefined ? entry.prism_stage_index : idx,
+            raw_report: entry.raw_report
+        }));
+    }
+
+    // Reset review / submission lifecycle metadata
+    delete payload.submitted_at;
+    delete payload.review;
+    delete payload.feedback;
+    delete payload.github_author;
+    payload.submission_state = 'staged';
+
+    return {
+        payload,
+        newRunId,
+        forkDetail
+    };
+}
+
+/**
+ * Builds a staging workspace bundle from a forked PrismResultPayload.
+ *
+ * @param {Object} forkedPayload - The forked PrismResultPayload object.
+ * @param {Object} [rawRunStat=null] - Optional reference to the source stat item.
+ * @returns {Object} Staged bundle object suitable for handleValidatedUpload and SubmitValidationPage.
+ */
+export function buildForkedBundle(forkedPayload, rawRunStat = null) {
+    const newRunId = forkedPayload.runId;
+
+    const stageFiles = (forkedPayload.entries || []).map((entry, idx) => {
+        const rawContent = typeof entry.raw_report === 'object'
+            ? JSON.stringify(entry.raw_report)
+            : (entry.raw_report || '');
+
+        const filename = entry.filename || `benchmark_report_v0.2,_stage_${entry.prism_stage_index ?? idx}_lifecycle_metrics.json.yaml`;
+
+        return {
+            file: {
+                name: filename,
+                webkitRelativePath: `${newRunId}/${filename}`
+            },
+            content: rawContent,
+            validation: validateBenchmark(rawContent, filename)
+        };
+    });
+
+    const metadataFiles = {
+        run_metadata: forkedPayload.run_metadata ? {
+            file: { name: 'run_metadata.json' },
+            content: JSON.stringify(forkedPayload.run_metadata),
+            parsed: forkedPayload.run_metadata
+        } : null,
+        config: forkedPayload.config ? {
+            file: { name: 'config.json' },
+            content: JSON.stringify(forkedPayload.config),
+            parsed: forkedPayload.config
+        } : null
+    };
+
+    const bundleValidation = {
+        format: 'brv02',
+        isValid: true,
+        errors: [],
+        warnings: [],
+        dcoChecked: true
+    };
+
+    return {
+        id: Math.random().toString(36).substring(7),
+        dirKey: newRunId,
+        name: forkedPayload.runLabel,
+        stageFiles,
+        metadataFiles,
+        payload: forkedPayload,
+        validation: bundleValidation,
+        isExpanded: true,
+        isSkipped: false,
+        targetDashboards: rawRunStat?.targetDashboards || ['performance-browser']
+    };
+}
+
+/**
+ * Convenience helper that forks a benchmark and returns both the payload and the staging bundle.
+ *
+ * @param {Object} runPayloadOrStat - The benchmark stat or payload to fork.
+ * @param {Array} [benchmarkData=[]] - The benchmark stage records.
+ * @param {Object} [options={}] - Additional options for forking.
+ * @returns {{ payload: Object, bundle: Object, newRunId: string, forkDetail: Object }}
+ */
+export function forkBenchmark(runPayloadOrStat, benchmarkData = [], options = {}) {
+    const { payload, newRunId, forkDetail } = forkBenchmarkPayload(runPayloadOrStat, benchmarkData, options);
+    const bundle = buildForkedBundle(payload, runPayloadOrStat);
+    return {
+        payload,
+        bundle,
+        newRunId,
+        forkDetail
+    };
+}

--- a/src/utils/benchmarkForker.test.js
+++ b/src/utils/benchmarkForker.test.js
@@ -1,0 +1,229 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import assert from 'node:assert';
+import { v4 as uuidv4 } from 'uuid';
+import { forkBenchmarkPayload, forkBenchmark } from './benchmarkForker.js';
+import { getRawPrismCloudPayload } from './brv02Exporter.js';
+import { PrismResultPayloadSchema } from '../../server/results/api.ts';
+import { validatePrismUploadStructure } from './benchmarkValidator.js';
+
+console.log('Running benchmark forking unit tests...');
+
+// 1. Single Benchmark Forking Test
+const originalRunId = uuidv4();
+const originalEntryRunId = uuidv4();
+const sampleStat = {
+    benchmarkKey: `gcs:team-bucket:${originalRunId}`,
+    model: "meta-llama/Llama-3.1-70B-Instruct",
+    hardware: "H100",
+    accelerator_count: 8,
+    data: [
+        {
+            run_id: originalRunId,
+            model: "meta-llama/Llama-3.1-70B-Instruct",
+            source: "gcs:team-bucket",
+            source_info: {
+                type: "benchmark_report_v02",
+                bucket: "team-bucket",
+                submission_state: "public",
+                submitted_at: "2026-08-01T10:00:00Z"
+            },
+            github_author: {
+                username: "octocat",
+                name: "Mona Lisa Octocat"
+            },
+            payload: {
+                runId: originalRunId,
+                runLabel: "Team Benchmark Baseline",
+                model_name: "meta-llama/Llama-3.1-70B-Instruct",
+                hardware: {
+                    hardware_name: "H100",
+                    accelerator_count: 8
+                },
+                format: "brv02",
+                submission_state: "public",
+                submitted_at: "2026-08-01T10:00:00Z",
+                github_author: {
+                    username: "octocat",
+                    name: "Mona Lisa Octocat"
+                },
+                entries: [
+                    {
+                        run_id: originalEntryRunId,
+                        run_description: "Team Benchmark Baseline",
+                        filename: "stage_0_report.yaml",
+                        prism_stage_index: 0,
+                        raw_report: {
+                            version: "0.2",
+                            workload: { stage: 0 },
+                            scenario: { model: "meta-llama/Llama-3.1-70B-Instruct" },
+                            results: {
+                                request_performance: {
+                                    aggregate: {
+                                        throughput: { output_token_rate: { mean: 128.5 } },
+                                        latency: { request_latency: { mean: 0.25 }, time_to_first_token: { mean: 0.05 } }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
+            }
+        }
+    ]
+};
+
+const { payload: forkedPayload, newRunId, forkDetail: singleForkDetail } = forkBenchmarkPayload(sampleStat, sampleStat.data);
+
+// 1.1 Fresh UUIDs generated
+assert.ok(forkedPayload.runId, "Forked payload must have a runId");
+assert.strictEqual(forkedPayload.runId, newRunId, "Returned newRunId must match payload.runId");
+assert.notStrictEqual(forkedPayload.runId, originalRunId, "Forked runId must be freshly generated");
+assert.ok(forkedPayload.entries[0].run_id, "Forked entry must have a run_id");
+assert.notStrictEqual(forkedPayload.entries[0].run_id, originalEntryRunId, "Forked entry run_id must be freshly generated");
+
+// 1.2 State reset to local staging
+assert.strictEqual(forkedPayload.submission_state, "staged", "Forked submission_state must be 'staged'");
+assert.strictEqual(forkedPayload.submitted_at, undefined, "submitted_at must be stripped");
+assert.strictEqual(forkedPayload.github_author, undefined, "github_author must be stripped");
+assert.strictEqual(forkedPayload.review, undefined, "review must be stripped");
+assert.strictEqual(forkedPayload.feedback, undefined, "feedback must be stripped");
+
+// 1.3 Provenance metadata populated in root $.forked_from
+assert.ok(forkedPayload.forked_from, "Root $.forked_from must be defined");
+const forkDetail = Array.isArray(forkedPayload.forked_from) ? forkedPayload.forked_from[0] : forkedPayload.forked_from;
+assert.strictEqual(forkDetail.original_run_id, originalRunId);
+assert.strictEqual(forkDetail.original_run_label, "Team Benchmark Baseline");
+assert.strictEqual(forkDetail.source_bucket, "team-bucket");
+assert.deepStrictEqual(forkDetail.original_author, { username: "octocat", name: "Mona Lisa Octocat" });
+assert.ok(forkDetail.forked_at, "forked_at must be an ISO timestamp");
+assert.deepStrictEqual(forkDetail, singleForkDetail);
+
+// 1.4 Raw reports remain intact and unmodified
+assert.deepStrictEqual(
+    forkedPayload.entries[0].raw_report,
+    sampleStat.data[0].payload.entries[0].raw_report,
+    "Raw report dictionary must remain strictly intact"
+);
+
+// 1.5 Zod & structure validation tests
+const zodResult = PrismResultPayloadSchema.safeParse(forkedPayload);
+assert.strictEqual(zodResult.success, true, `Zod schema validation failed: ${JSON.stringify(zodResult.error?.issues)}`);
+
+const structValidation = validatePrismUploadStructure(forkedPayload, { isUpload: false });
+assert.strictEqual(structValidation.isValid, true, `Structure validation failed: ${structValidation.errors?.join(', ')}`);
+
+// 2. Lineage Chaining Test (Forking an already forked benchmark)
+const secondStat = {
+    benchmarkKey: `brv02:${forkedPayload.runId}`,
+    payload: forkedPayload,
+    data: [
+        {
+            run_id: forkedPayload.runId,
+            source: `brv02:${forkedPayload.runId}`,
+            source_info: {
+                type: "benchmark_report_v02",
+                bucket: "custom-writable-bucket"
+            },
+            github_author: { username: "contributor2" },
+            payload: forkedPayload
+        }
+    ]
+};
+
+const { payload: secondForkedPayload } = forkBenchmarkPayload(secondStat, secondStat.data);
+
+assert.ok(Array.isArray(secondForkedPayload.forked_from), "Re-forked benchmark should have an array forked_from lineage");
+assert.strictEqual(secondForkedPayload.forked_from.length, 2, "Lineage should chain both origins");
+assert.strictEqual(secondForkedPayload.forked_from[0].original_run_id, originalRunId);
+assert.strictEqual(secondForkedPayload.forked_from[1].original_run_id, forkedPayload.runId);
+
+const zodResult2 = PrismResultPayloadSchema.safeParse(secondForkedPayload);
+assert.strictEqual(zodResult2.success, true, `Zod validation failed for array forked_from: ${JSON.stringify(zodResult2.error?.issues)}`);
+
+// 3. Bundle Builder & forkBenchmark Function Test
+const { bundle, payload: resultPayload } = forkBenchmark(sampleStat, sampleStat.data);
+assert.ok(bundle, "forkBenchmark must return a bundle");
+assert.ok(resultPayload, "forkBenchmark must return payload");
+assert.strictEqual(bundle.payload.runId, resultPayload.runId);
+assert.strictEqual(bundle.validation.isValid, true);
+assert.ok(bundle.stageFiles.length > 0, "bundle should contain stageFiles");
+
+// 4. Raw payload reconstruction preserves forked_from
+const reconstructedSingle = getRawPrismCloudPayload(secondStat, secondStat.data);
+assert.ok(reconstructedSingle.forked_from, "getRawPrismCloudPayload must preserve single forked_from");
+assert.strictEqual(reconstructedSingle.forked_from.original_run_id, originalRunId);
+
+const reconstructedChained = getRawPrismCloudPayload({ data: [{ forked_from: secondForkedPayload.forked_from, raw_report: {} }] });
+assert.ok(Array.isArray(reconstructedChained.forked_from), "getRawPrismCloudPayload must preserve chained array forked_from");
+assert.strictEqual(reconstructedChained.forked_from.length, 2);
+
+// 5. Submission payload construction preserves forked_from and validates against schema
+const submissionPayload = {
+    runId: bundle.payload.runId,
+    runLabel: bundle.name,
+    model_name: bundle.payload.model_name,
+    hardware: bundle.payload.hardware,
+    forked_from: bundle.payload.forked_from,
+    format: "brv02",
+    entries: bundle.payload.entries.map(e => ({
+        run_id: e.run_id,
+        run_description: bundle.name,
+        filename: e.filename,
+        raw_report: e.raw_report
+    }))
+};
+const submissionZod = PrismResultPayloadSchema.safeParse(submissionPayload);
+assert.strictEqual(submissionZod.success, true, `Submission payload schema validation failed: ${JSON.stringify(submissionZod.error?.issues)}`);
+
+// 6. Test groupStagesIntoRuns and stageToEntry preserve forked_from
+import { groupStagesIntoRuns, stageToEntry } from './benchmarkReportV02Parser.js';
+import { PrismResultContextSchema } from '../../server/results/api.ts';
+
+const groupedRuns = groupStagesIntoRuns([
+    {
+        runId: forkedPayload.runId,
+        runLabel: "Forked Run",
+        filename: "stage_0_report.yaml",
+        model_name: "meta-llama/Llama-3.1-70B-Instruct",
+        forked_from: forkedPayload.forked_from,
+        github_author: { username: "author1" },
+        scenario: { model: "meta-llama/Llama-3.1-70B-Instruct", hardware: "H100" },
+        performance: { outputTokenRate: 100, e2eMean: 0.2, ttftMean: 0.05 },
+        rawReport: {}
+    }
+]);
+assert.strictEqual(groupedRuns.length, 1);
+assert.ok(groupedRuns[0].forked_from, "groupStagesIntoRuns must preserve forked_from");
+assert.strictEqual(groupedRuns[0].forked_from.original_run_id, originalRunId);
+assert.strictEqual(groupedRuns[0].github_author.username, "author1");
+
+const entry = stageToEntry(groupedRuns[0].stages[0]);
+assert.ok(entry.forked_from, "stageToEntry must preserve forked_from");
+assert.strictEqual(entry.forked_from.original_run_id, originalRunId);
+
+// 7. Test PrismResultContextSchema accepts boolean forked flag
+const contextValidation = PrismResultContextSchema.safeParse({
+    submission_state: { value: "submitted_pending_review" },
+    github_user: { value: "octocat" },
+    run_id: { value: forkedPayload.runId },
+    hardware_name: { value: "H100" },
+    model_name: { value: "meta-llama/Llama-3.1-70B-Instruct" },
+    run_label: { value: "Forked Run" },
+    forked: { value: "true" }
+});
+assert.strictEqual(contextValidation.success, true, "PrismResultContextSchema must accept forked");
+
+console.log('All benchmark forking unit tests passed successfully!');

--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -433,6 +433,8 @@ export function groupStagesIntoRuns(stageRecords) {
                 other_tools: record.other_tools || null,
                 payload: record.payload || null,
                 bundle: record.bundle || null,
+                forked_from: record.forked_from || record.payload?.forked_from || null,
+                github_author: record.github_author || record.payload?.github_author || null,
                 targetDashboards: record.targetDashboards || []
             };
             runsList.push(targetRun);
@@ -457,6 +459,8 @@ export function groupStagesIntoRuns(stageRecords) {
         if (!targetRun.other_tools && record.other_tools) targetRun.other_tools = record.other_tools;
         if (!targetRun.payload && record.payload) targetRun.payload = record.payload;
         if (!targetRun.bundle && record.bundle) targetRun.bundle = record.bundle;
+        if (!targetRun.forked_from && (record.forked_from || record.payload?.forked_from)) targetRun.forked_from = record.forked_from || record.payload?.forked_from;
+        if (!targetRun.github_author && (record.github_author || record.payload?.github_author)) targetRun.github_author = record.github_author || record.payload?.github_author;
         if (!targetRun.targetDashboards && record.targetDashboards) targetRun.targetDashboards = record.targetDashboards;
     }
     
@@ -570,6 +574,7 @@ export function stageToEntry(stage) {
 
     return createEntry({
         payload: stage.payload || null,
+        forked_from: stage.forked_from || stage.payload?.forked_from || null,
         run_id: stage.runId,
         runLabel: stage.runLabel || '',
         github_author: stage.github_author,

--- a/src/utils/brv02Exporter.js
+++ b/src/utils/brv02Exporter.js
@@ -384,6 +384,20 @@ export function getRawPrismCloudPayload(runPayloadOrStat, benchmarkData = []) {
         };
     });
 
+    const forked_from = runPayloadOrStat?.forked_from 
+        || runPayloadOrStat?.payload?.forked_from 
+        || runPayloadOrStat?.bundle?.payload?.forked_from
+        || first?.forked_from 
+        || first?.payload?.forked_from
+        || null;
+
+    const github_author = runPayloadOrStat?.github_author 
+        || runPayloadOrStat?.payload?.github_author 
+        || runPayloadOrStat?.bundle?.payload?.github_author
+        || first?.github_author 
+        || first?.payload?.github_author
+        || (runPayloadOrStat?.submitter ? { username: runPayloadOrStat.submitter } : null);
+
     return {
         runId: rawRunId,
         runLabel,
@@ -393,6 +407,8 @@ export function getRawPrismCloudPayload(runPayloadOrStat, benchmarkData = []) {
             ...(acceleratorCount ? { accelerator_count: Number(acceleratorCount) } : {})
         },
         format: 'brv02',
+        ...(forked_from ? { forked_from } : {}),
+        ...(github_author ? { github_author } : {}),
         well_lit_path: runPayloadOrStat.well_lit_path || first.well_lit_path || null,
         inference_tool: runPayloadOrStat.inference_tool || first.inference_tool || null,
         inference_tool_version: runPayloadOrStat.inference_tool_version || first.inference_tool_version || null,


### PR DESCRIPTION
## What does this PR do?

This PR introduces three core capabilities to streamline local development, meet the operational needs of internal benchmarking teams hosting private Prism instances, and enable interactive curation of read-only benchmark catalogs.

### Configurable Results Store Destination & Bucket Prefix Scoping

Previously, Prism coupled the writable Results Store destination directly to the first entry of `DEFAULT_BUCKETS`. This made it difficult for deployments to separate immutable read-only catalog mirrors from the primary storage bucket used for interactive submissions and reviews.

This change introduces the `RESULTS_STORE_BUCKET` environment variable, allowing operators to explicitly configure the writable GCS bucket and directory prefix used for benchmark ingestion, state transitions, deletions, and IAM allowlists. In addition:

- The bucket parser (`server/buckets.js`) now supports path prefix scoping (e.g., `my-bucket/custom` alongside `my-bucket/mirror`), enabling multiple logical stores within a single physical GCS bucket.
- Any entries in `DEFAULT_BUCKETS` that match `RESULTS_STORE_BUCKET` are automatically deduplicated from the external catalog list.
- If `RESULTS_STORE_BUCKET` is not explicitly set, Prism gracefully falls back to `DEFAULT_BUCKETS[0]` (and then `llm-d-benchmarks`), maintaining full backward compatibility.

### Results Store Playground Mode (`RESULTS_STORE_PLAYGROUND_MODE=1`)

To address the needs of internal enterprise teams (such as teams at Google running private Prism instances) and streamline local development, this PR introduces Playground Mode via the `RESULTS_STORE_PLAYGROUND_MODE` configuration flag.

In internal environments, benchmark runs are frequently generated and uploaded by automated continuous benchmarking pipelines or background CI/CD jobs rather than public open-source contributors. Enforcing GitHub OAuth applications, callback URL configurations, client secrets, and DCO sign-offs introduces unnecessary operational friction when perimeter authentication or upstream access controls are already in place.

When `RESULTS_STORE_PLAYGROUND_MODE=1` is active:

- **Zero External OAuth Calls**: The session endpoint (`GET /api/auth/github/me`) immediately synthesizes an active administrative session, allowing full access to submit, review, approve, promote, reject, and delete benchmarks within `RESULTS_STORE_BUCKET`.
- **Strict Storage Boundaries**: Mutation requests are strictly confined to `RESULTS_STORE_BUCKET/prism-results-store/*`. All catalog buckets in `DEFAULT_BUCKETS` and IAM configuration files in `prism-iam/*` remain permanently read-only and return `403 Forbidden` on any write or delete attempts.
- **Tailored UI & Contributor Attribution**: The GitHub sign-in button is replaced by a subtle yellow-accented "Playground Mode" indicator with an explanatory tooltip. Contributor handles are rendered as plain text (avoiding dead GitHub profile links), and avatars are generated deterministically via a new SVG identicon endpoint (`/api/avatar/:seed`).
- **Streamlined Submissions**: In the submission dialog, submitters can provide an arbitrary author name (defaulting to "anonymous"), submissions are marked with `playground: true` / `playground_submitted: "true"`, and DCO sign-off checkboxes are omitted.
- **Pending Benchmarks Filter**: The "My Benchmarks" KPI card and filter tab in the Results Store are dynamically renamed to "Pending Benchmarks", allowing operators to view and manage all runs in non-public review states (`staged`, `unlisted`, `submitted_pending_processing`, `submitted_pending_review`, `rejected`).

### Benchmark Forking & Read-Only Source Republishing

Automated benchmarking harnesses often write directly into read-only catalog mirrors governed by strict GCS IAM policies. While these automated runs provide valuable raw performance data, the harnesses typically do not collect enough contextual metadata for Prism to automatically group relevant runs together, necessitating human intervention. Because read-only GCS IAM policies prevent modifying these catalog benchmarks directly in-place, the intended workflow is for users to fork automated results into browser staging and curate them into meaningful, structured benchmark datasets entirely within Prism.

Benchmark Forking bridges immutable catalog storage into the browser-local Staging Workspace:

- Users can click "Fork" on any single benchmark card or select multiple runs from the floating action bar to clone them into local staging.
- The cloning engine (`src/utils/benchmarkForker.js`) assigns fresh staging UUIDs, re-indexes stage entries while preserving raw BRV0.2 payloads, and injects structured root provenance metadata (`$.forked_from`) capturing original run IDs, labels, authors, source buckets, and timestamps.
- Once staged, users can freely edit metadata, reorder stages, and coalesce related runs together into cohesive multi-stage latency/throughput curves.
- The curated runs can then be published directly to the writable `RESULTS_STORE_BUCKET`.
- Forked runs are visually identified in the UI by a small blue "Forked" badge indicator with hover popovers detailing ancestral provenance.

### Compact Benchmark Detail Card Header & Metadata Modal

To maximize screen real estate for comparison curves, metric charts, and data tables, the benchmark detail card header has been redesigned:

- The previous multi-line metadata banner is replaced with a compact, unified pill displaying the submission date and author.
- A joined info button opens a comprehensive metadata dialog displaying hardware configuration, engine versions, runtime flags, and provenance details on demand.

### Production Environment Variable Changes & Hosting Internal Prism

```sh
# Primary writable GCS bucket and optional prefix for submissions, reviews, and IAM.
# Defaults to DEFAULT_BUCKETS[0] or 'llm-d-benchmarks'.
RESULTS_STORE_BUCKET=llm-d-benchmarks

# Disables GitHub OAuth; grants anonymous admin access over RESULTS_STORE_BUCKET.
# Set to 1/true/yes/on to enable. Defaults to 0 (production) and 1 (docker-compose.yml).
RESULTS_STORE_PLAYGROUND_MODE=0

# Comma-separated read-only catalog buckets/prefixes to display alongside the Results Store.
# Entries matching RESULTS_STORE_BUCKET are automatically deduplicated.
DEFAULT_BUCKETS=llm-d-benchmarks
```

#### What Operators & Developers Need to Know When Updating Internal Instances

1. **Explicitly Configure `RESULTS_STORE_BUCKET`**: Operators should explicitly set `RESULTS_STORE_BUCKET` in their deployment configurations (e.g. `-rsb <bucket>` in `deploy.sh` or `.deploy_config`). If hosting private instances with both read-only harness outputs and curated submissions, define separate destinations (e.g. `RESULTS_STORE_BUCKET=internal-prism/curated` and `DEFAULT_BUCKETS=internal-prism/harness-mirror`).
2. **Select Authentication Mode for Internal Teams**: For internal enterprise deployments where user access is managed by corporate network firewalls/SSO and benchmarks are produced by automated pipelines, enable `RESULTS_STORE_PLAYGROUND_MODE=1` to eliminate GitHub App dependencies and DCO friction. For public-facing instances requiring verified GitHub contributor identities, leave Playground Mode disabled and supply `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`.
3. **Prefix Scoping Support**: Internal teams sharing a single underlying GCS bucket can now namespace their data cleanly by using subpath prefixes in `RESULTS_STORE_BUCKET` and `DEFAULT_BUCKETS` without provisioning multiple physical cloud storage buckets (introduced in #118; special thanks to Brendan Slabe @bslabe123!).

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [ ] Tests pass locally (`make test`)
- [x] Linters pass (`make lint`)
- [x] Documentation updated (if applicable)

## Related Issues

- Related to #118
