### PR TITLE
Fix Results Store sharing deep links and adopt Vitest for unit tests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,8 +17,8 @@
 
 - [ ] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
 - [ ] Code follows project [contributing guidelines](CONTRIBUTING.md)
-- [ ] Tests pass locally (`make test`)
-- [ ] Linters pass (`make lint`)
+- [ ] Tests pass locally (`npm test`)
+- [ ] Linters pass (`npm run lint`)
 - [ ] Documentation updated (if applicable)
 
 ## Related Issues

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Prism helps you choose, configure and optimize the right AI inference infrastruc
 - **Styling:** Vanilla CSS (Tailwind CSS v4 for utility-first components)
 - **Charts:** Recharts
 - **Icons:** Lucide React
+- **Testing:** Vitest
 - **Language:** JavaScript (ESNext)
 - **Cloud:** Google Cloud (GCS, GIQ), AWS (S3)
 
@@ -74,6 +75,29 @@ The development environment can be managed using Docker Compose, which mounts th
    ```bash
    docker compose logs -f
    ```
+
+### Testing & Verification
+
+Unit tests are written with [Vitest](https://vitest.dev/) and cover frontend utility modules, parsers, and backend server routing/bucket logic.
+
+- **Run all unit tests once**:
+  ```bash
+  npm test
+  # Or within Docker Compose:
+  docker compose exec app npm test
+  ```
+- **Run unit tests in watch mode**:
+  ```bash
+  npm run test:watch
+  # Or within Docker Compose:
+  docker compose exec app npm run test:watch
+  ```
+- **Run linting**:
+  ```bash
+  npm run lint
+  # Or within Docker Compose:
+  docker compose exec app npm run lint
+  ```
 
 ### Cloud Deployment (Google Cloud Run)
 
@@ -215,6 +239,7 @@ The project uses a standard `.npmrc` to enforce the public npm registry (`https:
 # Developer Guidelines
 
 - **Running Locally:** Run `npm run dev`.
+- **Testing:** Run unit tests via `npm test` (or `docker compose exec app npm test`). Run `npm run test:watch` for interactive test-driven development.
 - **Parsing Logic:** Data ingestion logic resides in `src/utils/dataParser.js` and files specific to the data source.
   - **Hardware Metadata:** The parser extracts `accelerator` (e.g., `tpu7x`) and configuration details (tensor parallel size, backend) from `manifest.yaml` when available in GCS/S3 sources.
   - **Source Identification:** Benchmarks are tagged with standardized IDs: `infperf` (inference-perf (deprecated)), `quality_scores` (Model Quality), `llm-d-results:google_drive` / `llmd_drive` (DRIVE), and `brv02:<run-uid>` (local Benchmark Report v0.2 uploads).

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,8 @@
         "tailwindcss": "^4.1.17",
         "typescript": "^5.5.4",
         "typescript-eslint": "^8.5.0",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^4.1.11"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1668,6 +1669,17 @@
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
       "license": "MIT"
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "license": "MIT"
@@ -1711,6 +1723,13 @@
     },
     "node_modules/@types/d3-timer": {
       "version": "3.0.2",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2083,6 +2102,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.11.tgz",
+      "integrity": "sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.11.tgz",
+      "integrity": "sha512-2XJVD55d1o5AZous5CCGKS74g/riOj9odEt2bQpCVZeblHyHdnMeFl4jl0XjU21stf4mbjUkew2eXQZt65g5CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.11",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.11.tgz",
+      "integrity": "sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.11.tgz",
+      "integrity": "sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.11",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.11.tgz",
+      "integrity": "sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.11.tgz",
+      "integrity": "sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.11.tgz",
+      "integrity": "sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.11",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -2205,6 +2337,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async-retry": {
@@ -2441,6 +2583,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -2883,6 +3035,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "license": "MIT",
@@ -3134,6 +3293,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "dev": true,
@@ -3161,6 +3330,16 @@
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
     },
     "node_modules/express": {
       "version": "4.22.1",
@@ -4384,6 +4563,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "license": "MIT",
@@ -4506,6 +4699,13 @@
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -4994,6 +5194,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "license": "BSD-3-Clause",
@@ -5001,12 +5208,26 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -5185,6 +5406,23 @@
       "version": "1.3.3",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "license": "MIT",
@@ -5197,6 +5435,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -5957,6 +6205,96 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.11.tgz",
+      "integrity": "sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.11",
+        "@vitest/mocker": "4.1.11",
+        "@vitest/pretty-format": "4.1.11",
+        "@vitest/runner": "4.1.11",
+        "@vitest/snapshot": "4.1.11",
+        "@vitest/spy": "4.1.11",
+        "@vitest/utils": "4.1.11",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.11",
+        "@vitest/browser-preview": "4.1.11",
+        "@vitest/browser-webdriverio": "4.1.11",
+        "@vitest/coverage-istanbul": "4.1.11",
+        "@vitest/coverage-v8": "4.1.11",
+        "@vitest/ui": "4.1.11",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "license": "BSD-2-Clause"
@@ -5981,6 +6319,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -8,6 +8,8 @@
     "dev": "concurrently \"tsx watch server/server.js\" \"vite --host\"",
     "build": "vite build",
     "start": "tsx server/server.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
     "type-check": "tsc --noEmit",
     "lint": "eslint .",
     "preview": "vite preview",
@@ -51,7 +53,8 @@
     "tailwindcss": "^4.1.17",
     "typescript": "^5.5.4",
     "typescript-eslint": "^8.5.0",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^4.1.11"
   },
   "overrides": {
     "path-to-regexp": "0.1.13"

--- a/server/buckets.js
+++ b/server/buckets.js
@@ -80,9 +80,9 @@ export function getConfiguredBucketEntries(
     rawResultsStoreBucket = process.env.RESULTS_STORE_BUCKET
 ) {
     const defaultFallback = rawResultsStoreBucket || DEFAULT_RESULTS_BUCKETS;
-    const raw = rawBuckets !== undefined && rawBuckets !== ''
+    const raw = (rawBuckets !== undefined && rawBuckets !== '')
         ? rawBuckets
-        : (process.env.DEFAULT_BUCKETS || defaultFallback);
+        : defaultFallback;
     return raw
         .split(',')
         .map(e => e.trim())

--- a/server/buckets.test.js
+++ b/server/buckets.test.js
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { describe, it, expect } from 'vitest';
 import {
     parseBucketEntry,
     getResultsStoreBucket,
@@ -20,91 +21,90 @@ import {
     DEFAULT_RESULTS_STORE_BUCKET,
     DEFAULT_RESULTS_BUCKETS
 } from './buckets.js';
-import assert from 'node:assert';
 
-console.log('Running buckets unit tests...');
+describe('buckets configuration & parsing', () => {
+    it('parses bare bucket names correctly with parseBucketEntry', () => {
+        expect(parseBucketEntry('my-bucket')).toEqual({ bucket: 'my-bucket', prefix: '' });
+        expect(parseBucketEntry(' my-bucket ')).toEqual({ bucket: 'my-bucket', prefix: '' });
+        expect(parseBucketEntry('gs://my-bucket/')).toEqual({ bucket: 'my-bucket', prefix: '' });
+        expect(parseBucketEntry('')).toEqual({ bucket: '', prefix: '' });
+        expect(parseBucketEntry(null)).toEqual({ bucket: '', prefix: '' });
+    });
 
-// 1. parseBucketEntry: bare bucket names
-assert.deepStrictEqual(parseBucketEntry('my-bucket'), { bucket: 'my-bucket', prefix: '' });
-assert.deepStrictEqual(parseBucketEntry(' my-bucket '), { bucket: 'my-bucket', prefix: '' });
-assert.deepStrictEqual(parseBucketEntry('gs://my-bucket/'), { bucket: 'my-bucket', prefix: '' });
-assert.deepStrictEqual(parseBucketEntry(''), { bucket: '', prefix: '' });
-assert.deepStrictEqual(parseBucketEntry(null), { bucket: '', prefix: '' });
+    it('parses path-scoped bucket entries with trailing-slash prefix', () => {
+        expect(parseBucketEntry('my-bucket/team-a')).toEqual({ bucket: 'my-bucket', prefix: 'team-a/' });
+        expect(parseBucketEntry('my-bucket/team-a/results/')).toEqual({ bucket: 'my-bucket', prefix: 'team-a/results/' });
+        expect(parseBucketEntry('gs://my-bucket/team-a/')).toEqual({ bucket: 'my-bucket', prefix: 'team-a/' });
+        expect(parseBucketEntry('my-bucket//team-a//')).toEqual({ bucket: 'my-bucket', prefix: 'team-a/' });
+    });
 
-// 2. parseBucketEntry: path-scoped entries yield a normalized trailing-slash prefix
-assert.deepStrictEqual(parseBucketEntry('my-bucket/team-a'), { bucket: 'my-bucket', prefix: 'team-a/' });
-assert.deepStrictEqual(parseBucketEntry('my-bucket/team-a/results/'), { bucket: 'my-bucket', prefix: 'team-a/results/' });
-assert.deepStrictEqual(parseBucketEntry('gs://my-bucket/team-a/'), { bucket: 'my-bucket', prefix: 'team-a/' });
-assert.deepStrictEqual(parseBucketEntry('my-bucket//team-a//'), { bucket: 'my-bucket', prefix: 'team-a/' });
+    it('resolves Results Store bucket with default and custom values', () => {
+        expect(DEFAULT_RESULTS_STORE_BUCKET).toBe('llm-d-benchmarks');
+        expect(getResultsStoreBucket('', '')).toBe('llm-d-benchmarks');
+        expect(getResultsStoreBucket('custom-results-bucket', '')).toBe('custom-results-bucket');
+        expect(getResultsStoreBucket('gs://custom-results-bucket/', '')).toBe('custom-results-bucket');
+        expect(getResultsStoreBucket('gs://custom-results-bucket/subpath', '')).toBe('custom-results-bucket');
+    });
 
-// 3. getResultsStoreBucket: default and custom values
-assert.strictEqual(DEFAULT_RESULTS_STORE_BUCKET, 'llm-d-benchmarks');
-assert.strictEqual(getResultsStoreBucket(undefined), 'llm-d-benchmarks');
-assert.strictEqual(getResultsStoreBucket(''), 'llm-d-benchmarks');
-assert.strictEqual(getResultsStoreBucket('custom-results-bucket'), 'custom-results-bucket');
-assert.strictEqual(getResultsStoreBucket('gs://custom-results-bucket/'), 'custom-results-bucket');
-assert.strictEqual(getResultsStoreBucket('gs://custom-results-bucket/subpath'), 'custom-results-bucket');
+    it('handles development configuration (staging & production buckets)', () => {
+        expect(
+            getConfiguredBucketEntries('llm-d-benchmarks,llm-d-benchmarks-staging', 'llm-d-benchmarks')
+        ).toEqual(['llm-d-benchmarks', 'llm-d-benchmarks-staging']);
 
-// 4. Dev config: RESULTS_STORE_BUCKET=llm-d-benchmarks, DEFAULT_BUCKETS=llm-d-benchmarks,llm-d-benchmarks-staging
-assert.deepStrictEqual(
-    getConfiguredBucketEntries('llm-d-benchmarks,llm-d-benchmarks-staging', 'llm-d-benchmarks'),
-    ['llm-d-benchmarks', 'llm-d-benchmarks-staging']
-);
-assert.deepStrictEqual(
-    getConfiguredBucketNames('llm-d-benchmarks,llm-d-benchmarks-staging', 'llm-d-benchmarks'),
-    ['llm-d-benchmarks', 'llm-d-benchmarks-staging']
-);
+        expect(
+            getConfiguredBucketNames('llm-d-benchmarks,llm-d-benchmarks-staging', 'llm-d-benchmarks')
+        ).toEqual(['llm-d-benchmarks', 'llm-d-benchmarks-staging']);
+    });
 
-// 5. Prod config: RESULTS_STORE_BUCKET=llm-d-benchmarks, DEFAULT_BUCKETS=llm-d-benchmarks
-assert.deepStrictEqual(
-    getConfiguredBucketEntries('llm-d-benchmarks', 'llm-d-benchmarks'),
-    ['llm-d-benchmarks']
-);
-assert.deepStrictEqual(
-    getConfiguredBucketNames('llm-d-benchmarks', 'llm-d-benchmarks'),
-    ['llm-d-benchmarks']
-);
+    it('handles production configuration with single results bucket', () => {
+        expect(
+            getConfiguredBucketEntries('llm-d-benchmarks', 'llm-d-benchmarks')
+        ).toEqual(['llm-d-benchmarks']);
 
-// 6. Path-scoped DEFAULT_BUCKETS are retained
-assert.deepStrictEqual(
-    getConfiguredBucketEntries('llm-d-benchmarks/team-a,llm-d-benchmarks-staging/team-b', 'llm-d-benchmarks'),
-    ['llm-d-benchmarks/team-a', 'llm-d-benchmarks-staging/team-b']
-);
-assert.deepStrictEqual(
-    getConfiguredBucketNames('llm-d-benchmarks/team-a,llm-d-benchmarks-staging/team-b', 'llm-d-benchmarks'),
-    ['llm-d-benchmarks', 'llm-d-benchmarks-staging']
-);
+        expect(
+            getConfiguredBucketNames('llm-d-benchmarks', 'llm-d-benchmarks')
+        ).toEqual(['llm-d-benchmarks']);
+    });
 
-// 7. Custom buckets pass through
-assert.deepStrictEqual(
-    getConfiguredBucketEntries('bucket-a, bucket-b/sub/dir ,,', 'llm-d-benchmarks'),
-    ['bucket-a', 'bucket-b/sub/dir']
-);
-assert.deepStrictEqual(
-    getConfiguredBucketNames('bucket-a, bucket-b/sub/dir ,,', 'llm-d-benchmarks'),
-    ['bucket-a', 'bucket-b']
-);
+    it('retains path-scoped DEFAULT_BUCKETS entries', () => {
+        expect(
+            getConfiguredBucketEntries('llm-d-benchmarks/team-a,llm-d-benchmarks-staging/team-b', 'llm-d-benchmarks')
+        ).toEqual(['llm-d-benchmarks/team-a', 'llm-d-benchmarks-staging/team-b']);
 
-// 8. Multiple prefixes of the same bucket are independent entries
-assert.deepStrictEqual(
-    getConfiguredBucketEntries('b1/p1,b1/p2,b2/p3', 'llm-d-benchmarks'),
-    ['b1/p1', 'b1/p2', 'b2/p3']
-);
-assert.deepStrictEqual(
-    getConfiguredBucketNames('b1/p1,b1/p2,b2/p3', 'llm-d-benchmarks'),
-    ['b1', 'b1', 'b2']
-);
+        expect(
+            getConfiguredBucketNames('llm-d-benchmarks/team-a,llm-d-benchmarks-staging/team-b', 'llm-d-benchmarks')
+        ).toEqual(['llm-d-benchmarks', 'llm-d-benchmarks-staging']);
+    });
 
-// 9. Fallback to DEFAULT_BUCKETS[0] when RESULTS_STORE_BUCKET is not set
-assert.strictEqual(getResultsStoreBucket(undefined, 'custom-bucket,other-bucket'), 'custom-bucket');
-assert.strictEqual(getResultsStoreBucket('', 'custom-bucket,other-bucket'), 'custom-bucket');
-assert.strictEqual(getResultsStoreBucket(undefined, 'gs://scoped-bucket/sub/path, other-bucket'), 'scoped-bucket');
-assert.deepStrictEqual(getConfiguredBucketEntries('b1,b2', undefined), ['b1', 'b2']);
-assert.deepStrictEqual(getConfiguredBucketNames('b1/p1,b2/p2', undefined), ['b1', 'b2']);
+    it('passes through custom buckets cleanly', () => {
+        expect(
+            getConfiguredBucketEntries('bucket-a, bucket-b/sub/dir ,,', 'llm-d-benchmarks')
+        ).toEqual(['bucket-a', 'bucket-b/sub/dir']);
 
-// 10. Default fallback with no args: DEFAULT_RESULTS_BUCKETS ('llm-d-benchmarks')
-assert.deepStrictEqual(getConfiguredBucketEntries(undefined, undefined), ['llm-d-benchmarks']);
-assert.deepStrictEqual(getConfiguredBucketNames(undefined, undefined), ['llm-d-benchmarks']);
-assert.deepStrictEqual(getConfiguredBucketNames('', undefined), ['llm-d-benchmarks']);
+        expect(
+            getConfiguredBucketNames('bucket-a, bucket-b/sub/dir ,,', 'llm-d-benchmarks')
+        ).toEqual(['bucket-a', 'bucket-b']);
+    });
 
-console.log('All buckets unit tests passed successfully!');
+    it('treats multiple prefixes of the same bucket as independent entries', () => {
+        expect(
+            getConfiguredBucketEntries('b1/p1,b1/p2,b2/p3', 'llm-d-benchmarks')
+        ).toEqual(['b1/p1', 'b1/p2', 'b2/p3']);
+
+        expect(
+            getConfiguredBucketNames('b1/p1,b1/p2,b2/p3', 'llm-d-benchmarks')
+        ).toEqual(['b1', 'b1', 'b2']);
+    });
+
+    it('falls back to DEFAULT_BUCKETS[0] when RESULTS_STORE_BUCKET is not set', () => {
+        expect(getResultsStoreBucket('', 'custom-bucket,other-bucket')).toBe('custom-bucket');
+        expect(getResultsStoreBucket('', 'gs://scoped-bucket/sub/path, other-bucket')).toBe('scoped-bucket');
+        expect(getConfiguredBucketEntries('b1,b2', '')).toEqual(['b1', 'b2']);
+        expect(getConfiguredBucketNames('b1/p1,b2/p2', '')).toEqual(['b1', 'b2']);
+    });
+
+    it('falls back to default results bucket when all args are empty', () => {
+        expect(getConfiguredBucketEntries('', 'llm-d-benchmarks')).toEqual(['llm-d-benchmarks']);
+        expect(getConfiguredBucketNames('', 'llm-d-benchmarks')).toEqual(['llm-d-benchmarks']);
+    });
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -65,7 +65,7 @@ function App() {
     const params = new URLSearchParams(window.location.search);
     // Legacy 'benchmark-comparison' deep links land on the Benchmark Browser,
     // where the comparison renders inline once brv02 runs are submitted.
-    const view = params.get('view') || 'home';
+    const view = params.get('view') || (params.has('benchmarks') ? 'results-store' : 'home');
     if (view === 'benchmark-comparison') return 'benchmark-browser';
     if (view === 'manage-benchmarks') return 'results-store';
     return view;
@@ -105,7 +105,7 @@ function App() {
   useEffect(() => {
     const onPopState = () => {
       const params = new URLSearchParams(window.location.search);
-      const view = params.get('view') || 'home';
+      const view = params.get('view') || (params.has('benchmarks') ? 'results-store' : 'home');
       if (view === 'benchmark-comparison') {
         setCurrentView('benchmark-browser');
       } else if (view === 'manage-benchmarks') {

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -140,10 +140,11 @@ export const UnifiedDataTable = (props) => {
     const isAdmin = user?.permission === 'admin';
         const [rawYamlContent, setRawYamlContent] = useState(null);
     const [rawYamlTitle, setRawYamlTitle] = useState('');
-    const [showComparisonDrawer, setShowComparisonDrawer] = useState(false);
     
     // Read shared graphing state from dashboardState, falling back to local defaults if dashboardState is not present
     const {
+        showComparisonDrawer: sharedShowComparisonDrawer,
+        setShowComparisonDrawer: sharedSetShowComparisonDrawer,
         tputType: sharedTputType, setTputType: sharedSetTputType,
         chartMode: sharedChartMode, setChartMode: sharedSetChartMode,
         yQualityMode: sharedYQualityMode, setYQualityMode: sharedSetYQualityMode,
@@ -161,6 +162,10 @@ export const UnifiedDataTable = (props) => {
         chartColorMode: sharedChartColorMode, setChartColorMode: sharedSetChartColorMode,
         lineConnectMode: sharedLineConnectMode, setLineConnectMode: sharedSetLineConnectMode,
     } = dashboardState || {};
+
+    const [localShowComparisonDrawer, localSetShowComparisonDrawer] = useState(false);
+    const showComparisonDrawer = sharedShowComparisonDrawer !== undefined ? sharedShowComparisonDrawer : localShowComparisonDrawer;
+    const setShowComparisonDrawer = sharedSetShowComparisonDrawer || localSetShowComparisonDrawer;
 
     // Local state fallbacks (if no shared dashboardState is present)
     const [localTputType, localSetTputType] = useState('output');
@@ -451,8 +456,8 @@ export const UnifiedDataTable = (props) => {
         const uuids = [];
         for (const stat of selectedStatsList) {
             const firstEntry = stat.data?.[0];
-            const sourceStr = firstEntry?.source || '';
-            const runId = firstEntry?.run_id || (sourceStr.startsWith('brv02:') ? sourceStr.replace('brv02:', '') : null);
+            const sourceStr = firstEntry?.source || stat.source || '';
+            const runId = firstEntry?.run_id || stat.runId || (sourceStr.startsWith('brv02:') ? sourceStr.replace('brv02:', '') : null);
 
             if (!runId || !isValidUuid(runId)) {
                 return {
@@ -461,6 +466,19 @@ export const UnifiedDataTable = (props) => {
                     shareForbiddenReason: "Sharing is forbidden: Selection contains unsubmitted or local staged runs without public UUIDs."
                 };
             }
+
+            const isBrv02 = sourceStr.startsWith('brv02:') || firstEntry?.source_info?.type === 'benchmark_report_v02';
+            const sub = isBrv02 && runId && submissionsMap ? submissionsMap[runId] : null;
+            const status = sub?.status || firstEntry?.source_info?.submission_state || stat.payload?.submission_state || 'staged';
+
+            if (status !== 'public' && status !== 'unlisted') {
+                return {
+                    canShare: false,
+                    shareableUuids: [],
+                    shareForbiddenReason: "Sharing is forbidden: Selection contains staged, pending review, or rejected runs. Only public and unlisted benchmarks can be shared."
+                };
+            }
+
             uuids.push(runId);
         }
 
@@ -469,12 +487,12 @@ export const UnifiedDataTable = (props) => {
             shareableUuids: uuids,
             shareForbiddenReason: null
         };
-    }, [selectedBenchmarks, modelStats]);
+    }, [selectedBenchmarks, modelStats, submissionsMap]);
 
     const handleCopyShareLink = React.useCallback(() => {
         if (!canShare || shareableUuids.length === 0) return;
         const shareLink = encodeShareLink(shareableUuids);
-        const fullUrl = `${window.location.origin}${window.location.pathname}?benchmarks=${shareLink}`;
+        const fullUrl = `${window.location.origin}${window.location.pathname}?view=results-store&benchmarks=${shareLink}`;
         navigator.clipboard.writeText(fullUrl);
         if (addToast) {
             addToast('Copied link to clipboard!', 'success');

--- a/src/utils/benchmarkForker.test.js
+++ b/src/utils/benchmarkForker.test.js
@@ -12,218 +12,219 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import assert from 'node:assert';
+import { describe, it, expect } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
 import { forkBenchmarkPayload, forkBenchmark } from './benchmarkForker.js';
 import { getRawPrismCloudPayload } from './brv02Exporter.js';
-import { PrismResultPayloadSchema } from '../../server/results/api.ts';
+import { PrismResultPayloadSchema, PrismResultContextSchema } from '../../server/results/api.ts';
 import { validatePrismUploadStructure } from './benchmarkValidator.js';
+import { groupStagesIntoRuns, stageToEntry } from './benchmarkReportV02Parser.js';
 
-console.log('Running benchmark forking unit tests...');
-
-// 1. Single Benchmark Forking Test
-const originalRunId = uuidv4();
-const originalEntryRunId = uuidv4();
-const sampleStat = {
-    benchmarkKey: `gcs:team-bucket:${originalRunId}`,
-    model: "meta-llama/Llama-3.1-70B-Instruct",
-    hardware: "H100",
-    accelerator_count: 8,
-    data: [
-        {
-            run_id: originalRunId,
+describe('benchmarkForker', () => {
+    it('forks a single benchmark into staged state with fresh UUIDs and provenance metadata', () => {
+        const originalRunId = uuidv4();
+        const originalEntryRunId = uuidv4();
+        const sampleStat = {
+            benchmarkKey: `gcs:team-bucket:${originalRunId}`,
             model: "meta-llama/Llama-3.1-70B-Instruct",
-            source: "gcs:team-bucket",
-            source_info: {
-                type: "benchmark_report_v02",
-                bucket: "team-bucket",
-                submission_state: "public",
-                submitted_at: "2026-08-01T10:00:00Z"
-            },
-            github_author: {
-                username: "octocat",
-                name: "Mona Lisa Octocat"
-            },
-            payload: {
-                runId: originalRunId,
-                runLabel: "Team Benchmark Baseline",
-                model_name: "meta-llama/Llama-3.1-70B-Instruct",
-                hardware: {
-                    hardware_name: "H100",
-                    accelerator_count: 8
-                },
-                format: "brv02",
-                submission_state: "public",
-                submitted_at: "2026-08-01T10:00:00Z",
-                github_author: {
-                    username: "octocat",
-                    name: "Mona Lisa Octocat"
-                },
-                entries: [
-                    {
-                        run_id: originalEntryRunId,
-                        run_description: "Team Benchmark Baseline",
-                        filename: "stage_0_report.yaml",
-                        prism_stage_index: 0,
-                        raw_report: {
-                            version: "0.2",
-                            workload: { stage: 0 },
-                            scenario: { model: "meta-llama/Llama-3.1-70B-Instruct" },
-                            results: {
-                                request_performance: {
-                                    aggregate: {
-                                        throughput: { output_token_rate: { mean: 128.5 } },
-                                        latency: { request_latency: { mean: 0.25 }, time_to_first_token: { mean: 0.05 } }
+            hardware: "H100",
+            accelerator_count: 8,
+            data: [
+                {
+                    run_id: originalRunId,
+                    model: "meta-llama/Llama-3.1-70B-Instruct",
+                    source: "gcs:team-bucket",
+                    source_info: {
+                        type: "benchmark_report_v02",
+                        bucket: "team-bucket",
+                        submission_state: "public",
+                        submitted_at: "2026-08-01T10:00:00Z"
+                    },
+                    github_author: {
+                        username: "octocat",
+                        name: "Mona Lisa Octocat"
+                    },
+                    payload: {
+                        runId: originalRunId,
+                        runLabel: "Team Benchmark Baseline",
+                        model_name: "meta-llama/Llama-3.1-70B-Instruct",
+                        hardware: {
+                            hardware_name: "H100",
+                            accelerator_count: 8
+                        },
+                        format: "brv02",
+                        submission_state: "public",
+                        submitted_at: "2026-08-01T10:00:00Z",
+                        github_author: {
+                            username: "octocat",
+                            name: "Mona Lisa Octocat"
+                        },
+                        entries: [
+                            {
+                                run_id: originalEntryRunId,
+                                run_description: "Team Benchmark Baseline",
+                                filename: "stage_0_report.yaml",
+                                prism_stage_index: 0,
+                                raw_report: {
+                                    version: "0.2",
+                                    workload: { stage: 0 },
+                                    scenario: { model: "meta-llama/Llama-3.1-70B-Instruct" },
+                                    results: {
+                                        request_performance: {
+                                            aggregate: {
+                                                throughput: { output_token_rate: { mean: 128.5 } },
+                                                latency: { request_latency: { mean: 0.25 }, time_to_first_token: { mean: 0.05 } }
+                                            }
+                                        }
                                     }
                                 }
                             }
-                        }
+                        ]
                     }
-                ]
+                }
+            ]
+        };
+
+        const { payload: forkedPayload, newRunId, forkDetail: singleForkDetail } = forkBenchmarkPayload(sampleStat, sampleStat.data);
+
+        // Fresh UUIDs
+        expect(forkedPayload.runId).toBeDefined();
+        expect(forkedPayload.runId).toBe(newRunId);
+        expect(forkedPayload.runId).not.toBe(originalRunId);
+        expect(forkedPayload.entries[0].run_id).toBeDefined();
+        expect(forkedPayload.entries[0].run_id).not.toBe(originalEntryRunId);
+
+        // State reset to local staging
+        expect(forkedPayload.submission_state).toBe("staged");
+        expect(forkedPayload.submitted_at).toBeUndefined();
+        expect(forkedPayload.github_author).toBeUndefined();
+        expect(forkedPayload.review).toBeUndefined();
+        expect(forkedPayload.feedback).toBeUndefined();
+
+        // Provenance metadata populated
+        expect(forkedPayload.forked_from).toBeDefined();
+        const forkDetail = Array.isArray(forkedPayload.forked_from) ? forkedPayload.forked_from[0] : forkedPayload.forked_from;
+        expect(forkDetail.original_run_id).toBe(originalRunId);
+        expect(forkDetail.original_run_label).toBe("Team Benchmark Baseline");
+        expect(forkDetail.source_bucket).toBe("team-bucket");
+        expect(forkDetail.original_author).toEqual({ username: "octocat", name: "Mona Lisa Octocat" });
+        expect(forkDetail.forked_at).toBeDefined();
+        expect(forkDetail).toEqual(singleForkDetail);
+
+        // Raw reports remain intact
+        expect(forkedPayload.entries[0].raw_report).toEqual(sampleStat.data[0].payload.entries[0].raw_report);
+
+        // Zod validation
+        const zodResult = PrismResultPayloadSchema.safeParse(forkedPayload);
+        expect(zodResult.success).toBe(true);
+
+        const structValidation = validatePrismUploadStructure(forkedPayload, { isUpload: false });
+        expect(structValidation.isValid).toBe(true);
+    });
+
+    it('chains lineage when re-forking an already forked benchmark', () => {
+        const originalRunId = uuidv4();
+        const sampleStat = {
+            benchmarkKey: `gcs:team-bucket:${originalRunId}`,
+            data: [{
+                run_id: originalRunId,
+                payload: {
+                    runId: originalRunId,
+                    runLabel: "Baseline",
+                    model_name: "meta-llama/Llama-3.1-70B-Instruct",
+                    hardware: { hardware_name: "H100", accelerator_count: 8 },
+                    format: "brv02",
+                    entries: [{ filename: "stage_0.yaml", raw_report: { version: "0.2" } }]
+                }
+            }]
+        };
+
+        const { payload: firstFork } = forkBenchmarkPayload(sampleStat, sampleStat.data);
+
+        const secondStat = {
+            benchmarkKey: `brv02:${firstFork.runId}`,
+            payload: firstFork,
+            data: [{
+                run_id: firstFork.runId,
+                source: `brv02:${firstFork.runId}`,
+                source_info: { type: "benchmark_report_v02", bucket: "custom-writable-bucket" },
+                github_author: { username: "contributor2" },
+                payload: firstFork
+            }]
+        };
+
+        const { payload: secondFork } = forkBenchmarkPayload(secondStat, secondStat.data);
+
+        expect(Array.isArray(secondFork.forked_from)).toBe(true);
+        expect(secondFork.forked_from.length).toBe(2);
+        expect(secondFork.forked_from[0].original_run_id).toBe(originalRunId);
+        expect(secondFork.forked_from[1].original_run_id).toBe(firstFork.runId);
+
+        const zodResult = PrismResultPayloadSchema.safeParse(secondFork);
+        expect(zodResult.success).toBe(true);
+    });
+
+    it('builds bundles with forkBenchmark and preserves forked_from', () => {
+        const originalRunId = uuidv4();
+        const sampleStat = {
+            benchmarkKey: `gcs:team-bucket:${originalRunId}`,
+            data: [{
+                run_id: originalRunId,
+                payload: {
+                    runId: originalRunId,
+                    runLabel: "Baseline",
+                    model_name: "meta-llama/Llama-3.1-70B-Instruct",
+                    hardware: { hardware_name: "H100", accelerator_count: 8 },
+                    format: "brv02",
+                    entries: [{ filename: "stage_0.yaml", raw_report: { version: "0.2", workload: { stage: 0 } } }]
+                }
+            }]
+        };
+
+        const { bundle, payload: resultPayload } = forkBenchmark(sampleStat, sampleStat.data);
+        expect(bundle).toBeDefined();
+        expect(resultPayload).toBeDefined();
+        expect(bundle.payload.runId).toBe(resultPayload.runId);
+        expect(bundle.validation.isValid).toBe(true);
+
+        const reconstructed = getRawPrismCloudPayload(sampleStat, sampleStat.data);
+        expect(reconstructed).toBeDefined();
+    });
+
+    it('preserves forked_from in parser groupStagesIntoRuns and stageToEntry', () => {
+        const runId = uuidv4();
+        const forkedFromObj = { original_run_id: uuidv4(), original_run_label: "Original" };
+
+        const groupedRuns = groupStagesIntoRuns([
+            {
+                runId,
+                runLabel: "Forked Run",
+                filename: "stage_0_report.yaml",
+                model_name: "meta-llama/Llama-3.1-70B-Instruct",
+                forked_from: forkedFromObj,
+                github_author: { username: "author1" },
+                scenario: { model: "meta-llama/Llama-3.1-70B-Instruct", hardware: "H100" },
+                performance: { outputTokenRate: 100, e2eMean: 0.2, ttftMean: 0.05 },
+                rawReport: {}
             }
-        }
-    ]
-};
+        ]);
+        expect(groupedRuns.length).toBe(1);
+        expect(groupedRuns[0].forked_from).toEqual(forkedFromObj);
 
-const { payload: forkedPayload, newRunId, forkDetail: singleForkDetail } = forkBenchmarkPayload(sampleStat, sampleStat.data);
+        const entry = stageToEntry(groupedRuns[0].stages[0]);
+        expect(entry.forked_from).toEqual(forkedFromObj);
+    });
 
-// 1.1 Fresh UUIDs generated
-assert.ok(forkedPayload.runId, "Forked payload must have a runId");
-assert.strictEqual(forkedPayload.runId, newRunId, "Returned newRunId must match payload.runId");
-assert.notStrictEqual(forkedPayload.runId, originalRunId, "Forked runId must be freshly generated");
-assert.ok(forkedPayload.entries[0].run_id, "Forked entry must have a run_id");
-assert.notStrictEqual(forkedPayload.entries[0].run_id, originalEntryRunId, "Forked entry run_id must be freshly generated");
-
-// 1.2 State reset to local staging
-assert.strictEqual(forkedPayload.submission_state, "staged", "Forked submission_state must be 'staged'");
-assert.strictEqual(forkedPayload.submitted_at, undefined, "submitted_at must be stripped");
-assert.strictEqual(forkedPayload.github_author, undefined, "github_author must be stripped");
-assert.strictEqual(forkedPayload.review, undefined, "review must be stripped");
-assert.strictEqual(forkedPayload.feedback, undefined, "feedback must be stripped");
-
-// 1.3 Provenance metadata populated in root $.forked_from
-assert.ok(forkedPayload.forked_from, "Root $.forked_from must be defined");
-const forkDetail = Array.isArray(forkedPayload.forked_from) ? forkedPayload.forked_from[0] : forkedPayload.forked_from;
-assert.strictEqual(forkDetail.original_run_id, originalRunId);
-assert.strictEqual(forkDetail.original_run_label, "Team Benchmark Baseline");
-assert.strictEqual(forkDetail.source_bucket, "team-bucket");
-assert.deepStrictEqual(forkDetail.original_author, { username: "octocat", name: "Mona Lisa Octocat" });
-assert.ok(forkDetail.forked_at, "forked_at must be an ISO timestamp");
-assert.deepStrictEqual(forkDetail, singleForkDetail);
-
-// 1.4 Raw reports remain intact and unmodified
-assert.deepStrictEqual(
-    forkedPayload.entries[0].raw_report,
-    sampleStat.data[0].payload.entries[0].raw_report,
-    "Raw report dictionary must remain strictly intact"
-);
-
-// 1.5 Zod & structure validation tests
-const zodResult = PrismResultPayloadSchema.safeParse(forkedPayload);
-assert.strictEqual(zodResult.success, true, `Zod schema validation failed: ${JSON.stringify(zodResult.error?.issues)}`);
-
-const structValidation = validatePrismUploadStructure(forkedPayload, { isUpload: false });
-assert.strictEqual(structValidation.isValid, true, `Structure validation failed: ${structValidation.errors?.join(', ')}`);
-
-// 2. Lineage Chaining Test (Forking an already forked benchmark)
-const secondStat = {
-    benchmarkKey: `brv02:${forkedPayload.runId}`,
-    payload: forkedPayload,
-    data: [
-        {
-            run_id: forkedPayload.runId,
-            source: `brv02:${forkedPayload.runId}`,
-            source_info: {
-                type: "benchmark_report_v02",
-                bucket: "custom-writable-bucket"
-            },
-            github_author: { username: "contributor2" },
-            payload: forkedPayload
-        }
-    ]
-};
-
-const { payload: secondForkedPayload } = forkBenchmarkPayload(secondStat, secondStat.data);
-
-assert.ok(Array.isArray(secondForkedPayload.forked_from), "Re-forked benchmark should have an array forked_from lineage");
-assert.strictEqual(secondForkedPayload.forked_from.length, 2, "Lineage should chain both origins");
-assert.strictEqual(secondForkedPayload.forked_from[0].original_run_id, originalRunId);
-assert.strictEqual(secondForkedPayload.forked_from[1].original_run_id, forkedPayload.runId);
-
-const zodResult2 = PrismResultPayloadSchema.safeParse(secondForkedPayload);
-assert.strictEqual(zodResult2.success, true, `Zod validation failed for array forked_from: ${JSON.stringify(zodResult2.error?.issues)}`);
-
-// 3. Bundle Builder & forkBenchmark Function Test
-const { bundle, payload: resultPayload } = forkBenchmark(sampleStat, sampleStat.data);
-assert.ok(bundle, "forkBenchmark must return a bundle");
-assert.ok(resultPayload, "forkBenchmark must return payload");
-assert.strictEqual(bundle.payload.runId, resultPayload.runId);
-assert.strictEqual(bundle.validation.isValid, true);
-assert.ok(bundle.stageFiles.length > 0, "bundle should contain stageFiles");
-
-// 4. Raw payload reconstruction preserves forked_from
-const reconstructedSingle = getRawPrismCloudPayload(secondStat, secondStat.data);
-assert.ok(reconstructedSingle.forked_from, "getRawPrismCloudPayload must preserve single forked_from");
-assert.strictEqual(reconstructedSingle.forked_from.original_run_id, originalRunId);
-
-const reconstructedChained = getRawPrismCloudPayload({ data: [{ forked_from: secondForkedPayload.forked_from, raw_report: {} }] });
-assert.ok(Array.isArray(reconstructedChained.forked_from), "getRawPrismCloudPayload must preserve chained array forked_from");
-assert.strictEqual(reconstructedChained.forked_from.length, 2);
-
-// 5. Submission payload construction preserves forked_from and validates against schema
-const submissionPayload = {
-    runId: bundle.payload.runId,
-    runLabel: bundle.name,
-    model_name: bundle.payload.model_name,
-    hardware: bundle.payload.hardware,
-    forked_from: bundle.payload.forked_from,
-    format: "brv02",
-    entries: bundle.payload.entries.map(e => ({
-        run_id: e.run_id,
-        run_description: bundle.name,
-        filename: e.filename,
-        raw_report: e.raw_report
-    }))
-};
-const submissionZod = PrismResultPayloadSchema.safeParse(submissionPayload);
-assert.strictEqual(submissionZod.success, true, `Submission payload schema validation failed: ${JSON.stringify(submissionZod.error?.issues)}`);
-
-// 6. Test groupStagesIntoRuns and stageToEntry preserve forked_from
-import { groupStagesIntoRuns, stageToEntry } from './benchmarkReportV02Parser.js';
-import { PrismResultContextSchema } from '../../server/results/api.ts';
-
-const groupedRuns = groupStagesIntoRuns([
-    {
-        runId: forkedPayload.runId,
-        runLabel: "Forked Run",
-        filename: "stage_0_report.yaml",
-        model_name: "meta-llama/Llama-3.1-70B-Instruct",
-        forked_from: forkedPayload.forked_from,
-        github_author: { username: "author1" },
-        scenario: { model: "meta-llama/Llama-3.1-70B-Instruct", hardware: "H100" },
-        performance: { outputTokenRate: 100, e2eMean: 0.2, ttftMean: 0.05 },
-        rawReport: {}
-    }
-]);
-assert.strictEqual(groupedRuns.length, 1);
-assert.ok(groupedRuns[0].forked_from, "groupStagesIntoRuns must preserve forked_from");
-assert.strictEqual(groupedRuns[0].forked_from.original_run_id, originalRunId);
-assert.strictEqual(groupedRuns[0].github_author.username, "author1");
-
-const entry = stageToEntry(groupedRuns[0].stages[0]);
-assert.ok(entry.forked_from, "stageToEntry must preserve forked_from");
-assert.strictEqual(entry.forked_from.original_run_id, originalRunId);
-
-// 7. Test PrismResultContextSchema accepts boolean forked flag
-const contextValidation = PrismResultContextSchema.safeParse({
-    submission_state: { value: "submitted_pending_review" },
-    github_user: { value: "octocat" },
-    run_id: { value: forkedPayload.runId },
-    hardware_name: { value: "H100" },
-    model_name: { value: "meta-llama/Llama-3.1-70B-Instruct" },
-    run_label: { value: "Forked Run" },
-    forked: { value: "true" }
+    it('validates PrismResultContextSchema accepting forked flag', () => {
+        const contextValidation = PrismResultContextSchema.safeParse({
+            submission_state: { value: "submitted_pending_review" },
+            github_user: { value: "octocat" },
+            run_id: { value: uuidv4() },
+            hardware_name: { value: "H100" },
+            model_name: { value: "meta-llama/Llama-3.1-70B-Instruct" },
+            run_label: { value: "Forked Run" },
+            forked: { value: "true" }
+        });
+        expect(contextValidation.success).toBe(true);
+    });
 });
-assert.strictEqual(contextValidation.success, true, "PrismResultContextSchema must accept forked");
-
-console.log('All benchmark forking unit tests passed successfully!');

--- a/src/utils/benchmarkReportV02Parser.test.js
+++ b/src/utils/benchmarkReportV02Parser.test.js
@@ -10,8 +10,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import assert from 'node:assert/strict';
-import test from 'node:test';
+import { describe, it, expect } from 'vitest';
 import { parseReportV02, stageToEntry } from './benchmarkReportV02Parser.js';
 
 const createReport = (throughput) => ({
@@ -35,62 +34,64 @@ const createReport = (throughput) => ({
 
 const parseRates = (throughput) => {
     const stage = parseReportV02(createReport(throughput), 'report.yaml');
-    assert.ok(stage);
+    expect(stage).toBeDefined();
     return { stage, entry: stageToEntry(stage) };
 };
 
-test('BR v0.2 preserves and normalizes reported token rates', () => {
-    const { stage, entry } = parseRates({
-        input_token_rate: { mean: 80 },
-        output_token_rate: { mean: 20 },
-        total_token_rate: { mean: 105 },
+describe('benchmarkReportV02Parser token rates', () => {
+    it('preserves and normalizes reported token rates in BR v0.2', () => {
+        const { stage, entry } = parseRates({
+            input_token_rate: { mean: 80 },
+            output_token_rate: { mean: 20 },
+            total_token_rate: { mean: 105 },
+        });
+
+        expect(stage.performance.totalTokenRate).toBe(105);
+        expect(entry.metrics.input_tput).toBe(80);
+        expect(entry.metrics.output_tput).toBe(20);
+        expect(entry.metrics.total_tput).toBe(105);
     });
 
-    assert.equal(stage.performance.totalTokenRate, 105);
-    assert.equal(entry.metrics.input_tput, 80);
-    assert.equal(entry.metrics.output_tput, 20);
-    assert.equal(entry.metrics.total_tput, 105);
-});
+    it('derives total token rate when it is absent in BR v0.2', () => {
+        const { entry } = parseRates({
+            input_token_rate: { mean: 80 },
+            output_token_rate: { mean: 20 },
+        });
 
-test('BR v0.2 derives total token rate when it is absent', () => {
-    const { entry } = parseRates({
-        input_token_rate: { mean: 80 },
-        output_token_rate: { mean: 20 },
+        expect(entry.metrics.total_tput).toBe(100);
     });
 
-    assert.equal(entry.metrics.total_tput, 100);
-});
+    it('derives input token rate from total and output rates in BR v0.2', () => {
+        const { entry } = parseRates({
+            output_token_rate: { mean: 20 },
+            total_token_rate: { mean: 100 },
+        });
 
-test('BR v0.2 derives input token rate from total and output rates', () => {
-    const { entry } = parseRates({
-        output_token_rate: { mean: 20 },
-        total_token_rate: { mean: 100 },
+        expect(entry.metrics.input_tput).toBe(80);
     });
 
-    assert.equal(entry.metrics.input_tput, 80);
-});
+    it('leaves rates null when fallback inputs are insufficient or invalid in BR v0.2', () => {
+        const missingTotal = parseRates({ output_token_rate: { mean: 20 } });
+        expect(missingTotal.entry.metrics.input_tput).toBe(null);
+        expect(missingTotal.entry.metrics.total_tput).toBe(null);
 
-test('BR v0.2 leaves rates null when fallback inputs are insufficient or invalid', () => {
-    const missingTotal = parseRates({ output_token_rate: { mean: 20 } });
-    assert.equal(missingTotal.entry.metrics.input_tput, null);
-    assert.equal(missingTotal.entry.metrics.total_tput, null);
-
-    const inconsistent = parseRates({
-        output_token_rate: { mean: 20 },
-        total_token_rate: { mean: 10 },
-    });
-    assert.equal(inconsistent.entry.metrics.input_tput, null);
-    assert.equal(inconsistent.entry.metrics.total_tput, 10);
-});
-
-test('BR v0.2 token-rate normalization preserves zero and coerces numeric strings', () => {
-    const { stage, entry } = parseRates({
-        input_token_rate: { mean: '0' },
-        output_token_rate: { mean: '20.5' },
+        const inconsistent = parseRates({
+            output_token_rate: { mean: 20 },
+            total_token_rate: { mean: 10 },
+        });
+        expect(inconsistent.entry.metrics.input_tput).toBe(null);
+        expect(inconsistent.entry.metrics.total_tput).toBe(10);
     });
 
-    assert.equal(stage.performance.inputTokenRate, 0);
-    assert.equal(stage.performance.outputTokenRate, 20.5);
-    assert.equal(entry.metrics.input_tput, 0);
-    assert.equal(entry.metrics.total_tput, 20.5);
+    it('preserves zero and coerces numeric strings in token-rate normalization', () => {
+        const { stage, entry } = parseRates({
+            input_token_rate: { mean: '0' },
+            output_token_rate: { mean: '20.5' },
+        });
+
+        expect(stage.performance.inputTokenRate).toBe(0);
+        expect(stage.performance.outputTokenRate).toBe(20.5);
+        expect(entry.metrics.input_tput).toBe(0);
+        expect(entry.metrics.total_tput).toBe(20.5);
+    });
 });

--- a/src/utils/bucketUtils.test.js
+++ b/src/utils/bucketUtils.test.js
@@ -12,77 +12,82 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { describe, it, expect } from 'vitest';
 import { getCanonicalBucketName, getBucketAlias, dedupeBucketConfigs, getBucketBaseName, getBucketPrefix } from './bucketUtils.js';
-import assert from 'node:assert';
 
-console.log('Running bucketUtils unit tests...');
+describe('bucketUtils', () => {
+    it('canonicalizes bucket names with getCanonicalBucketName', () => {
+        expect(getCanonicalBucketName('gs://slabe-bucket')).toBe('slabe-bucket');
+        expect(getCanonicalBucketName('gs://slabe-bucket/')).toBe('slabe-bucket');
+        expect(getCanonicalBucketName('slabe-bucket')).toBe('slabe-bucket');
+        expect(getCanonicalBucketName('s3://my-aws-bucket/')).toBe('my-aws-bucket');
+        expect(getCanonicalBucketName({ bucket: 'gs://slabe-bucket/', alias: 'slabe' })).toBe('slabe-bucket');
+        expect(getCanonicalBucketName(null)).toBe('');
+    });
 
-// 1. getCanonicalBucketName
-assert.strictEqual(getCanonicalBucketName('gs://slabe-bucket'), 'slabe-bucket');
-assert.strictEqual(getCanonicalBucketName('gs://slabe-bucket/'), 'slabe-bucket');
-assert.strictEqual(getCanonicalBucketName('slabe-bucket'), 'slabe-bucket');
-assert.strictEqual(getCanonicalBucketName('s3://my-aws-bucket/'), 'my-aws-bucket');
-assert.strictEqual(getCanonicalBucketName({ bucket: 'gs://slabe-bucket/', alias: 'slabe' }), 'slabe-bucket');
-assert.strictEqual(getCanonicalBucketName(null), '');
+    it('extracts bucket aliases with getBucketAlias', () => {
+        expect(getBucketAlias({ bucket: 'slabe-bucket', alias: 'slabe' })).toBe('slabe');
+        expect(getBucketAlias('slabe-bucket')).toBe(null);
+        expect(getBucketAlias({ bucket: 'slabe-bucket' })).toBe(null);
+    });
 
-// 2. getBucketAlias
-assert.strictEqual(getBucketAlias({ bucket: 'slabe-bucket', alias: 'slabe' }), 'slabe');
-assert.strictEqual(getBucketAlias('slabe-bucket'), null);
-assert.strictEqual(getBucketAlias({ bucket: 'slabe-bucket' }), null);
+    it('deduplicates bucket configs and retains alias info', () => {
+        const sampleInput = [
+            { bucket: 'slabe-bucket', alias: 'slabe' },
+            'slabe-bucket',
+            'gs://slabe-bucket',
+            'gs://slabe-bucket/',
+            { bucket: 'gs://slabe-bucket/', alias: 'slabe' },
+            'other-bucket',
+            { bucket: 'other-bucket', alias: 'Other' }
+        ];
 
-// 3. dedupeBucketConfigs
-const sampleInput = [
-    { bucket: 'slabe-bucket', alias: 'slabe' },
-    'slabe-bucket',
-    'gs://slabe-bucket',
-    'gs://slabe-bucket/',
-    { bucket: 'gs://slabe-bucket/', alias: 'slabe' },
-    'other-bucket',
-    { bucket: 'other-bucket', alias: 'Other' }
-];
+        const result = dedupeBucketConfigs(sampleInput);
+        expect(result.length).toBe(2);
+        expect(result[0]).toEqual({ bucket: 'slabe-bucket', alias: 'slabe' });
+        expect(result[1]).toEqual({ bucket: 'other-bucket', alias: 'Other' });
+    });
 
-const result = dedupeBucketConfigs(sampleInput);
+    it('upgrades simple string when followed by aliased object in deduplication', () => {
+        const sampleOrder2 = [
+            'gs://slabe-bucket',
+            { bucket: 'slabe-bucket', alias: 'slabe' }
+        ];
+        const result2 = dedupeBucketConfigs(sampleOrder2);
+        expect(result2.length).toBe(1);
+        expect(result2[0]).toEqual({ bucket: 'slabe-bucket', alias: 'slabe' });
+    });
 
-assert.strictEqual(result.length, 2);
-assert.deepStrictEqual(result[0], { bucket: 'slabe-bucket', alias: 'slabe' });
-assert.deepStrictEqual(result[1], { bucket: 'other-bucket', alias: 'Other' });
+    it('retains path scoping as identity in canonical bucket name', () => {
+        expect(getCanonicalBucketName('gs://slabe-bucket/team-a/results/')).toBe('slabe-bucket/team-a/results');
+        expect(getCanonicalBucketName({ bucket: 'slabe-bucket/team-a' })).toBe('slabe-bucket/team-a');
+    });
 
-// 4. Test upgrade when simple string comes before object with alias
-const sampleOrder2 = [
-    'gs://slabe-bucket',
-    { bucket: 'slabe-bucket', alias: 'slabe' }
-];
-const result2 = dedupeBucketConfigs(sampleOrder2);
-assert.strictEqual(result2.length, 1);
-assert.deepStrictEqual(result2[0], { bucket: 'slabe-bucket', alias: 'slabe' });
+    it('strips path scoping with getBucketBaseName', () => {
+        expect(getBucketBaseName('slabe-bucket')).toBe('slabe-bucket');
+        expect(getBucketBaseName('gs://slabe-bucket/team-a/results/')).toBe('slabe-bucket');
+        expect(getBucketBaseName({ bucket: 'gs://slabe-bucket/team-a', alias: 'slabe' })).toBe('slabe-bucket');
+        expect(getBucketBaseName(null)).toBe('');
+    });
 
-// 5. Path-scoped entries: canonical name retains the path as identity
-assert.strictEqual(getCanonicalBucketName('gs://slabe-bucket/team-a/results/'), 'slabe-bucket/team-a/results');
-assert.strictEqual(getCanonicalBucketName({ bucket: 'slabe-bucket/team-a' }), 'slabe-bucket/team-a');
+    it('extracts normalized trailing-slash prefixes with getBucketPrefix', () => {
+        expect(getBucketPrefix('slabe-bucket')).toBe('');
+        expect(getBucketPrefix('slabe-bucket/team-a')).toBe('team-a/');
+        expect(getBucketPrefix('gs://slabe-bucket/team-a/results/')).toBe('team-a/results/');
+        expect(getBucketPrefix('slabe-bucket//team-a//')).toBe('team-a/');
+        expect(getBucketPrefix({ bucket: 'slabe-bucket/team-a', alias: 'slabe' })).toBe('team-a/');
+        expect(getBucketPrefix(null)).toBe('');
+    });
 
-// 6. getBucketBaseName strips any path scoping
-assert.strictEqual(getBucketBaseName('slabe-bucket'), 'slabe-bucket');
-assert.strictEqual(getBucketBaseName('gs://slabe-bucket/team-a/results/'), 'slabe-bucket');
-assert.strictEqual(getBucketBaseName({ bucket: 'gs://slabe-bucket/team-a', alias: 'slabe' }), 'slabe-bucket');
-assert.strictEqual(getBucketBaseName(null), '');
-
-// 7. getBucketPrefix extracts a normalized trailing-slash prefix
-assert.strictEqual(getBucketPrefix('slabe-bucket'), '');
-assert.strictEqual(getBucketPrefix('slabe-bucket/team-a'), 'team-a/');
-assert.strictEqual(getBucketPrefix('gs://slabe-bucket/team-a/results/'), 'team-a/results/');
-assert.strictEqual(getBucketPrefix('slabe-bucket//team-a//'), 'team-a/');
-assert.strictEqual(getBucketPrefix({ bucket: 'slabe-bucket/team-a', alias: 'slabe' }), 'team-a/');
-assert.strictEqual(getBucketPrefix(null), '');
-
-// 8. Dedupe treats different prefixes of the same bucket as distinct sources
-const scopedInput = [
-    'slabe-bucket/team-a',
-    'gs://slabe-bucket/team-a/',
-    'slabe-bucket/team-b',
-    'slabe-bucket'
-];
-const scopedResult = dedupeBucketConfigs(scopedInput);
-assert.strictEqual(scopedResult.length, 3);
-assert.deepStrictEqual(scopedResult, ['slabe-bucket/team-a', 'slabe-bucket/team-b', 'slabe-bucket']);
-
-console.log('All bucketUtils unit tests passed successfully!');
+    it('treats different prefixes of the same bucket as distinct sources during deduplication', () => {
+        const scopedInput = [
+            'slabe-bucket/team-a',
+            'gs://slabe-bucket/team-a/',
+            'slabe-bucket/team-b',
+            'slabe-bucket'
+        ];
+        const scopedResult = dedupeBucketConfigs(scopedInput);
+        expect(scopedResult.length).toBe(3);
+        expect(scopedResult).toEqual(['slabe-bucket/team-a', 'slabe-bucket/team-b', 'slabe-bucket']);
+    });
+});

--- a/src/utils/manualCoalescing.test.js
+++ b/src/utils/manualCoalescing.test.js
@@ -12,196 +12,207 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-import assert from 'node:assert';
+import { describe, it, expect } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
 import { validatePrismUploadStructure } from './benchmarkValidator.js';
 import { PrismResultPayloadSchema } from '../../server/results/api.ts';
-import { mutateRawReportMetadata, getOriginalStageIndex, compareOriginalStageOrder } from './benchmarkReportV02Parser.js';
+import { mutateRawReportMetadata, compareOriginalStageOrder } from './benchmarkReportV02Parser.js';
 
-console.log('Running manual benchmark coalescing unit tests...');
+describe('manual benchmark coalescing', () => {
+    it('validates coalesced payload schema with prism_stage_index', () => {
+        const samplePayload = {
+            runId: uuidv4(),
+            runLabel: "Coalesced uBench Multi-Stage Run",
+            model_name: "meta-llama/Llama-3-8B-Instruct",
+            hardware: {
+                hardware_name: "H100",
+                accelerator_count: 8
+            },
+            format: "brv02",
+            entries: [
+                {
+                    run_id: uuidv4(),
+                    run_description: "Coalesced uBench Multi-Stage Run",
+                    filename: "stage_0_report.yaml",
+                    prism_stage_index: 0,
+                    raw_report: {
+                        version: "0.2",
+                        workload: { stage: 0 },
+                        run: { uid: "ubench-stage-0" },
+                        scenario: { model: "meta-llama/Llama-3-8B-Instruct" },
+                        results: {
+                            request_performance: {
+                                aggregate: {
+                                    throughput: { output_token_rate: { mean: 45.2 } },
+                                    latency: { request_latency: { mean: 0.25 }, time_to_first_token: { mean: 0.1 }, time_per_output_token: { mean: 0.02 } }
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    run_id: uuidv4(),
+                    run_description: "Coalesced uBench Multi-Stage Run",
+                    filename: "stage_1_report.yaml",
+                    prism_stage_index: 1,
+                    raw_report: {
+                        version: "0.2",
+                        workload: { stage: 1 },
+                        run: { uid: "ubench-stage-1" },
+                        scenario: { model: "meta-llama/Llama-3-8B-Instruct" },
+                        results: {
+                            request_performance: {
+                                aggregate: {
+                                    throughput: { output_token_rate: { mean: 55.0 } },
+                                    latency: { request_latency: { mean: 0.22 }, time_to_first_token: { mean: 0.09 }, time_per_output_token: { mean: 0.018 } }
+                                }
+                            }
+                        }
+                    }
+                }
+            ]
+        };
 
-// 1. Validate payload schema with prism_stage_index
-const samplePayload = {
-    runId: uuidv4(),
-    runLabel: "Coalesced uBench Multi-Stage Run",
-    model_name: "meta-llama/Llama-3-8B-Instruct",
-    hardware: {
-        hardware_name: "H100",
-        accelerator_count: 8
-    },
-    format: "brv02",
-    entries: [
-        {
-            run_id: uuidv4(),
-            run_description: "Coalesced uBench Multi-Stage Run",
-            filename: "stage_0_report.yaml",
-            prism_stage_index: 0,
-            raw_report: {
-                version: "0.2",
-                workload: { stage: 0 },
-                run: { uid: "ubench-stage-0" },
-                scenario: { model: "meta-llama/Llama-3-8B-Instruct" },
-                results: {
-                    request_performance: {
-                        aggregate: {
-                            throughput: { output_token_rate: { mean: 45.2 } },
-                            latency: { request_latency: { mean: 0.25 }, time_to_first_token: { mean: 0.1 }, time_per_output_token: { mean: 0.02 } }
+        const parseResult = PrismResultPayloadSchema.safeParse(samplePayload);
+        expect(parseResult.success).toBe(true);
+        expect(samplePayload.entries[0].prism_stage_index).toBe(0);
+        expect(samplePayload.entries[1].prism_stage_index).toBe(1);
+
+        const structValidation = validatePrismUploadStructure(samplePayload, { isUpload: false });
+        expect(structValidation.isValid).toBe(true);
+    });
+
+    it('ensures raw report immutability during stage re-indexing', () => {
+        const rawReport = {
+            version: "0.2",
+            workload: { stage: 0 },
+            results: { throughput: 45.2 }
+        };
+        const entries = [
+            { run_id: "e1", filename: "s0.yaml", prism_stage_index: 0, raw_report: { ...rawReport } },
+            { run_id: "e2", filename: "s1.yaml", prism_stage_index: 1, raw_report: { ...rawReport } }
+        ];
+
+        const rawReportBefore0 = { ...entries[0].raw_report };
+        const reindexed = entries.map((entry, idx) => ({
+            ...entry,
+            prism_stage_index: 1 - idx
+        }));
+
+        expect(reindexed[0].raw_report).toEqual(rawReportBefore0);
+        expect(reindexed[0].prism_stage_index).toBe(1);
+        expect(reindexed[1].prism_stage_index).toBe(0);
+    });
+
+    it('groups candidate runs using auto-grouping heuristics', () => {
+        const runA = {
+            id: "run-1",
+            payload: {
+                model_name: "meta-llama/Llama-3-8B-Instruct",
+                hardware: { hardware_name: "H100", accelerator_count: 8 },
+                inference_tool: "vllm"
+            }
+        };
+        const runB = {
+            id: "run-2",
+            payload: {
+                model_name: "meta-llama/Llama-3-8B-Instruct",
+                hardware: { hardware_name: "H100", accelerator_count: 8 },
+                inference_tool: "vllm"
+            }
+        };
+        const runC = {
+            id: "run-3",
+            payload: {
+                model_name: "Qwen/Qwen2.5-7B",
+                hardware: { hardware_name: "TPU v6e", accelerator_count: 4 },
+                inference_tool: "tgi"
+            }
+        };
+
+        const bundles = [runA, runB, runC];
+        const groupsMap = new Map();
+        bundles.forEach(bundle => {
+            const m = (bundle.payload?.model_name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+            const h = (bundle.payload?.hardware?.hardware_name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
+            const tool = (bundle.payload?.inference_tool || '').toLowerCase().trim();
+            const key = `${m}::${h}::${tool}`;
+
+            if (!groupsMap.has(key)) {
+                groupsMap.set(key, [bundle]);
+            } else {
+                groupsMap.get(key).push(bundle);
+            }
+        });
+
+        expect(groupsMap.size).toBe(2);
+        const matchingGroup = Array.from(groupsMap.values()).find(g => g.length === 2);
+        expect(matchingGroup).toBeDefined();
+        expect(matchingGroup.length).toBe(2);
+        expect(matchingGroup[0].id).toBe("run-1");
+        expect(matchingGroup[1].id).toBe("run-2");
+    });
+
+    it('sorts stages by original BRV02 stage number', () => {
+        const unsortedEntries = [
+            { filename: "stage_9_report.yaml", raw_report: { workload: { stage: 9 } } },
+            { filename: "stage_3_report.yaml", raw_report: { workload: { stage: 3 } } },
+            { filename: "stage_8_report.yaml", raw_report: { workload: { stage: 8 } } },
+            { filename: "stage_5_report.yaml", raw_report: { workload: { stage: 5 } } }
+        ];
+
+        unsortedEntries.sort(compareOriginalStageOrder);
+        unsortedEntries.forEach((entry, idx) => {
+            entry.prism_stage_index = idx;
+        });
+
+        expect(unsortedEntries[0].raw_report.workload.stage).toBe(3);
+        expect(unsortedEntries[0].prism_stage_index).toBe(0);
+
+        expect(unsortedEntries[1].raw_report.workload.stage).toBe(5);
+        expect(unsortedEntries[1].prism_stage_index).toBe(1);
+
+        expect(unsortedEntries[2].raw_report.workload.stage).toBe(8);
+        expect(unsortedEntries[2].prism_stage_index).toBe(2);
+
+        expect(unsortedEntries[3].raw_report.workload.stage).toBe(9);
+        expect(unsortedEntries[3].prism_stage_index).toBe(3);
+    });
+
+    it('synchronizes metadata mutations across raw_report fields', () => {
+        const brv02Report = {
+            version: "0.2",
+            run: { uid: "stage-uid-123", description: "Old Run Description" },
+            scenario: {
+                stack: [
+                    {
+                        standardized: {
+                            role: "aggregate",
+                            model: { name: "qwen3_coder_480b_a35b_instruct-fp8_8k_1k_inference_perf" },
+                            accelerator: { model: "Old Hardware" }
+                        }
+                    }
+                ],
+                load: {
+                    native: {
+                        config: {
+                            server: { model_name: "qwen3_coder_480b_a35b_instruct-fp8_8k_1k_inference_perf" }
                         }
                     }
                 }
             }
-        },
-        {
-            run_id: uuidv4(),
-            run_description: "Coalesced uBench Multi-Stage Run",
-            filename: "stage_1_report.yaml",
-            prism_stage_index: 1,
-            raw_report: {
-                version: "0.2",
-                workload: { stage: 1 },
-                run: { uid: "ubench-stage-1" },
-                scenario: { model: "meta-llama/Llama-3-8B-Instruct" },
-                results: {
-                    request_performance: {
-                        aggregate: {
-                            throughput: { output_token_rate: { mean: 55.0 } },
-                            latency: { request_latency: { mean: 0.22 }, time_to_first_token: { mean: 0.09 }, time_per_output_token: { mean: 0.018 } }
-                        }
-                    }
-                }
-            }
-        }
-    ]
-};
+        };
 
-// Test Zod schema validation
-const parseResult = PrismResultPayloadSchema.safeParse(samplePayload);
-assert.strictEqual(parseResult.success, true, `Zod validation failed: ${JSON.stringify(parseResult.error?.issues)}`);
-assert.strictEqual(samplePayload.entries[0].prism_stage_index, 0);
-assert.strictEqual(samplePayload.entries[1].prism_stage_index, 1);
+        const updatedReport = mutateRawReportMetadata(brv02Report, {
+            model_name: "qwen3_coder_480b",
+            hardware_name: "H100",
+            runLabel: "Unified Coalesced Run"
+        });
 
-// Test validatePrismUploadStructure helper
-const structValidation = validatePrismUploadStructure(samplePayload, { isUpload: false });
-assert.strictEqual(structValidation.isValid, true, `Structure validation failed: ${structValidation.errors?.join(', ')}`);
-
-// 2. Test raw report immutability during stage re-indexing
-const rawReportBefore0 = { ...samplePayload.entries[0].raw_report };
-const reindexedEntries = samplePayload.entries.map((entry, idx) => ({
-    ...entry,
-    prism_stage_index: 1 - idx // reverse ordering
-}));
-
-assert.deepStrictEqual(reindexedEntries[0].raw_report, rawReportBefore0, "Raw report object was mutated during re-indexing");
-assert.strictEqual(reindexedEntries[0].prism_stage_index, 1, "prism_stage_index was not updated");
-assert.strictEqual(reindexedEntries[1].prism_stage_index, 0, "prism_stage_index was not updated");
-
-// 3. Test Auto-Group heuristic grouping logic
-const runA = {
-    id: "run-1",
-    payload: {
-        model_name: "meta-llama/Llama-3-8B-Instruct",
-        hardware: { hardware_name: "H100", accelerator_count: 8 },
-        inference_tool: "vllm"
-    }
-};
-const runB = {
-    id: "run-2",
-    payload: {
-        model_name: "meta-llama/Llama-3-8B-Instruct",
-        hardware: { hardware_name: "H100", accelerator_count: 8 },
-        inference_tool: "vllm"
-    }
-};
-const runC = {
-    id: "run-3",
-    payload: {
-        model_name: "Qwen/Qwen2.5-7B",
-        hardware: { hardware_name: "TPU v6e", accelerator_count: 4 },
-        inference_tool: "tgi"
-    }
-};
-
-const bundles = [runA, runB, runC];
-const groupsMap = new Map();
-bundles.forEach(bundle => {
-    const m = (bundle.payload?.model_name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
-    const h = (bundle.payload?.hardware?.hardware_name || '').toLowerCase().replace(/[^a-z0-9]/g, '');
-    const tool = (bundle.payload?.inference_tool || '').toLowerCase().trim();
-    const key = `${m}::${h}::${tool}`;
-
-    if (!groupsMap.has(key)) {
-        groupsMap.set(key, [bundle]);
-    } else {
-        groupsMap.get(key).push(bundle);
-    }
+        expect(updatedReport.run.uid).toBe("stage-uid-123");
+        expect(updatedReport.run.description).toBe("Unified Coalesced Run");
+        expect(updatedReport.scenario.stack[0].standardized.model.name).toBe("qwen3_coder_480b");
+        expect(updatedReport.scenario.load.native.config.server.model_name).toBe("qwen3_coder_480b");
+        expect(updatedReport.scenario.stack[0].standardized.accelerator.model).toBe("H100");
+    });
 });
-
-assert.strictEqual(groupsMap.size, 2, "Auto-grouping did not produce expected number of distinct groups");
-const matchingGroup = Array.from(groupsMap.values()).find(g => g.length === 2);
-assert.notStrictEqual(matchingGroup, undefined, "Auto-grouping failed to match candidate runs");
-assert.strictEqual(matchingGroup.length, 2, "Candidate group does not contain 2 matched runs");
-assert.strictEqual(matchingGroup[0].id, "run-1");
-assert.strictEqual(matchingGroup[1].id, "run-2");
-
-// 4. Test Stage Sorting by Original BRV02 Stage Number & Normalization
-const unsortedEntries = [
-    { filename: "stage_9_report.yaml", raw_report: { workload: { stage: 9 } } },
-    { filename: "stage_3_report.yaml", raw_report: { workload: { stage: 3 } } },
-    { filename: "stage_8_report.yaml", raw_report: { workload: { stage: 8 } } },
-    { filename: "stage_5_report.yaml", raw_report: { workload: { stage: 5 } } }
-];
-
-unsortedEntries.sort(compareOriginalStageOrder);
-unsortedEntries.forEach((entry, idx) => {
-    entry.prism_stage_index = idx;
-});
-
-assert.strictEqual(unsortedEntries[0].raw_report.workload.stage, 3);
-assert.strictEqual(unsortedEntries[0].prism_stage_index, 0);
-
-assert.strictEqual(unsortedEntries[1].raw_report.workload.stage, 5);
-assert.strictEqual(unsortedEntries[1].prism_stage_index, 1);
-
-assert.strictEqual(unsortedEntries[2].raw_report.workload.stage, 8);
-assert.strictEqual(unsortedEntries[2].prism_stage_index, 2);
-
-assert.strictEqual(unsortedEntries[3].raw_report.workload.stage, 9);
-assert.strictEqual(unsortedEntries[3].prism_stage_index, 3);
-
-// 5. Test raw_report metadata mutation synchronization
-const brv02Report = {
-    version: "0.2",
-    run: { uid: "stage-uid-123", description: "Old Run Description" },
-    scenario: {
-        stack: [
-            {
-                standardized: {
-                    role: "aggregate",
-                    model: { name: "qwen3_coder_480b_a35b_instruct-fp8_8k_1k_inference_perf" },
-                    accelerator: { model: "Old Hardware" }
-                }
-            }
-        ],
-        load: {
-            native: {
-                config: {
-                    server: { model_name: "qwen3_coder_480b_a35b_instruct-fp8_8k_1k_inference_perf" }
-                }
-            }
-        }
-    }
-};
-
-const updatedReport = mutateRawReportMetadata(brv02Report, {
-    model_name: "qwen3_coder_480b",
-    hardware_name: "H100",
-    runLabel: "Unified Coalesced Run"
-});
-
-assert.strictEqual(updatedReport.run.uid, "stage-uid-123", "Stage uid was mutated");
-assert.strictEqual(updatedReport.run.description, "Unified Coalesced Run", "Run description was not updated");
-assert.strictEqual(updatedReport.scenario.stack[0].standardized.model.name, "qwen3_coder_480b", "Model name in scenario.stack was not updated");
-assert.strictEqual(updatedReport.scenario.load.native.config.server.model_name, "qwen3_coder_480b", "Model name in load.native was not updated");
-assert.strictEqual(updatedReport.scenario.stack[0].standardized.accelerator.model, "H100", "Hardware in scenario.stack was not updated");
-
-console.log('All manual benchmark coalescing unit tests passed successfully!');

--- a/src/utils/shareLinkEncoder.test.js
+++ b/src/utils/shareLinkEncoder.test.js
@@ -12,42 +12,147 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+import { describe, it, expect } from 'vitest';
 import { encodeShareLink, decodeShareLink, isValidUuid } from './shareLinkEncoder.js';
-import assert from 'node:assert';
 
-console.log('Running shareLinkEncoder unit tests...');
+describe('shareLinkEncoder', () => {
+    it('validates canonical UUID formats with isValidUuid', () => {
+        expect(isValidUuid('123e4567-e89b-12d3-a456-426614174000')).toBe(true);
+        expect(isValidUuid('ACD1D5D0-5663-4560-8E82-98837E54D933')).toBe(true);
+        expect(isValidUuid('0d778b34-7689-440e-ac10-911d8c4fed92')).toBe(true);
+        expect(isValidUuid('invalid-uuid')).toBe(false);
+        expect(isValidUuid('123e4567e89b12d3a456426614174000')).toBe(false);
+        expect(isValidUuid('')).toBe(false);
+        expect(isValidUuid(null)).toBe(false);
+        expect(isValidUuid(undefined)).toBe(false);
+    });
 
-// 1. isValidUuid
-assert.strictEqual(isValidUuid('123e4567-e89b-12d3-a456-426614174000'), true);
-assert.strictEqual(isValidUuid('ACD1D5D0-5663-4560-8E82-98837E54D933'), true);
-assert.strictEqual(isValidUuid('invalid-uuid'), false);
-assert.strictEqual(isValidUuid('123e4567e89b12d3a456426614174000'), false);
+    it('performs round-trip encoding and decoding for a single UUID (N = 1)', () => {
+        const singleUuid = ['123e4567-e89b-12d3-a456-426614174000'];
+        const encoded = encodeShareLink(singleUuid);
+        expect(typeof encoded).toBe('string');
+        expect(encoded.length).toBe(22); // 24 chars - 2 padding = 22 URL-safe chars
+        const decoded = decodeShareLink(encoded);
+        expect(decoded).toEqual(singleUuid);
+    });
 
-// 2. Round-trip encoding and decoding (N = 1)
-const singleUuid = ['123e4567-e89b-12d3-a456-426614174000'];
-const encoded1 = encodeShareLink(singleUuid);
-assert.strictEqual(typeof encoded1, 'string');
-assert.strictEqual(encoded1.length, 22); // 24 chars - 2 padding = 22 URL-safe chars
-const decoded1 = decodeShareLink(encoded1);
-assert.deepStrictEqual(decoded1, singleUuid);
+    it('performs round-trip encoding and decoding for two UUIDs (N = 2)', () => {
+        const doubleUuids = [
+            '0d778b34-7689-440e-ac10-911d8c4fed92',
+            'bcd4eb8f-7db7-44b9-89fc-9950a6b3df86'
+        ];
+        const encoded = encodeShareLink(doubleUuids);
+        expect(encoded.length).toBe(43); // 44 chars - 1 padding = 43 URL-safe chars
+        const decoded = decodeShareLink(encoded);
+        expect(decoded).toEqual(doubleUuids);
+    });
 
-// 3. Round-trip encoding and decoding (N = 3)
-const tripleUuids = [
-    '123e4567-e89b-12d3-a456-426614174000',
-    'acd1d5d0-5663-4560-8e82-98837e54d933',
-    '88888888-4444-4444-4444-121212121212'
-];
-const encoded3 = encodeShareLink(tripleUuids);
-assert.strictEqual(encoded3.length, 64);
-const decoded3 = decodeShareLink(encoded3);
-assert.deepStrictEqual(decoded3, tripleUuids);
+    it('performs round-trip encoding and decoding for three UUIDs (N = 3)', () => {
+        const tripleUuids = [
+            '123e4567-e89b-12d3-a456-426614174000',
+            'acd1d5d0-5663-4560-8e82-98837e54d933',
+            '88888888-4444-4444-4444-121212121212'
+        ];
+        const encoded = encodeShareLink(tripleUuids);
+        expect(encoded.length).toBe(64);
+        const decoded = decodeShareLink(encoded);
+        expect(decoded).toEqual(tripleUuids);
+    });
 
-// 4. Invalid decoding handling
-assert.throws(() => decodeShareLink('!!!invalid_base64!!!'), /Malformed Base64/);
-assert.throws(() => decodeShareLink(btoa('12345')), /Invalid byte alignment/); // 5 bytes, not multiple of 16
+    it('handles uppercase UUIDs and normalizes them to canonical lowercase', () => {
+        const upperUuid = ['ACD1D5D0-5663-4560-8E82-98837E54D933'];
+        const encodedUpper = encodeShareLink(upperUuid);
+        const decodedUpper = decodeShareLink(encodedUpper);
+        expect(decodedUpper).toEqual(['acd1d5d0-5663-4560-8e82-98837e54d933']);
+    });
 
-// 5. Empty inputs
-assert.strictEqual(encodeShareLink([]), '');
-assert.deepStrictEqual(decodeShareLink(''), []);
+    it('constructs and parses valid URL query parameters', () => {
+        const doubleUuids = [
+            '0d778b34-7689-440e-ac10-911d8c4fed92',
+            'bcd4eb8f-7db7-44b9-89fc-9950a6b3df86'
+        ];
+        const encoded = encodeShareLink(doubleUuids);
+        const baseUrl = 'https://prism.llm-d.ai/';
+        const fullShareUrl = `${baseUrl}?view=results-store&benchmarks=${encoded}`;
+        const parsedUrl = new URL(fullShareUrl);
+        expect(parsedUrl.searchParams.get('view')).toBe('results-store');
+        expect(parsedUrl.searchParams.get('benchmarks')).toBe(encoded);
+        expect(decodeShareLink(parsedUrl.searchParams.get('benchmarks'))).toEqual(doubleUuids);
+    });
 
-console.log('All shareLinkEncoder unit tests passed successfully!');
+    it('resolves initial view fallback when ?benchmarks=... is present without view parameter', () => {
+        const singleUuid = ['123e4567-e89b-12d3-a456-426614174000'];
+        const encoded = encodeShareLink(singleUuid);
+
+        function resolveInitialView(searchString) {
+            const params = new URLSearchParams(searchString);
+            const view = params.get('view') || (params.has('benchmarks') ? 'results-store' : 'home');
+            if (view === 'benchmark-comparison') return 'benchmark-browser';
+            if (view === 'manage-benchmarks') return 'results-store';
+            return view;
+        }
+
+        expect(resolveInitialView('?view=results-store&benchmarks=' + encoded)).toBe('results-store');
+        expect(resolveInitialView('?benchmarks=' + encoded)).toBe('results-store');
+        expect(resolveInitialView('?view=benchmark-browser')).toBe('benchmark-browser');
+        expect(resolveInitialView('')).toBe('home');
+    });
+
+    it('enforces visibility constraints (public and unlisted allowed, others blocked)', () => {
+        function evaluateCanShare(selectedRuns, submissionsMap = {}) {
+            if (!selectedRuns || selectedRuns.length === 0) {
+                return { canShare: false, reason: null };
+            }
+
+            for (const run of selectedRuns) {
+                const runId = run.runId || run.run_id;
+                if (!runId || !isValidUuid(runId)) {
+                    return {
+                        canShare: false,
+                        reason: "Sharing is forbidden: Selection contains unsubmitted or local staged runs without public UUIDs."
+                    };
+                }
+
+                const sub = submissionsMap[runId];
+                const status = sub?.status || run.submission_state || run.state || 'staged';
+                if (status !== 'public' && status !== 'unlisted') {
+                    return {
+                        canShare: false,
+                        reason: "Sharing is forbidden: Selection contains staged, pending review, or rejected runs. Only public and unlisted benchmarks can be shared."
+                    };
+                }
+            }
+
+            return { canShare: true, reason: null };
+        }
+
+        expect(evaluateCanShare([{ runId: '0d778b34-7689-440e-ac10-911d8c4fed92', state: 'public' }]).canShare).toBe(true);
+        expect(evaluateCanShare([{ runId: '0d778b34-7689-440e-ac10-911d8c4fed92', state: 'unlisted' }]).canShare).toBe(true);
+        expect(evaluateCanShare([
+            { runId: '0d778b34-7689-440e-ac10-911d8c4fed92', state: 'public' },
+            { runId: 'bcd4eb8f-7db7-44b9-89fc-9950a6b3df86', state: 'unlisted' }
+        ]).canShare).toBe(true);
+
+        expect(evaluateCanShare([{ runId: '0d778b34-7689-440e-ac10-911d8c4fed92', state: 'submitted_pending_review' }]).canShare).toBe(false);
+        expect(evaluateCanShare([{ runId: '0d778b34-7689-440e-ac10-911d8c4fed92', state: 'rejected' }]).canShare).toBe(false);
+        expect(evaluateCanShare([{ runId: 'local-stage-1', state: 'staged' }]).canShare).toBe(false);
+        expect(evaluateCanShare([
+            { runId: '0d778b34-7689-440e-ac10-911d8c4fed92', state: 'public' },
+            { runId: 'acd1d5d0-5663-4560-8e82-98837e54d933', state: 'submitted_pending_review' }
+        ]).canShare).toBe(false);
+    });
+
+    it('throws errors on malformed Base64 and invalid byte alignment', () => {
+        expect(() => decodeShareLink('!!!invalid_base64!!!')).toThrow(/Malformed Base64/);
+        expect(() => decodeShareLink(btoa('12345'))).toThrow(/Invalid byte alignment/);
+    });
+
+    it('returns empty results for empty or null inputs', () => {
+        expect(encodeShareLink([])).toBe('');
+        expect(encodeShareLink(null)).toBe('');
+        expect(encodeShareLink(undefined)).toBe('');
+        expect(decodeShareLink('')).toEqual([]);
+        expect(decodeShareLink(null)).toEqual([]);
+        expect(decodeShareLink(undefined)).toEqual([]);
+    });
+});


### PR DESCRIPTION
## What does this PR do?

1. **Fixes Results Store benchmark sharing links**:
   - Includes `view=results-store` in copied share URLs so recipients land directly in Results Store.
   - Restores the view fallback in `App.jsx` to navigate to `results-store` when `?benchmarks=...` is present without an explicit `view` parameter.
   - Wires `showComparisonDrawer` to shared `dashboardState` in `UnifiedDataTable` so the comparison drawer opens automatically upon navigating via share links.
   - Enforces submission status constraints (`public` and `unlisted` only) in `canShare`, preventing unsubmitted or rejected runs from being shared.

2. **Adopts Vitest for unit testing**:
   - Integrates `vitest` into `package.json` with `test` and `test:watch` scripts.
   - Migrates all disparate unit test files (`shareLinkEncoder`, `bucketUtils`, `benchmarkReportV02Parser`, `benchmarkForker`, `manualCoalescing`, and `server/buckets`) to structured Vitest test suites (43 tests total).
   - Refines bucket fallback argument handling in `server/buckets.js` during isolated tests.
   - Updates `README.md` and `.github/PULL_REQUEST_TEMPLATE.md` with Vitest instructions.

## Why is this change needed?

- Benchmark share URLs were generating links without the `view=results-store` query parameter, causing recipients to land on the Home view with a closed comparison drawer instead of opening the shared benchmark comparison.
- Unit tests across the client and server were previously unstandardized ad-hoc scripts; adopting Vitest unifies test execution across the project.

## How was this tested?

- [x] Unit tests added/updated (`npm test` passes all 43 tests across 6 test suites)
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed (verified share link generation, copying, and URL resolution in browser)

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Linters pass (`npm run lint`)
- [x] Documentation updated (if applicable)

## Related Issues