### PR TITLE
Fix coalesced benchmark stage loss and filenames

### DIFF
--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -277,8 +277,21 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
         let combinedSummary = null;
 
         targetBundles.forEach(bundle => {
+            const originalRunLabel = bundle.payload?.runLabel || bundle.name || bundle.dirKey || '';
+
             if (bundle.stageFiles) {
-                combinedStageFiles.push(...bundle.stageFiles);
+                const mappedStageFiles = bundle.stageFiles.map(sf => {
+                    const originalName = sf.filename || sf.name || sf.file?.name || '';
+                    const newFilename = originalRunLabel && !originalName.startsWith(`${originalRunLabel}/`)
+                        ? `${originalRunLabel}/${originalName}`
+                        : originalName;
+                    return {
+                        ...sf,
+                        name: newFilename,
+                        filename: newFilename
+                    };
+                });
+                combinedStageFiles.push(...mappedStageFiles);
             }
             if (bundle.metadataFiles?.run_metadata?.parsed) {
                 combinedRunMetadata = bundle.metadataFiles.run_metadata.parsed;
@@ -298,8 +311,15 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     runLabel: resolvedMetadata.runLabel,
                     inference_tool: resolvedMetadata.inference_tool
                 });
+                const originalFilePath = entry.filename || entry.run_uid || 'report.json';
+                const newFilename = originalRunLabel && !originalFilePath.startsWith(`${originalRunLabel}/`)
+                    ? `${originalRunLabel}/${originalFilePath}`
+                    : originalFilePath;
+
                 combinedEntries.push({
                     ...entry,
+                    filename: newFilename,
+                    run_id: entry.run_id || uuidv4(),
                     run_description: resolvedMetadata.runLabel || entry.run_description,
                     raw_report: mutatedRawReport
                 });
@@ -578,8 +598,8 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             entriesWithMetrics.sort((a, b) => {
                 let valA, valB;
                 if (column === 'filename') {
-                    valA = (a.check.filename || '').split('/').pop();
-                    valB = (b.check.filename || '').split('/').pop();
+                    valA = a.check.filename || '';
+                    valB = b.check.filename || '';
                     const cmp = valA.localeCompare(valB, undefined, { numeric: true, sensitivity: 'base' });
                     return newDirection === 'asc' ? cmp : -cmp;
                 } else if (column === 'timestamp') {
@@ -698,8 +718,11 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             }));
 
             const remainingFilenames = new Set(remainingEntries.map(e => e.filename));
-            const updatedStageFiles = (bundle.stageFiles || []).filter(sf => {
-                const fname = sf.file?.name || sf.name || sf.filename || sf.path;
+            const updatedStageFiles = (bundle.stageFiles || []).filter((sf, idx) => {
+                if (bundle.stageFiles?.length === bundle.payload?.entries?.length) {
+                    return idx !== stageIndexToDelete;
+                }
+                const fname = sf.filename || sf.name || sf.file?.name || sf.path;
                 return remainingFilenames.has(fname) || remainingEntries.some(e => e.filename?.endsWith(fname));
             });
 
@@ -2505,7 +2528,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
         stagedFiles.forEach(bundle => {
             if (Array.isArray(bundle.stageFiles)) {
                 bundle.stageFiles.forEach((sf, sIdx) => {
-                    const parsedData = parseReportV02(sf.content, sf.file?.name);
+                    const parsedData = parseReportV02(sf.content, sf.filename || sf.name || sf.file?.name);
                     if (parsedData) {
                         stagesList.push({
                             id: `${bundle.id}-${sIdx}`,

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -2074,6 +2074,9 @@ export const useDashboardData = (initialState, dashboardState) => {
                             record.runLabel = bundleRunLabel || record.runLabel;
                             record.run_id = entry.run_id || uuidv4();
                             record.prism_stage_index = entry.prism_stage_index !== undefined ? entry.prism_stage_index : idx;
+                            if (record.stageIndex === null || record.stageIndex === undefined) {
+                                record.stageIndex = record.prism_stage_index;
+                            }
                             if (record.workload) {
                                 record.workload.stage = record.prism_stage_index;
                             }
@@ -2096,8 +2099,22 @@ export const useDashboardData = (initialState, dashboardState) => {
                             record.payload = bundle.payload || null;
                             record.targetDashboards = bundle.targetDashboards;
                             
-                            const isDupInBatch = trulyNewStages.some(s => s.filename === record.filename && s.runId === record.runId);
-                            const isDupInExisting = otherStages.some(existingStage => existingStage.filename === record.filename && existingStage.runId === record.runId);
+                            const isDupInBatch = trulyNewStages.some(s => {
+                                if (s.runId !== record.runId) return false;
+                                if (s.run_id && record.run_id) return s.run_id === record.run_id;
+                                if (s.prism_stage_index !== undefined && record.prism_stage_index !== undefined) {
+                                    return s.prism_stage_index === record.prism_stage_index && s.filename === record.filename;
+                                }
+                                return s.filename === record.filename;
+                            });
+                            const isDupInExisting = otherStages.some(existingStage => {
+                                if (existingStage.runId !== record.runId) return false;
+                                if (existingStage.run_id && record.run_id) return existingStage.run_id === record.run_id;
+                                if (existingStage.prism_stage_index !== undefined && record.prism_stage_index !== undefined) {
+                                    return existingStage.prism_stage_index === record.prism_stage_index && existingStage.filename === record.filename;
+                                }
+                                return existingStage.filename === record.filename;
+                            });
                             
                             if (!isDupInBatch && !isDupInExisting) {
                                 trulyNewStages.push(record);
@@ -2105,14 +2122,22 @@ export const useDashboardData = (initialState, dashboardState) => {
                         }
                     }
                 } else if (bundle.stageFiles && bundle.stageFiles.length > 0) {
-                    for (const sf of bundle.stageFiles) {
-                        const identifier = sf.file?.webkitRelativePath || sf.file?.name || sf.filename || sf.name;
+                    for (let idx = 0; idx < bundle.stageFiles.length; idx++) {
+                        const sf = bundle.stageFiles[idx];
+                        const identifier = sf.filename || sf.name || sf.file?.webkitRelativePath || sf.file?.name;
                         const record = await parseReportV02(sf.validation?.parsedData || sf.content, identifier);
                         if (record) {
                             record.runId = resolvedRunId || record.runId;
                             record.runLabel = bundleRunLabel || record.runLabel;
                             const matchingEntry = bundle.payload?.entries?.find(e => e.filename === record.filename);
                             record.run_id = matchingEntry?.run_id || uuidv4();
+                            record.prism_stage_index = matchingEntry?.prism_stage_index !== undefined ? matchingEntry.prism_stage_index : idx;
+                            if (record.stageIndex === null || record.stageIndex === undefined) {
+                                record.stageIndex = record.prism_stage_index;
+                            }
+                            if (record.workload) {
+                                record.workload.stage = record.prism_stage_index;
+                            }
                             // Enrich stage record with bundle metadata
                             record.model_name = bundle.payload?.model_name || null;
                             record.hardware = bundle.payload?.hardware || null;
@@ -2132,8 +2157,22 @@ export const useDashboardData = (initialState, dashboardState) => {
                             record.payload = bundle.payload || null;
                             record.targetDashboards = bundle.targetDashboards;
                             
-                            const isDupInBatch = trulyNewStages.some(s => s.filename === record.filename && s.runId === record.runId);
-                            const isDupInExisting = otherStages.some(existingStage => existingStage.filename === record.filename && existingStage.runId === record.runId);
+                            const isDupInBatch = trulyNewStages.some(s => {
+                                if (s.runId !== record.runId) return false;
+                                if (s.run_id && record.run_id) return s.run_id === record.run_id;
+                                if (s.prism_stage_index !== undefined && record.prism_stage_index !== undefined) {
+                                    return s.prism_stage_index === record.prism_stage_index && s.filename === record.filename;
+                                }
+                                return s.filename === record.filename;
+                            });
+                            const isDupInExisting = otherStages.some(existingStage => {
+                                if (existingStage.runId !== record.runId) return false;
+                                if (existingStage.run_id && record.run_id) return existingStage.run_id === record.run_id;
+                                if (existingStage.prism_stage_index !== undefined && record.prism_stage_index !== undefined) {
+                                    return existingStage.prism_stage_index === record.prism_stage_index && existingStage.filename === record.filename;
+                                }
+                                return existingStage.filename === record.filename;
+                            });
                             
                             if (!isDupInBatch && !isDupInExisting) {
                                 trulyNewStages.push(record);

--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -347,7 +347,7 @@ export function getOriginalStageIndex(entry) {
         const num = Number(raw.stageIndex);
         if (!isNaN(num)) return num;
     }
-    const strToMatch = entry.filename || entry.run_uid || '';
+    const strToMatch = (entry.filename || entry.run_uid || '').split('/').pop();
     const match = strToMatch.match(/stage[_-]?(\d+)/i);
     if (match) {
         const num = parseInt(match[1], 10);
@@ -360,14 +360,22 @@ export function getOriginalStageIndex(entry) {
  * Compares two stage entries by original BRV02 stage number or filename.
  */
 export function compareOriginalStageOrder(a, b) {
+    const filenameA = a.filename || a.run_uid || '';
+    const filenameB = b.filename || b.run_uid || '';
+    const slashIdxA = filenameA.indexOf('/');
+    const slashIdxB = filenameB.indexOf('/');
+    const dirA = slashIdxA !== -1 ? filenameA.slice(0, slashIdxA) : '';
+    const dirB = slashIdxB !== -1 ? filenameB.slice(0, slashIdxB) : '';
+    if (dirA !== dirB) {
+        const dirCmp = dirA.localeCompare(dirB, undefined, { numeric: true, sensitivity: 'base' });
+        if (dirCmp !== 0) return dirCmp;
+    }
     const idxA = getOriginalStageIndex(a);
     const idxB = getOriginalStageIndex(b);
     if (idxA !== idxB) {
         return idxA - idxB;
     }
-    const nameA = (a.filename || a.run_uid || '').split('/').pop();
-    const nameB = (b.filename || b.run_uid || '').split('/').pop();
-    return nameA.localeCompare(nameB, undefined, { numeric: true, sensitivity: 'base' });
+    return filenameA.localeCompare(filenameB, undefined, { numeric: true, sensitivity: 'base' });
 }
 
 /**
@@ -634,6 +642,13 @@ export function stageToEntry(stage) {
         ntpot: performance.tpotMean ?? null,
         itl: performance.itlMean ?? null,
 
+        prism_stage_index: stage.prism_stage_index !== undefined && stage.prism_stage_index !== null
+            ? stage.prism_stage_index
+            : (stage.stageIndex !== undefined && stage.stageIndex !== null ? stage.stageIndex : null),
+        stageIndex: stage.prism_stage_index !== undefined && stage.prism_stage_index !== null
+            ? stage.prism_stage_index
+            : (stage.stageIndex !== undefined && stage.stageIndex !== null ? stage.stageIndex : null),
+
         source: `brv02:${runId}`,
         source_info: {
             type: 'benchmark_report_v02',
@@ -656,6 +671,12 @@ export function stageToEntry(stage) {
             tp: scenario.tp || 1,
             architecture: scenario.role || 'aggregate',
             components: components || [],
+            stage_index: stage.prism_stage_index !== undefined && stage.prism_stage_index !== null
+                ? stage.prism_stage_index
+                : (stage.stageIndex !== undefined && stage.stageIndex !== null ? stage.stageIndex : null),
+            stage: stage.prism_stage_index !== undefined && stage.prism_stage_index !== null
+                ? stage.prism_stage_index
+                : (stage.stageIndex !== undefined && stage.stageIndex !== null ? stage.stageIndex : null),
         },
 
         workload: {
@@ -663,7 +684,9 @@ export function stageToEntry(stage) {
             output_tokens: scenario.osl ?? null,
             target_qps: scenario.rateQps ?? null,
             concurrency: scenario.concurrency ?? null,
-            stage: stage.stageIndex,
+            stage: stage.prism_stage_index !== undefined && stage.prism_stage_index !== null
+                ? stage.prism_stage_index
+                : (stage.stageIndex !== undefined && stage.stageIndex !== null ? stage.stageIndex : null),
         },
 
         metrics: {

--- a/src/utils/manualCoalescing.test.js
+++ b/src/utils/manualCoalescing.test.js
@@ -16,7 +16,7 @@ import { describe, it, expect } from 'vitest';
 import { v4 as uuidv4 } from 'uuid';
 import { validatePrismUploadStructure } from './benchmarkValidator.js';
 import { PrismResultPayloadSchema } from '../../server/results/api.ts';
-import { mutateRawReportMetadata, compareOriginalStageOrder } from './benchmarkReportV02Parser.js';
+import { mutateRawReportMetadata, compareOriginalStageOrder, getOriginalStageIndex, parseReportV02, groupStagesIntoRuns, stageToEntry } from './benchmarkReportV02Parser.js';
 
 describe('manual benchmark coalescing', () => {
     it('validates coalesced payload schema with prism_stage_index', () => {
@@ -214,5 +214,261 @@ describe('manual benchmark coalescing', () => {
         expect(updatedReport.scenario.stack[0].standardized.model.name).toBe("qwen3_coder_480b");
         expect(updatedReport.scenario.load.native.config.server.model_name).toBe("qwen3_coder_480b");
         expect(updatedReport.scenario.stack[0].standardized.accelerator.model).toBe("H100");
+    });
+
+    it('preserves all stages with identical filenames during coalesce staging without dropping or summing metrics', async () => {
+        const coalescedRunId = uuidv4();
+        const stageConfigs = [
+            { concurrency: 16, tput: 500.0, tpotSec: 0.040, uid: "ubench-run-c16" },
+            { concurrency: 32, tput: 1000.0, tpotSec: 0.080, uid: "ubench-run-c32" },
+            { concurrency: 64, tput: 1500.0, tpotSec: 0.173, uid: "ubench-run-c64" }
+        ];
+
+        // All 3 stage reports come from separate runs with the exact same filename
+        const entries = stageConfigs.map((cfg, idx) => ({
+            run_id: uuidv4(),
+            run_description: "Coalesced uBench Suite",
+            filename: "llmd_benchmark_report.json",
+            prism_stage_index: idx,
+            raw_report: {
+                version: "0.2",
+                run: { uid: cfg.uid, description: "Coalesced uBench Suite" },
+                scenario: {
+                    stack: [
+                        {
+                            standardized: {
+                                role: "aggregate",
+                                model: { name: "meta-llama/Llama-3-8B-Instruct" },
+                                accelerator: { model: "TPU v6e", count: 4 }
+                            }
+                        }
+                    ],
+                    load: {
+                        standardized: {
+                            tool: "vllm",
+                            concurrency: cfg.concurrency
+                        }
+                    }
+                },
+                results: {
+                    request_performance: {
+                        aggregate: {
+                            throughput: { output_token_rate: { mean: cfg.tput } },
+                            latency: {
+                                request_latency: { mean: 0.5 },
+                                time_to_first_token: { mean: 0.05 },
+                                time_per_output_token: { mean: cfg.tpotSec }
+                            }
+                        }
+                    }
+                }
+            }
+        }));
+
+        // Simulate handleValidatedUpload stage extraction and deduplication logic
+        const trulyNewStages = [];
+        for (let idx = 0; idx < entries.length; idx++) {
+            const entry = entries[idx];
+            const record = await parseReportV02(entry.raw_report, entry.filename);
+            expect(record).toBeDefined();
+
+            record.runId = coalescedRunId;
+            record.runLabel = "Coalesced uBench Suite";
+            record.run_id = entry.run_id;
+            record.prism_stage_index = entry.prism_stage_index !== undefined ? entry.prism_stage_index : idx;
+            if (record.stageIndex === null || record.stageIndex === undefined) {
+                record.stageIndex = record.prism_stage_index;
+            }
+            if (record.workload) {
+                record.workload.stage = record.prism_stage_index;
+            }
+
+            const isDupInBatch = trulyNewStages.some(s => {
+                if (s.runId !== record.runId) return false;
+                if (s.run_id && record.run_id) return s.run_id === record.run_id;
+                if (s.prism_stage_index !== undefined && record.prism_stage_index !== undefined) {
+                    return s.prism_stage_index === record.prism_stage_index && s.filename === record.filename;
+                }
+                return s.filename === record.filename;
+            });
+
+            if (!isDupInBatch) {
+                trulyNewStages.push(record);
+            }
+        }
+
+        // Verify that NO stages were dropped due to sharing filename "llmd_benchmark_report.json"
+        expect(trulyNewStages.length).toBe(3);
+
+        // Group into runs
+        const groupedRuns = groupStagesIntoRuns(trulyNewStages);
+        expect(groupedRuns.length).toBe(1);
+        const run = groupedRuns[0];
+        expect(run.runId).toBe(coalescedRunId);
+        expect(run.stages.length).toBe(3);
+
+        // Convert each stage to entry (as useDashboardData does for scatter chart and tables)
+        const entriesForDashboard = run.stages.map(stageToEntry);
+        expect(entriesForDashboard.length).toBe(3);
+
+        // Verify each stage preserves its distinct metrics without summation
+        expect(entriesForDashboard[0].throughput).toBe(500.0);
+        expect(entriesForDashboard[0].time_per_output_token).toBe(40.0); // 0.040s converted to 40ms
+        expect(entriesForDashboard[0].workload.stage).toBe(0);
+        expect(entriesForDashboard[0].prism_stage_index).toBe(0);
+
+        expect(entriesForDashboard[1].throughput).toBe(1000.0);
+        expect(entriesForDashboard[1].time_per_output_token).toBe(80.0); // 0.080s converted to 80ms
+        expect(entriesForDashboard[1].workload.stage).toBe(1);
+        expect(entriesForDashboard[1].prism_stage_index).toBe(1);
+
+        expect(entriesForDashboard[2].throughput).toBe(1500.0);
+        expect(entriesForDashboard[2].time_per_output_token).toBe(173.0); // 0.173s converted to 173ms
+        expect(entriesForDashboard[2].workload.stage).toBe(2);
+        expect(entriesForDashboard[2].prism_stage_index).toBe(2);
+
+        // Ensure metrics are NOT summed into one single row
+        expect(entriesForDashboard.map(e => e.time_per_output_token)).toEqual([40.0, 80.0, 173.0]);
+        expect(entriesForDashboard.map(e => e.throughput)).toEqual([500.0, 1000.0, 1500.0]);
+    });
+
+    it('correctly deduplicates true duplicate entries with identical run_id or prism_stage_index', async () => {
+        const runId = uuidv4();
+        const stageId = uuidv4();
+        const stageRawReport = {
+            version: "0.2",
+            run: { uid: "duplicate-check-uid" },
+            scenario: { stack: [{ standardized: { role: "aggregate", model: { name: "model-x" } } }] },
+            results: { request_performance: { aggregate: { throughput: { output_token_rate: { mean: 120 } } } } }
+        };
+
+        const firstRecord = await parseReportV02(stageRawReport, "llmd_benchmark_report.json");
+        firstRecord.runId = runId;
+        firstRecord.run_id = stageId;
+        firstRecord.prism_stage_index = 0;
+
+        const duplicateRecord = await parseReportV02(stageRawReport, "llmd_benchmark_report.json");
+        duplicateRecord.runId = runId;
+        duplicateRecord.run_id = stageId; // Same stage run_id
+        duplicateRecord.prism_stage_index = 0;
+
+        const trulyNewStages = [firstRecord];
+        const isDup = trulyNewStages.some(s => {
+            if (s.runId !== duplicateRecord.runId) return false;
+            if (s.run_id && duplicateRecord.run_id) return s.run_id === duplicateRecord.run_id;
+            if (s.prism_stage_index !== undefined && duplicateRecord.prism_stage_index !== undefined) {
+                return s.prism_stage_index === duplicateRecord.prism_stage_index && s.filename === duplicateRecord.filename;
+            }
+            return s.filename === duplicateRecord.filename;
+        });
+
+        expect(isDup).toBe(true);
+    });
+
+    it('prepends original run label to filenames when coalescing runs', () => {
+        const bundleA = {
+            id: 'bundle-a',
+            name: 'vLLM Baseline',
+            payload: {
+                runLabel: 'vLLM Baseline',
+                entries: [
+                    { filename: 'llmd_benchmark_report.json', raw_report: { version: '0.2' } }
+                ]
+            },
+            stageFiles: [
+                { filename: 'llmd_benchmark_report.json', name: 'llmd_benchmark_report.json' }
+            ]
+        };
+
+        const bundleB = {
+            id: 'bundle-b',
+            name: 'SGLang Baseline',
+            payload: {
+                runLabel: 'SGLang Baseline',
+                entries: [
+                    { filename: 'llmd_benchmark_report.json', raw_report: { version: '0.2' } }
+                ]
+            },
+            stageFiles: [
+                { filename: 'llmd_benchmark_report.json', name: 'llmd_benchmark_report.json' }
+            ]
+        };
+
+        const targetBundles = [bundleA, bundleB];
+        const combinedEntries = [];
+        const combinedStageFiles = [];
+
+        targetBundles.forEach(bundle => {
+            const originalRunLabel = bundle.payload?.runLabel || bundle.name || bundle.dirKey || '';
+
+            if (bundle.stageFiles) {
+                const mappedStageFiles = bundle.stageFiles.map(sf => {
+                    const originalName = sf.filename || sf.name || sf.file?.name || '';
+                    const newFilename = originalRunLabel && !originalName.startsWith(`${originalRunLabel}/`)
+                        ? `${originalRunLabel}/${originalName}`
+                        : originalName;
+                    return {
+                        ...sf,
+                        name: newFilename,
+                        filename: newFilename
+                    };
+                });
+                combinedStageFiles.push(...mappedStageFiles);
+            }
+
+            const entries = bundle.payload?.entries || [];
+            entries.forEach(entry => {
+                const originalFilePath = entry.filename || entry.run_uid || 'report.json';
+                const newFilename = originalRunLabel && !originalFilePath.startsWith(`${originalRunLabel}/`)
+                    ? `${originalRunLabel}/${originalFilePath}`
+                    : originalFilePath;
+
+                combinedEntries.push({
+                    ...entry,
+                    filename: newFilename
+                });
+            });
+        });
+
+        expect(combinedEntries[0].filename).toBe('vLLM Baseline/llmd_benchmark_report.json');
+        expect(combinedEntries[1].filename).toBe('SGLang Baseline/llmd_benchmark_report.json');
+        expect(combinedStageFiles[0].filename).toBe('vLLM Baseline/llmd_benchmark_report.json');
+        expect(combinedStageFiles[1].filename).toBe('SGLang Baseline/llmd_benchmark_report.json');
+
+        // Does not double-prepend if already prefixed
+        const rePrefixedFilename = bundleA.payload.runLabel && !combinedEntries[0].filename.startsWith(`${bundleA.payload.runLabel}/`)
+            ? `${bundleA.payload.runLabel}/${combinedEntries[0].filename}`
+            : combinedEntries[0].filename;
+        expect(rePrefixedFilename).toBe('vLLM Baseline/llmd_benchmark_report.json');
+    });
+
+    it('sorts coalesced stages grouping by run label directory before stage index', () => {
+        const entries = [
+            { filename: 'vLLM Baseline/stage_1.yaml', raw_report: { workload: { stage: 1 } } },
+            { filename: 'vLLM Baseline/stage_0.yaml', raw_report: { workload: { stage: 0 } } },
+            { filename: 'SGLang Baseline/stage_1.yaml', raw_report: { workload: { stage: 1 } } },
+            { filename: 'SGLang Baseline/stage_0.yaml', raw_report: { workload: { stage: 0 } } }
+        ];
+
+        entries.sort(compareOriginalStageOrder);
+
+        expect(entries.map(e => e.filename)).toEqual([
+            'SGLang Baseline/stage_0.yaml',
+            'SGLang Baseline/stage_1.yaml',
+            'vLLM Baseline/stage_0.yaml',
+            'vLLM Baseline/stage_1.yaml'
+        ]);
+    });
+
+    it('extracts stage number from basename even if run label has numbers or stage keywords', () => {
+        const entryWithStageInLabel = {
+            filename: 'Stage 3 Sweep/stage_0.yaml'
+        };
+        expect(getOriginalStageIndex(entryWithStageInLabel)).toBe(0);
+
+        const entryWithNumberInLabel = {
+            filename: 'Cluster-42/stage-1.json'
+        };
+        expect(getOriginalStageIndex(entryWithNumberInLabel)).toBe(1);
     });
 });


### PR DESCRIPTION
## What does this PR do?

This PR fixes stage loss when coalescing multiple benchmarks and improves stage traceability and sorting:

- **Coalesced Stage Loss**:
  - **Problem**: When combining multiple benchmark runs into a single run, only the first stage was kept. Subsequent stages were dropped, causing metrics in the dashboard to collapse into a single data point with seemingly summed values.
  - **Cause**: Staged upload deduplication identified unique stages using only the run ID and filename. Because benchmark reports commonly share the same default filename (`llmd_benchmark_report.json`), every stage after stage 0 collided and was discarded as a duplicate.
  - **Fix**: Deduplicate and index stages using their unique stage IDs and sequential stage order rather than filename alone, and propagate the assigned sequence across all stage representations.

- **Stage Provenance and Sorting**:
  - **Problem**: After coalescing runs, users could not tell which original benchmark each stage came from, and sorting by filename stripped directory paths and broke run grouping.
  - **Cause**: Stages kept only their raw filenames without source context, and stage sorting stripped path prefixes.
  - **Fix**: Prepend each stage's filename with its originating run label (`<run label>/<original file path>`), and update stage sorting to preserve the full path and keep stages grouped by their source run.

## Why is this change needed?

Coalescing multiple benchmark runs is essential for combining sweeps and comparing configurations under a single unified benchmark. Dropping stages broke this workflow and distorted visualized metrics, while missing run labels made it difficult to identify and organize the combined stages.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

- Added unit tests covering:
  - Preserving all stages sharing identical filenames without dropping rows or summing metrics.
  - Prepending originating run labels to filenames without double-prefixing.
  - Grouping and sorting stages by run label directory.
  - Extracting stage numbers cleanly when run labels include numbers.
- Verified all unit tests pass (`npm test`).
- Verified production build completes cleanly (`npm run build`).
- Verified linter checks pass on modified files (`npm run lint`).

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Linters pass (`npm run lint`)
- [ ] Documentation updated (if applicable)

## Related Issues