### PR TITLE
Add glob search support to Results Store

### DIFF
--- a/src/components/DataInspector.jsx
+++ b/src/components/DataInspector.jsx
@@ -17,6 +17,7 @@ import { X, Search, AlertTriangle, CheckCircle, Database, FileJson, ArrowRight }
 import { normalizeQualityModelName } from '../utils/qualityParser';
 import { Badge, Checkbox, EmptyState, Input, Select } from './ui';
 import { cn } from '../utils/cn';
+import { createGlobMatcher } from '../utils/globUtils';
 
 const DataInspector = ({ data, qualityMetrics, isOpen, onClose, initialSelectionId }) => {
   const [searchTerm, setSearchTerm] = useState('');
@@ -58,12 +59,14 @@ const DataInspector = ({ data, qualityMetrics, isOpen, onClose, initialSelection
       );
     }
 
-    if (searchTerm) {
-      const term = searchTerm.toLowerCase();
+    if (searchTerm && searchTerm.trim()) {
+      const matcher = createGlobMatcher(searchTerm);
       result = result.filter(d => 
-        (d.metadata?.model_name || '').toLowerCase().includes(term) ||
-        (d.source_info?.origin || '').toLowerCase().includes(term) ||
-        (d.source_info?.file_identifier || '').toLowerCase().includes(term)
+        (d.model && matcher(d.model)) ||
+        (d.metadata?.model_name && matcher(d.metadata.model_name)) ||
+        (d.hardware && matcher(d.hardware)) ||
+        (d.source_info?.origin && matcher(d.source_info.origin)) ||
+        (d.source_info?.file_identifier && matcher(d.source_info.file_identifier))
       );
     }
 

--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -955,7 +955,7 @@ export const FilterPanel = ({
                                 type="text"
                                 value={searchTerm}
                                 onChange={(e) => setSearchTerm(e.target.value)}
-                                placeholder="Search by model name or hardware..."
+                                placeholder="Search by model, hardware, or glob (*, ?)..."
                                 className="pl-9 pr-4 text-xs rounded-xl font-medium"
                             />
                         </div>

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -29,6 +29,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { downloadRunBRV02, downloadSingleStageYaml, getRawPrismCloudPayload } from '../../utils/brv02Exporter';
 import { parseDataUri } from '../../utils/dataParser';
 import { forkBenchmark } from '../../utils/benchmarkForker';
+import { createGlobMatcher, matchesBenchmarkStat } from '../../utils/globUtils';
 
 const getStatusTooltipText = (status, sub) => {
     switch (status) {
@@ -1277,15 +1278,10 @@ export const UnifiedDataTable = (props) => {
             }
         }
 
-        // Apply Text Search Term Filter
-        if (searchTerm) {
-            const term = searchTerm.toLowerCase();
-            stats = stats.filter(stat => {
-                const modelMatch = (stat.model || '').toLowerCase().includes(term);
-                const hwMatch = (stat.hardware || '').toLowerCase().includes(term);
-                const confMatch = (stat.configuration || '').toLowerCase().includes(term);
-                return modelMatch || hwMatch || confMatch;
-            });
+        // Apply Text Search Term Filter with globbing (* and ?)
+        if (searchTerm && searchTerm.trim()) {
+            const matcher = createGlobMatcher(searchTerm);
+            stats = stats.filter(stat => matchesBenchmarkStat(stat, matcher));
         }
 
         return stats;

--- a/src/utils/globUtils.js
+++ b/src/utils/globUtils.js
@@ -1,0 +1,133 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Converts a glob pattern containing `*` and `?` wildcards into a RegExp pattern string.
+ * All regex special characters except `*` and `?` are escaped.
+ * Multiple consecutive asterisks (e.g. `**`) are collapsed to a single `.*`.
+ *
+ * @param {string} pattern - The glob search pattern.
+ * @returns {string} The regular expression pattern string.
+ */
+export function globToRegexPattern(pattern) {
+    if (!pattern) return '';
+
+    // Step 1: Escape regex special characters except '*' and '?'
+    // Special regex characters: \ ^ $ . + ( ) [ ] { } |
+    const escaped = pattern.replace(/[\\^$.+()[\]{}|]/g, '\\$&');
+
+    // Step 2: Convert glob wildcards to regex equivalents
+    // - One or more '*' -> '.*'
+    // - '?' -> '.'
+    return escaped
+        .replace(/\*+/g, '.*')
+        .replace(/\?/g, '.');
+}
+
+/**
+ * Creates a reusable matcher function for a given glob pattern.
+ * Supports simple `*` (zero or more characters) and `?` (single character) wildcard syntax.
+ * Matches anywhere in the target string (unanchored, case-insensitive by default).
+ *
+ * @param {string} pattern - The glob search term.
+ * @param {Object} [options]
+ * @param {boolean} [options.caseSensitive=false] - Whether matching should be case-sensitive.
+ * @returns {(target: any) => boolean} Matcher function returning true if target matches.
+ */
+export function createGlobMatcher(pattern, { caseSensitive = false } = {}) {
+    const trimmed = (pattern || '').trim();
+    if (!trimmed) {
+        return () => true;
+    }
+
+    try {
+        const regexStr = globToRegexPattern(trimmed);
+        const flags = caseSensitive ? '' : 'i';
+        const regex = new RegExp(regexStr, flags);
+
+        return (target) => {
+            if (target === null || target === undefined) return false;
+            return regex.test(String(target));
+        };
+    } catch {
+        // Fallback to substring matching if regex creation fails
+        const lowerPattern = trimmed.toLowerCase();
+        return (target) => {
+            if (target === null || target === undefined) return false;
+            return String(target).toLowerCase().includes(lowerPattern);
+        };
+    }
+}
+
+/**
+ * Convenience helper to test if a target string matches a glob pattern.
+ *
+ * @param {string} pattern - Glob search pattern with * and ?
+ * @param {any} target - Target string or value to test
+ * @param {Object} [options]
+ * @returns {boolean}
+ */
+export function matchesGlob(pattern, target, options) {
+    return createGlobMatcher(pattern, options)(target);
+}
+
+/**
+ * Checks if a benchmark stat or entry matches a search query using glob syntax.
+ *
+ * @param {Object} stat - Benchmark stat or entry object.
+ * @param {string|Function} search - The search term string or a pre-compiled matcher function.
+ * @returns {boolean}
+ */
+export function matchesBenchmarkStat(stat, search) {
+    if (!stat) return false;
+    if (!search) return true;
+
+    const matcher = typeof search === 'function' ? search : createGlobMatcher(search);
+
+    // Primary benchmark metadata
+    if (stat.model && matcher(stat.model)) return true;
+    if (stat.model_name && matcher(stat.model_name)) return true;
+    if (stat.hardware && matcher(stat.hardware)) return true;
+    if (stat.configuration && matcher(stat.configuration)) return true;
+    if (stat.runLabel && matcher(stat.runLabel)) return true;
+    if (stat.benchmarkKey && matcher(stat.benchmarkKey)) return true;
+
+    // Authorship and provenance
+    if (stat.forked_from && matcher(stat.forked_from)) return true;
+    if (stat.github_author?.username && matcher(stat.github_author.username)) return true;
+    if (stat.github_author?.name && matcher(stat.github_author.name)) return true;
+
+    // Source info
+    if (stat.source && matcher(stat.source)) return true;
+    if (stat.source_info?.origin && matcher(stat.source_info.origin)) return true;
+    if (stat.source_info?.file_identifier && matcher(stat.source_info.file_identifier)) return true;
+
+    // Underlying run data items if present
+    if (Array.isArray(stat.data) && stat.data.length > 0) {
+        for (const item of stat.data) {
+            if (item.model && matcher(item.model)) return true;
+            if (item.model_name && matcher(item.model_name)) return true;
+            if (item.hardware && matcher(item.hardware)) return true;
+            if (item.configuration && matcher(item.configuration)) return true;
+            if (item.runLabel && matcher(item.runLabel)) return true;
+            if (item.run_id && matcher(item.run_id)) return true;
+            if (item.filename && matcher(item.filename)) return true;
+            if (item.backend && matcher(item.backend)) return true;
+            if (item.metadata?.model_name && matcher(item.metadata.model_name)) return true;
+            if (item.metadata?.hardware && matcher(item.metadata.hardware)) return true;
+        }
+    }
+
+    return false;
+}

--- a/src/utils/globUtils.test.js
+++ b/src/utils/globUtils.test.js
@@ -1,0 +1,192 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import {
+    globToRegexPattern,
+    createGlobMatcher,
+    matchesGlob,
+    matchesBenchmarkStat
+} from './globUtils';
+
+describe('globUtils', () => {
+    describe('globToRegexPattern', () => {
+        it('should return empty string for empty inputs', () => {
+            expect(globToRegexPattern('')).toBe('');
+            expect(globToRegexPattern(null)).toBe('');
+            expect(globToRegexPattern(undefined)).toBe('');
+        });
+
+        it('should escape regex special characters', () => {
+            expect(globToRegexPattern('llama-3.1')).toBe('llama-3\\.1');
+            expect(globToRegexPattern('(tp=8)')).toBe('\\(tp=8\\)');
+            expect(globToRegexPattern('[vllm]')).toBe('\\[vllm\\]');
+            expect(globToRegexPattern('a+b^c$d{e}|f\\g')).toBe('a\\+b\\^c\\$d\\{e\\}\\|f\\\\g');
+        });
+
+        it('should convert * to .* and collapse consecutive asterisks', () => {
+            expect(globToRegexPattern('llama*8b')).toBe('llama.*8b');
+            expect(globToRegexPattern('*llama*')).toBe('.*llama.*');
+            expect(globToRegexPattern('llama***8b')).toBe('llama.*8b');
+        });
+
+        it('should convert ? to .', () => {
+            expect(globToRegexPattern('llama-?-8b')).toBe('llama-.-8b');
+            expect(globToRegexPattern('???')).toBe('...');
+        });
+
+        it('should handle combined * and ? with special characters', () => {
+            expect(globToRegexPattern('meta-llama-3.1*8b?(tp=1)')).toBe('meta-llama-3\\.1.*8b.\\(tp=1\\)');
+        });
+    });
+
+    describe('createGlobMatcher & matchesGlob', () => {
+        it('should match plain substring queries anywhere in target', () => {
+            const matcher = createGlobMatcher('llama');
+            expect(matcher('meta-llama-3-8b')).toBe(true);
+            expect(matcher('LLAMA-3-70B')).toBe(true);
+            expect(matcher('mistral-7b')).toBe(false);
+        });
+
+        it('should match with * wildcard anywhere in the string', () => {
+            expect(matchesGlob('llama*8b', 'meta-llama-3-8b-instruct')).toBe(true);
+            expect(matchesGlob('llama*8b', 'meta-llama-3-70b-instruct')).toBe(false);
+            expect(matchesGlob('*8b', 'meta-llama-3-8b')).toBe(true);
+            expect(matchesGlob('8b*', '8b-instruct-v0.1')).toBe(true);
+            expect(matchesGlob('*llama*', 'meta-llama-3-8b')).toBe(true);
+            expect(matchesGlob('h100*sxm*80gb', '8x NVIDIA H100 SXM5 80GB HBM3')).toBe(true);
+            expect(matchesGlob('h100*sxm*80gb', '8x NVIDIA H100 PCIe 80GB')).toBe(false);
+        });
+
+        it('should match with ? single character wildcard', () => {
+            expect(matchesGlob('llama-?-8b', 'meta-llama-3-8b')).toBe(true);
+            expect(matchesGlob('llama-?-8b', 'meta-llama-2-8b')).toBe(true);
+            expect(matchesGlob('llama-?-8b', 'meta-llama-3.1-8b')).toBe(false);
+            expect(matchesGlob('llama-?.?-8b', 'meta-llama-3.1-8b')).toBe(true);
+        });
+
+        it('should treat regex special characters as literal text', () => {
+            expect(matchesGlob('llama-3.1', 'meta-llama-3.1-8b')).toBe(true);
+            expect(matchesGlob('llama-3.1', 'meta-llama-301-8b')).toBe(false);
+            expect(matchesGlob('(tp=8)', 'vLLM (tp=8) config')).toBe(true);
+            expect(matchesGlob('(tp=8)', 'vLLM (tp=4) config')).toBe(false);
+            expect(matchesGlob('[vllm]', '[vllm] serving engine')).toBe(true);
+            expect(matchesGlob('a+b', 'a+b')).toBe(true);
+            expect(matchesGlob('a+b', 'ab')).toBe(false);
+        });
+
+        it('should respect case sensitivity option', () => {
+            expect(matchesGlob('LLAMA', 'meta-llama-3-8b', { caseSensitive: false })).toBe(true);
+            expect(matchesGlob('LLAMA', 'meta-llama-3-8b', { caseSensitive: true })).toBe(false);
+            expect(matchesGlob('llama', 'meta-llama-3-8b', { caseSensitive: true })).toBe(true);
+        });
+
+        it('should match all for empty or whitespace query', () => {
+            expect(matchesGlob('', 'anything')).toBe(true);
+            expect(matchesGlob('   ', 'anything')).toBe(true);
+            expect(matchesGlob(null, 'anything')).toBe(true);
+            expect(matchesGlob(undefined, 'anything')).toBe(true);
+        });
+
+        it('should return false safely for null or undefined target', () => {
+            expect(matchesGlob('test', null)).toBe(false);
+            expect(matchesGlob('test', undefined)).toBe(false);
+        });
+
+        it('should coerce numbers or other types to string', () => {
+            expect(matchesGlob('*80*', 80)).toBe(true);
+            expect(matchesGlob('?0', 80)).toBe(true);
+            expect(matchesGlob('?0', 800)).toBe(true);
+        });
+    });
+
+    describe('matchesBenchmarkStat', () => {
+        const sampleStat = {
+            benchmarkKey: 'meta-llama/Meta-Llama-3-70B-Instruct::8x H100 SXM5 80GB::vLLM 0.6.3::isl=512_osl=128',
+            model: 'meta-llama/Meta-Llama-3-70B-Instruct',
+            model_name: 'Meta-Llama-3-70B-Instruct',
+            hardware: '8x NVIDIA H100 SXM5 80GB',
+            configuration: 'vLLM 0.6.3 (tp=8)',
+            runLabel: 'Baseline vLLM v0.6.3 benchmark',
+            forked_from: 'run-12345-orig',
+            github_author: { username: 'octocat', name: 'Mona Lisa Octocat' },
+            source: 'gcs:llm-d-benchmarks',
+            source_info: {
+                origin: 'gcs:llm-d-benchmarks',
+                file_identifier: 'llama3-70b-h100.json'
+            },
+            data: [
+                {
+                    run_id: 'run-98765-uuid',
+                    filename: 'report-2026-03-26.json',
+                    backend: 'vLLM',
+                    model: 'Meta-Llama-3-70B-Instruct',
+                    hardware: '8x NVIDIA H100 SXM5 80GB'
+                }
+            ]
+        };
+
+        it('should match on model name with glob wildcards', () => {
+            expect(matchesBenchmarkStat(sampleStat, 'llama*70b')).toBe(true);
+            expect(matchesBenchmarkStat(sampleStat, 'llama*8b')).toBe(false);
+            expect(matchesBenchmarkStat(sampleStat, '*llama*instruct')).toBe(true);
+        });
+
+        it('should match on hardware with glob wildcards', () => {
+            expect(matchesBenchmarkStat(sampleStat, 'h100*80gb')).toBe(true);
+            expect(matchesBenchmarkStat(sampleStat, 'h100*pcie')).toBe(false);
+            expect(matchesBenchmarkStat(sampleStat, '?x nvidia*')).toBe(true);
+        });
+
+        it('should match on configuration', () => {
+            expect(matchesBenchmarkStat(sampleStat, 'vllm*tp=8')).toBe(true);
+            expect(matchesBenchmarkStat(sampleStat, 'vllm*tp=4')).toBe(false);
+            expect(matchesBenchmarkStat(sampleStat, 'vllm 0.6.?')).toBe(true);
+        });
+
+        it('should match on runLabel', () => {
+            expect(matchesBenchmarkStat(sampleStat, 'baseline*v0.6.3*')).toBe(true);
+        });
+
+        it('should match across full benchmarkKey', () => {
+            expect(matchesBenchmarkStat(sampleStat, 'llama*h100*vllm')).toBe(true);
+        });
+
+        it('should match on github author', () => {
+            expect(matchesBenchmarkStat(sampleStat, 'octocat')).toBe(true);
+            expect(matchesBenchmarkStat(sampleStat, 'mona*lisa')).toBe(true);
+        });
+
+        it('should match on source or file identifier', () => {
+            expect(matchesBenchmarkStat(sampleStat, 'llama3*h100.json')).toBe(true);
+            expect(matchesBenchmarkStat(sampleStat, 'gcs:llm-d-*')).toBe(true);
+        });
+
+        it('should match on data run_id or filename', () => {
+            expect(matchesBenchmarkStat(sampleStat, 'run-98765*')).toBe(true);
+            expect(matchesBenchmarkStat(sampleStat, 'report-2026-*.json')).toBe(true);
+        });
+
+        it('should accept pre-compiled matcher function', () => {
+            const matcher = createGlobMatcher('llama*70b');
+            expect(matchesBenchmarkStat(sampleStat, matcher)).toBe(true);
+        });
+
+        it('should handle null or empty values gracefully', () => {
+            expect(matchesBenchmarkStat(null, 'llama')).toBe(false);
+            expect(matchesBenchmarkStat(sampleStat, '')).toBe(true);
+            expect(matchesBenchmarkStat(sampleStat, null)).toBe(true);
+        });
+    });
+});


### PR DESCRIPTION
## What does this PR do?

Adds glob wildcard search matching (`*` and `?`) anywhere in the query string across the Prism Results Store explorer table and Data Inspector search bars.

- Adds `globToRegexPattern` and `createGlobMatcher` in `src/utils/globUtils.js` to parse `*` and `?` wildcards into unanchored, case-insensitive regular expressions while safely escaping all other regex special characters.
- Integrates glob matching into `UnifiedDataTable.jsx` for filtering benchmark models, hardware, configurations, run labels, authors, benchmark keys, and source origins.
- Integrates glob matching into `DataInspector.jsx`.
- Updates the search input placeholder to reflect wildcard support.
- Adds comprehensive Vitest unit tests in `src/utils/globUtils.test.js` covering prefix, infix, and suffix `*` wildcards, `?` single-character wildcards, regex character escaping, and benchmark stat matching.

## Why is this change needed?

Allows users to perform flexible pattern queries (e.g. `llama*8b`, `h100*80gb`, `vllm*`, `llama-?-8b`) across large benchmark datasets directly from the search bar.

## How was this tested?

- [x] Unit tests added/updated (`npm test` passes all 77 tests in 8 suites including 23 new glob tests)
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Linters pass (`npm run lint`)
- [ ] Documentation updated (if applicable)

## Related Issues