### PR TITLE
Normalize latency units and refine staging table

### DIFF
--- a/server/results/processing.ts
+++ b/server/results/processing.ts
@@ -14,6 +14,7 @@
 
 import { readResultPayload, writeResult, deleteResult } from './gcs.ts';
 import { validatePrismUploadStructure } from '../../src/utils/benchmarkValidator.js';
+import { normalizeReportUnits } from '../../src/utils/benchmarkReportV02Parser.js';
 import { PrismSubmissionState } from './api.ts';
 
 export interface ProcessSubmissionResult {
@@ -40,8 +41,17 @@ export async function processSubmission(
         // Resolve contributor/author username
         const username = payload.github_author?.username || 'Unknown';
 
-        // Perform validation checks
+        // Perform validation checks before normalizing units so original unit presence is validated
         const validation = validatePrismUploadStructure(payload, { isUpload: true });
+
+        // Ensure all entry raw reports have normalized units (seconds)
+        if (payload.entries && Array.isArray(payload.entries)) {
+            for (const entry of payload.entries) {
+                if (entry.raw_report) {
+                    entry.raw_report = normalizeReportUnits(entry.raw_report);
+                }
+            }
+        }
 
         // If validation fails, drop the submission completely from GCS storage
         if (!validation.isValid) {

--- a/server/results/routes/submit.ts
+++ b/server/results/routes/submit.ts
@@ -19,6 +19,7 @@ import { isPlaygroundMode } from '../../iam.ts';
 import { writeResult, deleteResult } from '../gcs.ts';
 import { processSubmission } from '../processing.ts';
 import { PrismSubmissionState, PrismResultPayload } from '../api.ts';
+import { normalizeReportUnits } from '../../../src/utils/benchmarkReportV02Parser.js';
 
 export interface ResultsSubmitResponse {
     success: boolean;
@@ -86,6 +87,9 @@ export async function submitResultsHandler(
     if (uploadData.entries && Array.isArray(uploadData.entries)) {
         for (const entry of uploadData.entries) {
             entry.run_id = crypto.randomUUID();
+            if (entry.raw_report) {
+                entry.raw_report = normalizeReportUnits(entry.raw_report);
+            }
         }
     }
 

--- a/specs/main/completed/results-api/README.md
+++ b/specs/main/completed/results-api/README.md
@@ -66,6 +66,10 @@ upstream repository:
   individual BRV0.2 files are parsed, grouped into runs, normalized, and
   enriched with fallback metadata, refer to the dedicated
   [Parser & Data Model Specification](parser_and_data_model.md).
+- **Unit Handling & Normalization Spec:** For detailed specifications on how
+  latency and throughput units are parsed, converted to milliseconds, defaulted
+  upon omission, and validated against suspicious values, refer to the dedicated
+  [Unit Handling Specification](unit_handling.md).
 
 ---
 

--- a/specs/main/completed/results-api/parser_and_data_model.md
+++ b/specs/main/completed/results-api/parser_and_data_model.md
@@ -81,6 +81,13 @@ containing:
     - End-to-End request latency mean, p50, and p99.
 - Total requests count and failure count.
 
+> [!NOTE]
+>
+> For comprehensive details on unit normalization factors, per-token vs.
+> request-level latency handling, missing unit assumptions, and Zod schema
+> preservation rules, see the dedicated
+> [Unit Handling Specification](unit_handling.md).
+
 ### 2.4 Observability Metrics (Optional)
 
 - Mean, p50, and p99 of KV cache utilization (normalized to 0-100%).

--- a/specs/main/completed/results-api/unit_handling.md
+++ b/specs/main/completed/results-api/unit_handling.md
@@ -1,0 +1,233 @@
+# Prism Results API Unit Handling, Defaulting & Normalization Specification
+
+This document serves as the canonical reference for how Prism parses,
+canonicalizes, validates, and defaults metric units across benchmark reports.
+
+---
+
+## 1. Core Architecture & Unit Representations
+
+Prism operates with a **dual unit representation** model across its pipeline:
+
+```mermaid
+graph LR
+    A[Upstream Raw BRv0.2 Report] -->|Preserves original seconds & units| B[Raw Report Store / GCS]
+    A -->|Normalization to canonical units| C[normalizeReportUnits]
+    C -->|Canonical seconds: s, s/token| B
+    A -->|parseReportV02 LatencyValuesSchema| D[Performance Record]
+    D -->|Converted to milliseconds: toMs| E[Dashboard UI / Charts / Tables]
+```
+
+1. **Storage / Ingestion Tier (Canonical Units)**:
+    - Request-level latencies (`request_latency`, `time_to_first_token`, pod
+      startup times) are stored in **seconds (`s`)**.
+    - Per-token latencies (`time_per_output_token`, `inter_token_latency`,
+      `normalized_time_per_output_token`) are stored in **seconds per token
+      (`s/token`)**.
+    - Throughput metrics are stored in rates (**`tokens/s`** for token rates,
+      **`queries/s`** for request rates).
+    - The original raw report (`rawReport` / `raw_report`) is preserved intact
+      to prevent loss of precision or unmapped attributes.
+
+2. **Presentation / UI Tier (Display Units)**:
+    - For human readability and chart scaling, latencies are converted from
+      seconds to **milliseconds (`ms`)** or **milliseconds per token
+      (`ms/token`)**.
+    - Tooltips, scatter plots, and summary cards display millisecond values
+      while preserving underlying canonical units in payload exports.
+
+---
+
+## 2. Unit Parsing & Scaling Factors (`unitToSecondsFactor`)
+
+When parsing metric blocks, Prism resolves unit strings using case-insensitive
+and whitespace-tolerant normalization (`unit.trim().toLowerCase()` with
+normalized `/` separators).
+
+| Declared Unit String(s)                                               | Multiplier to Canonical Seconds | Notes                                  |
+| :-------------------------------------------------------------------- | :------------------------------ | :------------------------------------- |
+| `s`, `sec`, `second`, `seconds`, `s/token`, `s / token`               | `1.0`                           | Canonical seconds base unit            |
+| `ms`, `msec`, `millisecond`, `milliseconds`, `ms/token`, `ms / token` | `1e-3`                          | Multiplied by 0.001                    |
+| `us`, `µs`, `microsecond`, `microseconds`, `us/token`, `µs/token`     | `1e-6`                          | Multiplied by 1e-6                     |
+| `ns`, `nsec`, `nanosecond`, `nanoseconds`, `ns/token`, `nsec/token`   | `1e-9`                          | Multiplied by 1e-9                     |
+| Empty, `null`, `undefined`, or unrecognized custom string             | `1.0`                           | Numbers kept unscaled; assumed seconds |
+
+---
+
+## 3. Per-Token vs. Request-Level Latency Distinction
+
+A common source of confusion in benchmark ingestion is the distinction between
+per-token metrics and request-level metrics.
+
+### 3.1 Per-Token Metrics (`isPerTokenMetric`)
+
+Metrics that evaluate throughput-normalized or incremental token delays belong
+to the per-token category:
+
+- `time_per_output_token` (TPOT)
+- `normalized_time_per_output_token` (NTPOT)
+- `inter_token_latency` (ITL)
+- Any metric key containing `per_output_token`, `per_token`, or `/token`
+
+**Canonical Unit:** `s/token` (displayed as `ms` / `ms/token`).
+
+### 3.2 Request-Level Metrics
+
+Metrics measuring overall request duration or execution phases:
+
+- `request_latency` (End-to-End latency)
+- `time_to_first_token` (TTFT)
+- `pod_startup_times` (`aggregate` and `by_pod.*`)
+- Session performance latencies
+
+**Canonical Unit:** `s` (displayed as `ms` or `s`).
+
+> [!IMPORTANT]
+>
+> **The TTFT Quirk (`time_to_first_token` is NOT per-token)**: Although
+> `time_to_first_token` contains the substring `token`, it represents the
+> elapsed duration from request dispatch until the arrival of the first token.
+> Its unit is **seconds (`s`)**, never `s/token`. The `isPerTokenMetric` helper
+> explicitly excludes `time_to_first_token`.
+
+---
+
+## 4. Missing Unit Detection & Default Assumptions
+
+Upstream benchmark harnesses (e.g., custom test scripts or legacy harnesses)
+sometimes emit metric data blocks containing numbers without an explicit `units`
+property.
+
+Prism detects these omissions using
+`detectMissingUnitWarnings(rawReport, filename)`.
+
+### 4.1 Default Assumptions by Field
+
+| Metric JSON Path Pattern                                               | Assumed Default Unit | Label / Display                 |
+| :--------------------------------------------------------------------- | :------------------- | :------------------------------ |
+| `$.results.request_performance.aggregate.latency.*` (request-level)    | `s`                  | `'s' (seconds)`                 |
+| `$.results.request_performance.aggregate.latency.*` (per-token)        | `s/token`            | `'s/token' (seconds per token)` |
+| `$.results.request_performance.aggregate.throughput.output_token_rate` | `tokens/s`           | `'tokens/s'`                    |
+| `$.results.request_performance.aggregate.throughput.total_token_rate`  | `tokens/s`           | `'tokens/s'`                    |
+| `$.results.request_performance.aggregate.throughput.input_token_rate`  | `tokens/s`           | `'tokens/s'`                    |
+| `$.results.request_performance.aggregate.throughput.request_rate`      | `queries/s`          | `'queries/s'`                   |
+| `$.results.request_performance.time_series.latency.*` (request-level)  | `s`                  | `'s' (seconds)`                 |
+| `$.results.request_performance.time_series.latency.*` (per-token)      | `s/token`            | `'s/token' (seconds per token)` |
+| `$.results.observability.pod_startup_times.aggregate`                  | `s`                  | `'s' (seconds)`                 |
+| `$.results.observability.pod_startup_times.by_pod.*`                   | `s`                  | `'s' (seconds)`                 |
+| `$.results.session_performance.aggregate.latency.*` (request-level)    | `s`                  | `'s' (seconds)`                 |
+| `$.results.session_performance.aggregate.latency.*` (per-token)        | `s/token`            | `'s/token' (seconds per token)` |
+
+### 4.2 Structured Warning Format
+
+Whenever units are missing from a metric that contains actual numeric data,
+Prism records a non-blocking diagnostic warning:
+
+```text
+[<filename>] Missing units for '<jsonPath>'; assumed <defaultUnit>, but validation is needed since units are missing from original report file.
+```
+
+**Example:**
+
+```text
+[stage_0.json] Missing units for '$.results.request_performance.aggregate.latency.request_latency'; assumed 's' (seconds), but validation is needed since units are missing from original report file.
+```
+
+### 4.3 Pipeline Propagation
+
+1. `parseReportV02(rawDoc, filename)`: Evaluates
+   `detectMissingUnitWarnings(rawDoc)` directly on the untouched raw report and
+   records warnings in `stage.warnings`.
+2. `stageToEntry(stage)`: Transfers `stage.warnings` into entry diagnostics
+   (`entry._diagnostics.msg`).
+3. `validateBenchmark`: Surfaces missing unit warnings in `result.warnings`.
+4. `validatePrismUploadStructure`: Records warnings in
+   `uploadValidation.warnings` and attaches them to `fieldErrors` with severity
+   `'warning'`.
+5. **Non-Blocking Rule:** Warnings do not invalidate uploads (`isValid` remains
+   `true` as long as `errors.length === 0`).
+
+---
+
+## 5. Zod Schema Preservation & Quirks
+
+Prism uses runtime Zod schemas to validate ingestion structures.
+
+> [!WARNING]
+>
+> **Zod Stripping Pitfall**: By default, Zod objects strip unlisted properties
+> unless `.passthrough()` is declared. If a nested metric schema omits `units`
+> or lacks `.passthrough()`, `zod.safeParse()` silently discards the `units` key
+> during parsing.
+
+To guarantee that units and upstream attributes are never lost:
+
+1. **`ThroughputMetricSchema`**:
+    ```javascript
+    const ThroughputMetricSchema = z
+        .object({
+            units: z.string().optional().nullable(),
+            mean: numericField.optional(),
+            p50: numericField.optional(),
+            p99: numericField.optional(),
+        })
+        .passthrough()
+        .optional()
+        .nullable();
+    ```
+2. **`MetricValuesSchema` and `PercentValuesSchema`**: Both include
+   `units: z.string().optional().nullable()` and `.passthrough()`.
+3. **`PodStartupMetricSchema`**: Includes both `aggregate: MetricValuesSchema`
+   and `by_pod: z.record(z.string(), MetricValuesSchema)` with `.passthrough()`.
+4. **Container Passthrough**: `RawBRV02ReportSchema`, `results`,
+   `request_performance`, `aggregate`, `throughput`, `time_series`, and
+   `session_performance` all declare `.passthrough()`.
+5. **Raw Doc Preservation**: `parseReportV02` returns `rawReport: rawDoc` so the
+   raw object stored in GCS retains the exact original input before any
+   display-level conversions.
+
+---
+
+## 6. Report Normalization (`normalizeReportUnits`)
+
+Prior to saving a benchmark run to the Results Store, `normalizeReportUnits`
+produces a canonical report where all metrics are guaranteed to have explicit
+units and scaled numbers:
+
+1. **Latency Scaling**: Latency objects with `units: 'ms'`, `'us'`, or `'ns'`
+   have their numbers multiplied by the appropriate conversion factor so they
+   are recorded in canonical seconds.
+2. **Canonical Unit Tagging**:
+    - `units` is set to `'s'` or `'s/token'`.
+    - **Per-Token Fallback Rule:**
+        ```javascript
+        const hasToken =
+            defaultToken ||
+            Boolean(units && units.toLowerCase().includes("/token"));
+        const targetUnits = hasToken ? "s/token" : "s";
+        ```
+        Even if an upstream report wrote `units: ms` on `time_per_output_token`,
+        `hasToken` resolves to `true`, ensuring the metric is normalized to
+        `'s/token'` rather than bare `'s'`.
+3. **Throughput Normalization**:
+    - If throughput contains data but lacks units, it is assigned `'tokens/s'`
+      or `'queries/s'`.
+    - Bare numeric throughput values (e.g. `request_rate: 10`) are converted
+      into `{ mean: 10, units: 'queries/s' }`.
+
+---
+
+## 7. Suspicious High Latency Warnings (> 1 Hour)
+
+When benchmark reports emit raw millisecond values without declaring `units: ms`
+(e.g., `request_latency: { mean: 20867 }`), Prism's default assumption of
+seconds would interpret this as 20,867 seconds (~5.8 hours).
+
+To catch these issues during staging:
+
+- If end-to-end request latency exceeds **3,600 seconds (1 hour)**, Prism flags:
+    > `E2E latency is unusually high (<N>s > 1 hour). Verify that latency units were not emitted in milliseconds or nanoseconds without declaring units.`
+- In the staging dialog table, cells with latencies > 1 hour are highlighted in
+  amber with an explanatory tooltip.
+- Warnings are aggregated into a single non-blocking banner notice in the
+  staging wizard.

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -1,9 +1,9 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { X, UploadCloud, CheckCircle, AlertCircle, AlertOctagon, AlertTriangle, FileText, ChevronLeft, ChevronRight, ChevronDown, Trash2, Upload, ShieldAlert, Check, ArrowRight, ArrowLeft, GitCompare, Zap, Cpu, Pencil, Layers, Split, GripVertical, Sparkles, Info, RotateCcw, GitFork } from 'lucide-react';
 import { v4 as uuidv4 } from 'uuid';
 import { ComposedChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, Legend, ResponsiveContainer, Scatter } from 'recharts';
 import { validateBenchmark, validatePrismUploadStructure } from '../../utils/benchmarkValidator';
-import { parseReportV02, stageToEntry, canonicalStringify, mutateRawReportMetadata, compareOriginalStageOrder } from '../../utils/benchmarkReportV02Parser';
+import { parseReportV02, stageToEntry, canonicalStringify, mutateRawReportMetadata, compareOriginalStageOrder, normalizeReportUnits } from '../../utils/benchmarkReportV02Parser';
 import { toOptimalDataUri, parseDataUri } from '../../utils/dataParser';
 import yaml from 'js-yaml';
 
@@ -53,6 +53,29 @@ const checkStageMetrics = (entry, format) => {
     }
 
     const latencyVal = normalized?.latency && typeof normalized.latency === 'object' ? normalized.latency.mean : normalized?.latency;
+    const ttftVal = parsedStage?.performance?.ttftMean ?? null;
+    const tpotVal = parsedStage?.performance?.tpotMean ?? null;
+    const throughputVal = normalized?.throughput ?? null;
+
+    // Latency warning thresholds (seconds)
+    const e2eSec = typeof latencyVal === 'number' && latencyVal > 0 ? latencyVal / 1000 : 0;
+    const isLatencyWarning = e2eSec > 3600;
+    const latencyWarningMsg = isLatencyWarning
+        ? `E2E latency is unusually high (${e2eSec.toFixed(1)}s > 1 hour). This may indicate that metrics were emitted in milliseconds or nanoseconds without declaring units.`
+        : null;
+
+    const ttftSec = typeof ttftVal === 'number' && ttftVal > 0 ? ttftVal / 1000 : 0;
+    const isTtftWarning = ttftSec > 600;
+    const ttftWarningMsg = isTtftWarning
+        ? `TTFT is unusually high (${ttftSec.toFixed(1)}s > 10 minutes). This may indicate that metrics were emitted in milliseconds or nanoseconds without declaring units.`
+        : null;
+
+    const tpotSec = typeof tpotVal === 'number' && tpotVal > 0 ? tpotVal / 1000 : 0;
+    const isTpotWarning = tpotSec > 60;
+    const tpotWarningMsg = isTpotWarning
+        ? `TPOT is unusually high (${tpotSec.toFixed(1)}s > 60 seconds per token). This may indicate that metrics were emitted in milliseconds or nanoseconds without declaring units.`
+        : null;
+
     const rawTimestamp = entry.raw_report?.run?.time?.start || entry.raw_report?.timestamp || entry.timestamp;
     let formattedTimestamp = 'N/A';
     if (rawTimestamp) {
@@ -68,21 +91,30 @@ const checkStageMetrics = (entry, format) => {
         rawTimestamp,
         timestamp: formattedTimestamp,
         throughput: {
-            val: normalized?.throughput,
-            isValid: typeof normalized?.throughput === 'number' && normalized.throughput > 0
+            val: throughputVal,
+            isValid: typeof throughputVal === 'number' && throughputVal > 0,
+            isWarning: false,
+            warningMessage: null,
         },
         latency: {
             val: latencyVal,
-            isValid: typeof latencyVal === 'number' && latencyVal > 0
+            isValid: typeof latencyVal === 'number' && latencyVal > 0,
+            isWarning: isLatencyWarning,
+            warningMessage: latencyWarningMsg,
         },
         ttft: {
-            val: parsedStage?.performance?.ttftMean ?? null,
-            isValid: format === 'inference-perf' ? true : (typeof parsedStage?.performance?.ttftMean === 'number' && parsedStage.performance.ttftMean > 0)
+            val: ttftVal,
+            isValid: format === 'inference-perf' ? true : (typeof ttftVal === 'number' && ttftVal > 0),
+            isWarning: isTtftWarning,
+            warningMessage: ttftWarningMsg,
         },
         tpot: {
-            val: parsedStage?.performance?.tpotMean ?? null,
-            isValid: format === 'inference-perf' ? true : (typeof parsedStage?.performance?.tpotMean === 'number' && parsedStage.performance.tpotMean > 0)
+            val: tpotVal,
+            isValid: format === 'inference-perf' ? true : (typeof tpotVal === 'number' && tpotVal > 0),
+            isWarning: isTpotWarning,
+            warningMessage: tpotWarningMsg,
         },
+        hasWarnings: isLatencyWarning || isTtftWarning || isTpotWarning,
         hardware: {
             val: normalized?.hardware || parsedStage?.scenario?.hardware,
             isValid: !!(normalized?.hardware || parsedStage?.scenario?.hardware) && (normalized?.hardware || parsedStage?.scenario?.hardware) !== 'Unknown' && (normalized?.hardware || parsedStage?.scenario?.hardware) !== 'Unknown Hardware'
@@ -155,6 +187,8 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
     const [draggedStageIndex, setDraggedStageIndex] = useState(null);
     const [stageSortConfig, setStageSortConfig] = useState({});
     const [hoveredFilenameTooltip, setHoveredFilenameTooltip] = useState(null);
+    const [hoveredWarningTooltip, setHoveredWarningTooltip] = useState(null);
+    const [hoveredTimestampTooltip, setHoveredTimestampTooltip] = useState(null);
 
     const [previewModalState, setPreviewModalState] = useState({
         isOpen: false,
@@ -197,6 +231,48 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
     const handleFilenameMouseLeave = () => {
         setHoveredFilenameTooltip(null);
     };
+
+    const handleTimestampMouseEnter = (e, timestamp, rawTimestamp) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        const isNearTop = rect.top < 120;
+        setHoveredTimestampTooltip({
+            timestamp,
+            rawTimestamp,
+            x: rect.left + rect.width / 2,
+            y: isNearTop ? rect.bottom + 8 : rect.top - 8,
+            isNearTop
+        });
+    };
+
+    const handleTimestampMouseLeave = () => {
+        setHoveredTimestampTooltip(null);
+    };
+
+    const handleWarningMouseEnter = (e, title, message) => {
+        const rect = e.currentTarget.getBoundingClientRect();
+        const isNearTop = rect.top < 140;
+        setHoveredWarningTooltip({
+            title,
+            message,
+            x: Math.min(Math.max(160, rect.left + rect.width / 2), window.innerWidth - 160),
+            y: isNearTop ? rect.bottom + 8 : rect.top - 8,
+            isNearTop
+        });
+    };
+
+    const handleWarningMouseLeave = () => {
+        setHoveredWarningTooltip(null);
+    };
+
+    useEffect(() => {
+        const handleScroll = () => {
+            if (hoveredFilenameTooltip) setHoveredFilenameTooltip(null);
+            if (hoveredWarningTooltip) setHoveredWarningTooltip(null);
+            if (hoveredTimestampTooltip) setHoveredTimestampTooltip(null);
+        };
+        window.addEventListener('scroll', handleScroll, { passive: true, capture: true });
+        return () => window.removeEventListener('scroll', handleScroll, { capture: true });
+    }, [hoveredFilenameTooltip, hoveredWarningTooltip, hoveredTimestampTooltip]);
 
     // Selection handlers
     const toggleSelectBundle = (bundleId) => {
@@ -1646,6 +1722,10 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     console.error("Failed to parse raw report content into JSON object:", e);
                 }
 
+                if (rawReportObj && typeof rawReportObj === 'object') {
+                    rawReportObj = normalizeReportUnits(rawReportObj);
+                }
+
                 payloadEntries.push({
                     run_id: uuidv4(),
                     run_description: groupName,
@@ -2134,7 +2214,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                         run_id: entry.run_id || uuidv4(),
                         run_description: bundle.name || bundle.payload.runLabel || 'Unnamed Run',
                         filename: entry.filename,
-                        raw_report: entry.rawReport || entry.raw_report || entry.content
+                        raw_report: normalizeReportUnits(entry.rawReport || entry.raw_report || entry.content)
                     }))
                 };
 
@@ -3151,14 +3231,29 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                             {bundle.isExpanded && (
                                                 <div className="p-4 border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 text-sm">
                                                     <div className={cn('grid grid-cols-1', wizardStep === 2 ? 'lg:grid-cols-3' : 'lg:grid-cols-1', 'gap-4')}>
-                                                        <div className={cn(wizardStep === 2 ? 'lg:col-span-2' : 'w-full', 'space-y-4')}>
+                                                        <div className={cn(wizardStep === 2 ? 'lg:col-span-2 min-w-0' : 'w-full min-w-0', 'space-y-4')}>
                                                     
                                                     {(() => {
-                                                        const activeErrors = bundle.validation.errors || [];
-                                                        const activeWarnings = (bundle.validation.warnings || []).filter(w => 
+                                                        const activeErrors = [...new Set(bundle.validation.errors || [])];
+                                                        const rawWarnings = bundle.validation.warnings || [];
+                                                        const filteredWarnings = rawWarnings.filter(w => 
                                                             !w.toLowerCase().includes("hardware metadata is missing") && 
                                                             !w.toLowerCase().includes("missing attribution fields")
                                                         );
+
+                                                        const isHighMetricWarning = (w) => w.toLowerCase().includes("unusually high");
+                                                        const hasHighMetricWarning = filteredWarnings.some(isHighMetricWarning) ||
+                                                            Boolean(bundle.payload?.entries?.some(entry => checkStageMetrics(entry, bundle.payload.format).hasWarnings));
+
+                                                        const otherWarnings = filteredWarnings.filter(w => !isHighMetricWarning(w));
+                                                        const uniqueOtherWarnings = [...new Set(otherWarnings)];
+
+                                                        const activeWarnings = [...uniqueOtherWarnings];
+                                                        if (hasHighMetricWarning) {
+                                                            activeWarnings.push(
+                                                                "One or more stages have unusually high latency metrics (highlighted in yellow below). Check if units were emitted in milliseconds or nanoseconds without declaring units."
+                                                            );
+                                                        }
 
                                                         if (activeErrors.length === 0 && activeWarnings.length === 0) return null;
 
@@ -3660,24 +3755,21 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                     {bundle.payload.entries && bundle.payload.entries.length > 0 && (
                                                         <div>
                                                             <h4 className="font-bold text-slate-300 text-xs uppercase tracking-wider mb-2.5 select-none">Parsed Sub-runs / Stages Validation Checklist ({bundle.payload.entries.length})</h4>
-                                                            <div className="overflow-visible border border-slate-900/60 rounded-xl bg-slate-950/20">
+                                                            <div className="overflow-x-auto regular-scrollbar-x border border-slate-900/60 rounded-xl bg-slate-950/20">
                                                                 <table className="w-full text-left text-xs border-collapse">
                                                                     <thead className="bg-[#0b101c]/45 text-slate-400 border-b border-slate-900/80 uppercase tracking-widest text-[9px]">
                                                                         <tr>
-                                                                            <th className="pl-2 pr-0 py-1.5 w-8 text-center"></th>
-                                                                            <th className="px-3 py-1.5 w-14 text-center select-none">
-                                                                                <div className="relative inline-flex items-center justify-center gap-1 group/stage-tooltip cursor-help">
+                                                                            <th className="pl-2 pr-0 py-1.5 text-center whitespace-nowrap w-px"></th>
+                                                                            <th className="px-1.5 py-1.5 text-center select-none whitespace-nowrap w-px" title="Stages are automatically sequential and do not reflect the original values.">
+                                                                                <div className="inline-flex items-center justify-center gap-1 cursor-help">
                                                                                     <span className="underline decoration-dotted underline-offset-4 decoration-slate-500/70 hover:decoration-cyan-400">
                                                                                         Stage
                                                                                     </span>
-                                                                                    <div className="absolute left-1/2 -translate-x-1/2 bottom-full mb-2 hidden group-hover/stage-tooltip:block w-56 px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-normal break-words text-center normal-case tracking-normal font-sans font-normal pointer-events-none">
-                                                                                        <span className="text-[11px] text-slate-300">Stages are automatically sequential and do not reflect the original values.</span>
-                                                                                    </div>
                                                                                 </div>
                                                                             </th>
                                                                             <th
                                                                                 onClick={() => handleSortStages(bundle.id, 'filename')}
-                                                                                className="px-3 py-1.5 text-center cursor-pointer hover:text-cyan-400 select-none transition-colors group"
+                                                                                className="px-1.5 py-1.5 text-center cursor-pointer hover:text-cyan-400 select-none transition-colors group whitespace-nowrap w-px"
                                                                                 title="Click to sort by file name"
                                                                             >
                                                                                 <div className="flex items-center justify-center gap-1">
@@ -3690,22 +3782,8 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                 </div>
                                                                             </th>
                                                                             <th
-                                                                                onClick={() => handleSortStages(bundle.id, 'timestamp')}
-                                                                                className="px-3 py-1.5 cursor-pointer hover:text-cyan-400 select-none transition-colors group"
-                                                                                title="Click to sort by timestamp"
-                                                                            >
-                                                                                <div className="flex items-center gap-1">
-                                                                                    <span>Timestamp</span>
-                                                                                    {stageSortConfig[bundle.id]?.column === 'timestamp' ? (
-                                                                                        <span className="text-cyan-400 font-bold">{stageSortConfig[bundle.id].direction === 'asc' ? '▲' : '▼'}</span>
-                                                                                    ) : (
-                                                                                        <span className="opacity-0 group-hover:opacity-60 text-slate-500">▲</span>
-                                                                                    )}
-                                                                                </div>
-                                                                            </th>
-                                                                            <th
                                                                                 onClick={() => handleSortStages(bundle.id, 'throughput')}
-                                                                                className="px-3 py-1.5 text-right cursor-pointer hover:text-cyan-400 select-none transition-colors group"
+                                                                                className="px-1.5 py-1.5 text-right cursor-pointer hover:text-cyan-400 select-none transition-colors group whitespace-nowrap w-px"
                                                                                 title="Click to sort by throughput"
                                                                             >
                                                                                 <div className="flex items-center justify-end gap-1">
@@ -3719,10 +3797,10 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                             </th>
                                                                             <th
                                                                                 onClick={() => handleSortStages(bundle.id, 'latency')}
-                                                                                className="px-3 py-1.5 text-right cursor-pointer hover:text-cyan-400 select-none transition-colors group"
-                                                                                title="Click to sort by E2E latency"
+                                                                                className="px-1.5 py-1.5 text-right cursor-pointer hover:text-cyan-400 select-none transition-colors group whitespace-nowrap w-px"
+                                                                                title="Click to sort by End-to-End Latency"
                                                                             >
-                                                                                <div className="relative flex items-center justify-end gap-1 group/metric-tooltip">
+                                                                                <div className="flex items-center justify-end gap-1">
                                                                                     {stageSortConfig[bundle.id]?.column === 'latency' ? (
                                                                                         <span className="text-cyan-400 font-bold">{stageSortConfig[bundle.id].direction === 'asc' ? '▲' : '▼'}</span>
                                                                                     ) : (
@@ -3731,17 +3809,14 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                     <span className="underline decoration-dotted underline-offset-4 decoration-slate-500/70 hover:decoration-cyan-400">
                                                                                         Latency
                                                                                     </span>
-                                                                                    <div className="absolute right-0 bottom-full mb-2 hidden group-hover/metric-tooltip:block px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-nowrap text-right normal-case tracking-normal font-sans font-normal pointer-events-none">
-                                                                                        <span className="text-[11px] text-slate-300">End-to-End Latency</span>
-                                                                                    </div>
                                                                                 </div>
                                                                             </th>
                                                                             <th
                                                                                 onClick={() => handleSortStages(bundle.id, 'ttft')}
-                                                                                className="px-3 py-1.5 text-right cursor-pointer hover:text-cyan-400 select-none transition-colors group"
-                                                                                title="Click to sort by TTFT"
+                                                                                className="px-1.5 py-1.5 text-right cursor-pointer hover:text-cyan-400 select-none transition-colors group whitespace-nowrap w-px"
+                                                                                title="Click to sort by Time to First Token (Prefill)"
                                                                             >
-                                                                                <div className="relative flex items-center justify-end gap-1 group/metric-tooltip">
+                                                                                <div className="flex items-center justify-end gap-1">
                                                                                     {stageSortConfig[bundle.id]?.column === 'ttft' ? (
                                                                                         <span className="text-cyan-400 font-bold">{stageSortConfig[bundle.id].direction === 'asc' ? '▲' : '▼'}</span>
                                                                                     ) : (
@@ -3750,17 +3825,14 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                     <span className="underline decoration-dotted underline-offset-4 decoration-slate-500/70 hover:decoration-cyan-400">
                                                                                         TTFT
                                                                                     </span>
-                                                                                    <div className="absolute right-0 bottom-full mb-2 hidden group-hover/metric-tooltip:block px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-nowrap text-right normal-case tracking-normal font-sans font-normal pointer-events-none">
-                                                                                        <span className="text-[11px] text-slate-300">Time to First Token (Prefill)</span>
-                                                                                    </div>
                                                                                 </div>
                                                                             </th>
                                                                             <th
                                                                                 onClick={() => handleSortStages(bundle.id, 'tpot')}
-                                                                                className="px-3 py-1.5 text-right cursor-pointer hover:text-cyan-400 select-none transition-colors group"
-                                                                                title="Click to sort by TPOT"
+                                                                                className="px-1.5 py-1.5 text-right cursor-pointer hover:text-cyan-400 select-none transition-colors group whitespace-nowrap w-px"
+                                                                                title="Click to sort by Time per Output Token (Decode)"
                                                                             >
-                                                                                <div className="relative flex items-center justify-end gap-1 group/metric-tooltip">
+                                                                                <div className="flex items-center justify-end gap-1">
                                                                                     {stageSortConfig[bundle.id]?.column === 'tpot' ? (
                                                                                         <span className="text-cyan-400 font-bold">{stageSortConfig[bundle.id].direction === 'asc' ? '▲' : '▼'}</span>
                                                                                     ) : (
@@ -3769,19 +3841,28 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                     <span className="underline decoration-dotted underline-offset-4 decoration-slate-500/70 hover:decoration-cyan-400">
                                                                                         TPOT
                                                                                     </span>
-                                                                                    <div className="absolute right-0 bottom-full mb-2 hidden group-hover/metric-tooltip:block px-2.5 py-1.5 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-lg shadow-xl z-50 whitespace-nowrap text-right normal-case tracking-normal font-sans font-normal pointer-events-none">
-                                                                                        <span className="text-[11px] text-slate-300">Time per Output Token (Decode)</span>
-                                                                                    </div>
                                                                                 </div>
                                                                             </th>
-                                                                            <th className="px-3 py-1.5 text-center">Status</th>
+                                                                            <th
+                                                                                onClick={() => handleSortStages(bundle.id, 'timestamp')}
+                                                                                className="px-2 py-1.5 text-left cursor-pointer hover:text-cyan-400 select-none transition-colors group whitespace-nowrap w-auto"
+                                                                                title="Click to sort by timestamp"
+                                                                            >
+                                                                                <div className="flex items-center gap-1">
+                                                                                    <span>Timestamp</span>
+                                                                                    {stageSortConfig[bundle.id]?.column === 'timestamp' ? (
+                                                                                        <span className="text-cyan-400 font-bold">{stageSortConfig[bundle.id].direction === 'asc' ? '▲' : '▼'}</span>
+                                                                                    ) : (
+                                                                                        <span className="opacity-0 group-hover:opacity-60 text-slate-500">▲</span>
+                                                                                    )}
+                                                                                </div>
+                                                                            </th>
                                                                         </tr>
                                                                     </thead>
                                                                     <tbody className="divide-y divide-slate-900/50">
                                                                         {bundle.payload.entries.map((entry, idx) => {
                                                                             const check = checkStageMetrics(entry, bundle.payload.format);
-                                                                                const isStageValid = check.throughput.isValid && check.latency.isValid && check.ttft.isValid && check.tpot.isValid;
-                                                                                return (
+                                                                            return (
                                                                                     <tr
                                                                                         key={entry.run_id || idx}
                                                                                         draggable
@@ -3795,7 +3876,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                         }}
                                                                                         className="hover:bg-slate-900/30 border-b border-slate-900/10 font-medium transition-colors"
                                                                                     >
-                                                                                        <td className="pl-2 pr-0 py-1.5 text-center">
+                                                                                        <td className="pl-2 pr-0 py-1.5 text-center whitespace-nowrap">
                                                                                             <div className="flex items-center justify-center gap-0.5">
                                                                                                 <div
                                                                                                     className="cursor-grab active:cursor-grabbing p-1 text-slate-500 hover:text-cyan-400 transition-colors inline-block"
@@ -3845,27 +3926,18 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                                 </div>
                                                                                             </div>
                                                                                         </td>
-                                                                                        <td className="px-3 py-1.5 text-center font-bold font-mono text-slate-400">{check.stageIndex}</td>
-                                                                                        <td className="px-3 py-1.5 text-center">
+                                                                                        <td className="px-1.5 py-1.5 text-center font-bold font-mono text-slate-400 whitespace-nowrap">{check.stageIndex}</td>
+                                                                                        <td className="px-1 py-1.5 text-center whitespace-nowrap">
                                                                                             <div
                                                                                                 onMouseEnter={(e) => handleFilenameMouseEnter(e, check.filename)}
                                                                                                 onMouseLeave={handleFilenameMouseLeave}
-                                                                                                className="p-1 text-slate-400 hover:text-cyan-400 cursor-pointer transition-colors inline-flex items-center justify-center"
+                                                                                                className="p-0.5 text-slate-400 hover:text-cyan-400 cursor-pointer transition-colors inline-flex items-center justify-center"
                                                                                             >
                                                                                                 <Info size={15} />
                                                                                             </div>
                                                                                         </td>
-                                                                                        <td className="px-3 py-1.5 font-mono whitespace-nowrap" title={check.timestamp}>
-                                                                                            {check.timestamp === 'N/A' || !check.timestamp ? (
-                                                                                                <span className="text-amber-400 italic" title="Timestamp missing or unavailable">
-                                                                                                    N/A
-                                                                                                </span>
-                                                                                            ) : (
-                                                                                                <span className="text-slate-400">{check.timestamp}</span>
-                                                                                            )}
-                                                                                        </td>
                                                                                         
-                                                                                        <td className="px-3 py-1.5 text-right font-mono">
+                                                                                        <td className="px-1.5 py-1.5 text-right font-mono whitespace-nowrap">
                                                                                             {check.throughput.isValid ? (
                                                                                                 <span className="text-slate-300">{check.throughput.val.toFixed(2)} t/s</span>
                                                                                             ) : (
@@ -3873,18 +3945,56 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                             )}
                                                                                         </td>
                                                                                         
-                                                                                        <td className="px-3 py-1.5 text-right font-mono">
+                                                                                        <td className={cn("px-1.5 py-1.5 text-right font-mono transition-colors whitespace-nowrap", check.latency.isWarning && "bg-amber-500/15 dark:bg-amber-500/20")}>
                                                                                             {check.latency.isValid ? (
-                                                                                                <span className="text-slate-300">{check.latency.val.toFixed(1)}ms</span>
+                                                                                                <div
+                                                                                                    className="inline-flex items-center justify-end gap-1.5"
+                                                                                                    onMouseEnter={(e) => check.latency.isWarning && handleWarningMouseEnter(e, "Unusually High Latency", check.latency.warningMessage)}
+                                                                                                    onMouseLeave={handleWarningMouseLeave}
+                                                                                                >
+                                                                                                    <span className={cn(
+                                                                                                        "transition-colors",
+                                                                                                        check.latency.isWarning ? "text-amber-400 dark:text-amber-300 font-bold" : "text-slate-300"
+                                                                                                    )}>
+                                                                                                        {check.latency.val.toFixed(1)}ms
+                                                                                                    </span>
+                                                                                                    {check.latency.isWarning && (
+                                                                                                        <span
+                                                                                                            className="cursor-help inline-flex items-center text-amber-400 hover:text-amber-300 transition-colors"
+                                                                                                            title={check.latency.warningMessage}
+                                                                                                        >
+                                                                                                            <AlertTriangle size={13} className="shrink-0 animate-pulse text-amber-400" />
+                                                                                                        </span>
+                                                                                                    )}
+                                                                                                </div>
                                                                                             ) : (
                                                                                                 <span className="text-red-500 bg-red-500/10 px-1.5 py-0.5 rounded border border-red-500/20" title="End-to-end latency must be greater than zero">❌ Absent</span>
                                                                                             )}
                                                                                         </td>
 
-                                                                                        <td className="px-3 py-1.5 text-right font-mono">
+                                                                                        <td className={cn("px-1.5 py-1.5 text-right font-mono transition-colors whitespace-nowrap", check.ttft.isWarning && "bg-amber-500/15 dark:bg-amber-500/20")}>
                                                                                             {check.ttft.isValid ? (
                                                                                                 check.ttft.val !== null ? (
-                                                                                                    <span className="text-slate-300">{check.ttft.val.toFixed(1)}ms</span>
+                                                                                                    <div
+                                                                                                        className="inline-flex items-center justify-end gap-1.5"
+                                                                                                        onMouseEnter={(e) => check.ttft.isWarning && handleWarningMouseEnter(e, "Unusually High TTFT", check.ttft.warningMessage)}
+                                                                                                        onMouseLeave={handleWarningMouseLeave}
+                                                                                                    >
+                                                                                                        <span className={cn(
+                                                                                                            "transition-colors",
+                                                                                                            check.ttft.isWarning ? "text-amber-400 dark:text-amber-300 font-bold" : "text-slate-300"
+                                                                                                        )}>
+                                                                                                            {check.ttft.val.toFixed(1)}ms
+                                                                                                        </span>
+                                                                                                        {check.ttft.isWarning && (
+                                                                                                            <span
+                                                                                                                className="cursor-help inline-flex items-center text-amber-400 hover:text-amber-300 transition-colors"
+                                                                                                                title={check.ttft.warningMessage}
+                                                                                                            >
+                                                                                                                <AlertTriangle size={13} className="shrink-0 animate-pulse text-amber-400" />
+                                                                                                            </span>
+                                                                                                        )}
+                                                                                                    </div>
                                                                                                 ) : (
                                                                                                     <span className="text-slate-400">N/A (Legacy)</span>
                                                                                                 )
@@ -3893,10 +4003,29 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                             )}
                                                                                         </td>
 
-                                                                                        <td className="px-3 py-1.5 text-right font-mono">
+                                                                                        <td className={cn("px-1.5 py-1.5 text-right font-mono transition-colors whitespace-nowrap", check.tpot.isWarning && "bg-amber-500/15 dark:bg-amber-500/20")}>
                                                                                             {check.tpot.isValid ? (
                                                                                                 check.tpot.val !== null ? (
-                                                                                                    <span className="text-slate-300">{check.tpot.val.toFixed(2)}ms</span>
+                                                                                                    <div
+                                                                                                        className="inline-flex items-center justify-end gap-1.5"
+                                                                                                        onMouseEnter={(e) => check.tpot.isWarning && handleWarningMouseEnter(e, "Unusually High TPOT", check.tpot.warningMessage)}
+                                                                                                        onMouseLeave={handleWarningMouseLeave}
+                                                                                                    >
+                                                                                                        <span className={cn(
+                                                                                                            "transition-colors",
+                                                                                                            check.tpot.isWarning ? "text-amber-400 dark:text-amber-300 font-bold" : "text-slate-300"
+                                                                                                        )}>
+                                                                                                            {check.tpot.val.toFixed(2)}ms
+                                                                                                        </span>
+                                                                                                        {check.tpot.isWarning && (
+                                                                                                            <span
+                                                                                                                className="cursor-help inline-flex items-center text-amber-400 hover:text-amber-300 transition-colors"
+                                                                                                                title={check.tpot.warningMessage}
+                                                                                                            >
+                                                                                                                <AlertTriangle size={13} className="shrink-0 animate-pulse text-amber-400" />
+                                                                                                            </span>
+                                                                                                        )}
+                                                                                                    </div>
                                                                                                 ) : (
                                                                                                     <span className="text-slate-400">N/A (Legacy)</span>
                                                                                                 )
@@ -3905,11 +4034,17 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                                                                                             )}
                                                                                         </td>
 
-                                                                                        <td className="px-3 py-1.5 text-center">
-                                                                                            {isStageValid ? (
-                                                                                                <Badge tone="success">Pass</Badge>
+                                                                                        <td
+                                                                                            className="px-2 py-1.5 font-mono whitespace-nowrap text-left text-slate-400 w-auto cursor-default"
+                                                                                            onMouseEnter={(e) => handleTimestampMouseEnter(e, check.timestamp, check.rawTimestamp)}
+                                                                                            onMouseLeave={handleTimestampMouseLeave}
+                                                                                        >
+                                                                                            {check.timestamp === 'N/A' || !check.timestamp ? (
+                                                                                                <span className="text-amber-400 italic" title="Timestamp missing or unavailable">
+                                                                                                    N/A
+                                                                                                </span>
                                                                                             ) : (
-                                                                                                <Badge tone="danger">Fail</Badge>
+                                                                                                <span>{check.timestamp}</span>
                                                                                             )}
                                                                                         </td>
                                                                                     </tr>
@@ -4312,6 +4447,52 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                     >
                         <span className="font-bold text-cyan-400 block mb-0.5 text-[10px] font-sans uppercase tracking-wider">File Name / Path</span>
                         <span className="text-[11px] text-slate-300 select-all font-mono">{hoveredFilenameTooltip.filename}</span>
+                    </div>
+                )}
+
+                {hoveredWarningTooltip && (
+                    <div
+                        className={cn(
+                            "fixed px-3 py-2 bg-slate-900 border border-amber-500/50 text-slate-200 text-xs rounded-xl shadow-2xl z-[99999] w-72 max-w-sm whitespace-normal break-words pointer-events-none text-left backdrop-blur-md animate-in fade-in duration-100 font-sans",
+                            hoveredWarningTooltip.isNearTop ? "-translate-x-1/2" : "-translate-x-1/2 -translate-y-full"
+                        )}
+                        style={{
+                            left: `${hoveredWarningTooltip.x}px`,
+                            top: `${hoveredWarningTooltip.y}px`
+                        }}
+                    >
+                        <div className="flex items-center gap-1.5 text-amber-400 dark:text-amber-300 font-bold mb-1">
+                            <AlertTriangle size={13} className="shrink-0 text-amber-400" />
+                            <span>{hoveredWarningTooltip.title}</span>
+                        </div>
+                        <p className="text-[11px] text-slate-300 leading-relaxed">
+                            {hoveredWarningTooltip.message}
+                        </p>
+                    </div>
+                )}
+
+                {hoveredTimestampTooltip && (
+                    <div
+                        className={cn(
+                            "fixed px-3 py-2 bg-slate-900 border border-slate-700/80 text-slate-200 text-xs rounded-xl shadow-2xl z-[99999] min-w-[200px] w-max max-w-sm pointer-events-none text-left backdrop-blur-md animate-in fade-in duration-100 font-sans",
+                            hoveredTimestampTooltip.isNearTop ? "-translate-x-1/2" : "-translate-x-1/2 -translate-y-full"
+                        )}
+                        style={{
+                            left: `${hoveredTimestampTooltip.x}px`,
+                            top: `${hoveredTimestampTooltip.y}px`
+                        }}
+                    >
+                        <span className="font-bold text-cyan-400 block mb-0.5 text-[10px] font-sans uppercase tracking-wider">Run Timestamp</span>
+                        <span className="text-[11px] text-slate-300 font-mono block">
+                            {hoveredTimestampTooltip.timestamp && hoveredTimestampTooltip.timestamp !== 'N/A' 
+                                ? hoveredTimestampTooltip.timestamp 
+                                : <span className="text-amber-400 italic">Timestamp missing or unavailable</span>}
+                        </span>
+                        {hoveredTimestampTooltip.rawTimestamp && hoveredTimestampTooltip.rawTimestamp !== hoveredTimestampTooltip.timestamp && (
+                            <span className="text-[9px] text-slate-500 font-mono block mt-0.5 select-all">
+                                {hoveredTimestampTooltip.rawTimestamp}
+                            </span>
+                        )}
                     </div>
                 )}
 

--- a/src/index.css
+++ b/src/index.css
@@ -143,40 +143,54 @@
   scrollbar-color: #334155 rgba(15, 23, 42, 0.4);
 }
 
-/* Permanent, non-overlay visible scrollbars for code/manifest viewers */
-.regular-scrollbar {
-  overflow: scroll !important;
-  overflow-x: scroll !important;
-  overflow-y: scroll !important;
+/* Permanent, non-overlay visible scrollbars for code/manifest viewers and tables */
+.regular-scrollbar,
+.regular-scrollbar-x {
   scrollbar-gutter: stable always !important;
   scrollbar-width: auto !important;
   scrollbar-color: #64748b #1e293b !important;
 }
 
-.regular-scrollbar::-webkit-scrollbar {
+.regular-scrollbar {
+  overflow: scroll !important;
+  overflow-x: scroll !important;
+  overflow-y: scroll !important;
+}
+
+.regular-scrollbar-x {
+  overflow-x: auto !important;
+  overflow-y: hidden !important;
+}
+
+.regular-scrollbar::-webkit-scrollbar,
+.regular-scrollbar-x::-webkit-scrollbar {
   -webkit-appearance: none !important;
-  width: 14px !important;
-  height: 14px !important;
+  width: 12px !important;
+  height: 12px !important;
   display: block !important;
 }
 
-.regular-scrollbar::-webkit-scrollbar-track {
+.regular-scrollbar::-webkit-scrollbar-track,
+.regular-scrollbar-x::-webkit-scrollbar-track {
   background: #1e293b !important;
   border-radius: 4px !important;
 }
 
-.regular-scrollbar::-webkit-scrollbar-thumb {
+.regular-scrollbar::-webkit-scrollbar-thumb,
+.regular-scrollbar-x::-webkit-scrollbar-thumb {
   background: #64748b !important;
   border-radius: 4px !important;
   border: 2px solid #1e293b !important;
-  min-height: 30px !important;
-  min-width: 30px !important;
+  min-height: 24px !important;
+  min-width: 24px !important;
 }
 
-.regular-scrollbar::-webkit-scrollbar-thumb:hover {
+.regular-scrollbar::-webkit-scrollbar-thumb:hover,
+.regular-scrollbar-x::-webkit-scrollbar-thumb:hover {
   background: #94a3b8 !important;
 }
 
-.regular-scrollbar::-webkit-scrollbar-corner {
+.regular-scrollbar::-webkit-scrollbar-corner,
+.regular-scrollbar-x::-webkit-scrollbar-corner {
   background: #1e293b !important;
 }

--- a/src/utils/benchmarkReportV02Parser.js
+++ b/src/utils/benchmarkReportV02Parser.js
@@ -33,10 +33,301 @@ const safeNum = (val) => {
     return isNaN(n) ? null : n;
 };
 
-// v0.2 latency values are in seconds — convert to ms for display
-const toMs = (val) => {
+export function unitToSecondsFactor(units) {
+    if (!units || typeof units !== 'string') return 1;
+    const u = units.trim().toLowerCase().replace(/\s*\/\s*/g, '/');
+    if (
+        u === 's' ||
+        u === 'sec' ||
+        u === 'second' ||
+        u === 'seconds' ||
+        u === 's/token' ||
+        u === 'sec/token' ||
+        u === 'second/token' ||
+        u === 'seconds/token'
+    ) {
+        return 1;
+    }
+    if (
+        u === 'ms' ||
+        u === 'msec' ||
+        u === 'millisecond' ||
+        u === 'milliseconds' ||
+        u === 'ms/token' ||
+        u === 'msec/token' ||
+        u === 'millisecond/token' ||
+        u === 'milliseconds/token'
+    ) {
+        return 1e-3;
+    }
+    if (
+        u === 'us' ||
+        u === 'µs' ||
+        u === 'microsecond' ||
+        u === 'microseconds' ||
+        u === 'us/token' ||
+        u === 'µs/token' ||
+        u === 'microsecond/token' ||
+        u === 'microseconds/token'
+    ) {
+        return 1e-6;
+    }
+    if (
+        u === 'ns' ||
+        u === 'nsec' ||
+        u === 'nanosecond' ||
+        u === 'nanoseconds' ||
+        u === 'ns/token' ||
+        u === 'nsec/token' ||
+        u === 'nanosecond/token' ||
+        u === 'nanoseconds/token'
+    ) {
+        return 1e-9;
+    }
+    return 1;
+}
+
+export function normalizeLatencyStatistics(statBlock, defaultToken = false) {
+    if (!statBlock) return statBlock;
+    if (typeof statBlock === 'number' && Number.isFinite(statBlock)) {
+        return {
+            mean: statBlock,
+            units: defaultToken ? 's/token' : 's',
+        };
+    }
+    if (typeof statBlock !== 'object') return statBlock;
+
+    const units = typeof statBlock.units === 'string' ? statBlock.units : null;
+    const factor = unitToSecondsFactor(units);
+    const hasToken = defaultToken || Boolean(units && units.toLowerCase().includes('/token'));
+    const targetUnits = hasToken ? 's/token' : 's';
+
+    const normalized = { ...statBlock, units: targetUnits };
+    for (const [key, val] of Object.entries(statBlock)) {
+        if (key === 'units') continue;
+        const num = safeNum(val);
+        if (num !== null) {
+            normalized[key] = num * factor;
+        }
+    }
+    return normalized;
+}
+
+export function normalizeTimeSeriesLatency(tsData, defaultToken = false) {
+    if (!tsData || typeof tsData !== 'object') return tsData;
+    const units = typeof tsData.units === 'string' ? tsData.units : null;
+    const factor = unitToSecondsFactor(units);
+    const hasToken = defaultToken || Boolean(units && units.toLowerCase().includes('/token'));
+    const targetUnits = hasToken ? 's/token' : 's';
+
+    const normalized = { ...tsData, units: targetUnits };
+    if (Array.isArray(tsData.series)) {
+        normalized.series = tsData.series.map(pt => {
+            if (!pt || typeof pt !== 'object') return pt;
+            const newPt = { ...pt };
+            for (const [k, v] of Object.entries(pt)) {
+                if (k === 'ts') continue;
+                const num = safeNum(v);
+                if (num !== null) {
+                    newPt[k] = num * factor;
+                }
+            }
+            return newPt;
+        });
+    }
+    return normalized;
+}
+
+export const isPerTokenMetric = (key) =>
+    Boolean(key && (
+        key === 'time_per_output_token' ||
+        key === 'normalized_time_per_output_token' ||
+        key === 'inter_token_latency' ||
+        key.includes('/token') ||
+        key.includes('per_output_token') ||
+        key.includes('per_token')
+    ));
+
+export function hasMetricData(val) {
+    if (typeof val === 'number') return Number.isFinite(val);
+    if (!val || typeof val !== 'object') return false;
+    for (const [k, v] of Object.entries(val)) {
+        if (k === 'units') continue;
+        if (typeof v === 'number' && Number.isFinite(v)) return true;
+        if (typeof v === 'string' && v.trim() !== '' && !isNaN(parseFloat(v))) return true;
+        if (Array.isArray(v) && v.length > 0) return true;
+    }
+    return false;
+}
+
+export function isMissingUnits(val) {
+    if (!hasMetricData(val)) return false;
+    if (typeof val === 'number') return true;
+    return !val.units || typeof val.units !== 'string' || val.units.trim() === '';
+}
+
+export function detectMissingUnitWarnings(rawReport, filename = '') {
+    if (!rawReport) return [];
+
+    let doc = rawReport;
+    if (typeof rawReport === 'string') {
+        try {
+            doc = yaml.load(rawReport);
+        } catch {
+            return [];
+        }
+    }
+    if (!doc || typeof doc !== 'object') return [];
+
+    const warnings = [];
+    const prefix = filename ? `[${filename}] ` : '';
+
+    const addWarning = (path, defaultUnit) => {
+        warnings.push(
+            `${prefix}Missing units for '${path}'; assumed ${defaultUnit}, but validation is needed since units are missing from original report file.`
+        );
+    };
+
+    // 1. Aggregate latency metrics
+    const aggLat = doc.results?.request_performance?.aggregate?.latency;
+    if (aggLat && typeof aggLat === 'object') {
+        for (const [key, val] of Object.entries(aggLat)) {
+            if (isMissingUnits(val)) {
+                const isToken = isPerTokenMetric(key);
+                const defaultUnit = isToken ? "'s/token' (seconds per token)" : "'s' (seconds)";
+                addWarning(`$.results.request_performance.aggregate.latency.${key}`, defaultUnit);
+            }
+        }
+    }
+
+    // 2. Aggregate throughput metrics
+    const aggTput = doc.results?.request_performance?.aggregate?.throughput;
+    if (aggTput && typeof aggTput === 'object') {
+        for (const [key, val] of Object.entries(aggTput)) {
+            if (isMissingUnits(val)) {
+                const defaultUnit = key === 'request_rate' ? "'queries/s'" : "'tokens/s'";
+                addWarning(`$.results.request_performance.aggregate.throughput.${key}`, defaultUnit);
+            }
+        }
+    }
+
+    // 3. Time series latency metrics
+    const tsLat = doc.results?.request_performance?.time_series?.latency;
+    if (tsLat && typeof tsLat === 'object') {
+        for (const [key, val] of Object.entries(tsLat)) {
+            if (isMissingUnits(val)) {
+                const isToken = isPerTokenMetric(key);
+                const defaultUnit = isToken ? "'s/token' (seconds per token)" : "'s' (seconds)";
+                addWarning(`$.results.request_performance.time_series.latency.${key}`, defaultUnit);
+            }
+        }
+    }
+
+    // 4. Pod startup times observability
+    const podStartup = doc.results?.observability?.pod_startup_times?.aggregate;
+    if (isMissingUnits(podStartup)) {
+        addWarning('$.results.observability.pod_startup_times.aggregate', "'s' (seconds)");
+    }
+    const podStartupByPod = doc.results?.observability?.pod_startup_times?.by_pod;
+    if (podStartupByPod && typeof podStartupByPod === 'object') {
+        for (const [podName, val] of Object.entries(podStartupByPod)) {
+            if (isMissingUnits(val)) {
+                addWarning(`$.results.observability.pod_startup_times.by_pod.${podName}`, "'s' (seconds)");
+            }
+        }
+    }
+
+    // 5. Session performance latency
+    const sessionLatency = doc.results?.session_performance?.aggregate?.latency;
+    if (sessionLatency && typeof sessionLatency === 'object') {
+        for (const [key, val] of Object.entries(sessionLatency)) {
+            if (isMissingUnits(val)) {
+                const isToken = isPerTokenMetric(key);
+                const defaultUnit = isToken ? "'s/token' (seconds per token)" : "'s' (seconds)";
+                addWarning(`$.results.session_performance.aggregate.latency.${key}`, defaultUnit);
+            }
+        }
+    }
+
+    return warnings;
+}
+
+export function normalizeReportUnits(rawReport) {
+    if (!rawReport || typeof rawReport !== 'object') return rawReport;
+
+    const newReport = JSON.parse(JSON.stringify(rawReport));
+
+    // 1. Aggregate latency metrics
+    const latency = newReport.results?.request_performance?.aggregate?.latency;
+    if (latency && typeof latency === 'object') {
+        for (const [key, val] of Object.entries(latency)) {
+            if (val !== null && val !== undefined) {
+                const isPerToken = isPerTokenMetric(key);
+                latency[key] = normalizeLatencyStatistics(val, isPerToken);
+            }
+        }
+    }
+
+    // 2. Time series latency metrics
+    const tsLatency = newReport.results?.request_performance?.time_series?.latency;
+    if (tsLatency && typeof tsLatency === 'object') {
+        for (const [key, val] of Object.entries(tsLatency)) {
+            if (val !== null && val !== undefined) {
+                const isPerToken = isPerTokenMetric(key);
+                tsLatency[key] = normalizeTimeSeriesLatency(val, isPerToken);
+            }
+        }
+    }
+
+    // 3. Pod startup times observability
+    const podStartup = newReport.results?.observability?.pod_startup_times?.aggregate;
+    if (podStartup && typeof podStartup === 'object') {
+        newReport.results.observability.pod_startup_times.aggregate = normalizeLatencyStatistics(podStartup, false);
+    }
+    const podStartupByPod = newReport.results?.observability?.pod_startup_times?.by_pod;
+    if (podStartupByPod && typeof podStartupByPod === 'object') {
+        for (const [k, v] of Object.entries(podStartupByPod)) {
+            if (v && typeof v === 'object') {
+                podStartupByPod[k] = normalizeLatencyStatistics(v, false);
+            }
+        }
+    }
+
+    // 4. Session performance latency
+    const sessionLatency = newReport.results?.session_performance?.aggregate?.latency;
+    if (sessionLatency && typeof sessionLatency === 'object') {
+        for (const [key, val] of Object.entries(sessionLatency)) {
+            if (val !== null && val !== undefined) {
+                const isPerToken = isPerTokenMetric(key);
+                sessionLatency[key] = normalizeLatencyStatistics(val, isPerToken);
+            }
+        }
+    }
+
+    // 5. Aggregate throughput metrics
+    const throughput = newReport.results?.request_performance?.aggregate?.throughput;
+    if (throughput && typeof throughput === 'object') {
+        for (const [key, val] of Object.entries(throughput)) {
+            if (val && typeof val === 'object' && (!val.units || typeof val.units !== 'string' || val.units.trim() === '')) {
+                val.units = key === 'request_rate' ? 'queries/s' : 'tokens/s';
+            } else if (typeof val === 'number') {
+                throughput[key] = {
+                    mean: val,
+                    units: key === 'request_rate' ? 'queries/s' : 'tokens/s',
+                };
+            }
+        }
+    }
+
+    return newReport;
+}
+
+// Convert latency value to milliseconds, respecting declared units (defaults to seconds)
+const toMs = (val, units) => {
     const n = safeNum(val);
-    return n !== null ? n * 1000 : null;
+    if (n === null) return null;
+    const factor = unitToSecondsFactor(units);
+    return n * (factor * 1000);
 };
 
 // vllm cache rates are emitted as fractions for kv_cache_usage but as
@@ -59,37 +350,66 @@ const deriveRunLabel = (doc) => {
 
 const numericField = z.preprocess(safeNum, z.number().nullable());
 const percentField = z.preprocess(pct, z.number().nullable());
-const latencyField = z.preprocess(toMs, z.number().nullable());
 
 const MetricValuesSchema = z.object({
+    units: z.string().optional().nullable(),
     mean: numericField.optional(),
     p50: numericField.optional(),
     p99: numericField.optional(),
-}).optional().nullable();
+}).passthrough().optional().nullable();
 
 const PercentValuesSchema = z.object({
+    units: z.string().optional().nullable(),
     mean: percentField.optional(),
     p50: percentField.optional(),
     p99: percentField.optional(),
-}).optional().nullable();
+}).passthrough().optional().nullable();
 
-const LatencyValuesSchema = z.object({
-    mean: latencyField.optional(),
-    p50: latencyField.optional(),
-    p99: latencyField.optional(),
-}).optional().nullable();
+const ThroughputMetricSchema = z.object({
+    units: z.string().optional().nullable(),
+    mean: numericField.optional(),
+    p50: numericField.optional(),
+    p99: numericField.optional(),
+}).passthrough().optional().nullable();
+
+const LatencyValuesSchema = z.preprocess((val) => {
+    if (val === null || val === undefined) return null;
+    if (typeof val === 'number' || typeof val === 'string') {
+        const ms = toMs(val, null);
+        return { mean: ms, p50: ms, p99: ms };
+    }
+    if (typeof val === 'object') {
+        const units = typeof val.units === 'string' ? val.units : null;
+        const res = { ...val };
+        for (const [k, v] of Object.entries(val)) {
+            if (k === 'units') continue;
+            const num = safeNum(v);
+            if (num !== null) {
+                res[k] = toMs(v, units);
+            }
+        }
+        return res;
+    }
+    return val;
+}, z.object({
+    units: z.string().optional().nullable(),
+    mean: z.number().optional().nullable(),
+    p50: z.number().optional().nullable(),
+    p99: z.number().optional().nullable(),
+}).passthrough().optional().nullable());
 
 const ObservabilityMetricSchema = z.object({
     aggregated: MetricValuesSchema,
-}).optional().nullable();
+}).passthrough().optional().nullable();
 
 const PercentObservabilityMetricSchema = z.object({
     aggregated: PercentValuesSchema,
-}).optional().nullable();
+}).passthrough().optional().nullable();
 
 const PodStartupMetricSchema = z.object({
     aggregate: MetricValuesSchema,
-}).optional().nullable();
+    by_pod: z.record(z.string(), MetricValuesSchema).optional().nullable(),
+}).passthrough().optional().nullable();
 
 const ObservabilitySchema = z.object({
     vllm_kv_cache_usage_perc: PercentObservabilityMetricSchema,
@@ -112,53 +432,62 @@ const RawBRV02ReportSchema = z.object({
         pid: z.string().nullable().optional(),
         time: z.object({
             start: z.string().nullable().optional(),
-        }).nullable().optional(),
+        }).passthrough().nullable().optional(),
         description: z.string().nullable().optional(),
-    }).nullable().optional(),
+    }).passthrough().nullable().optional(),
     scenario: z.object({
         stack: z.array(z.any()).nullable().optional(),
         load: z.object({
             standardized: z.object({
                 stage: numericField.optional(),
                 tool: z.string().nullable().optional(),
-                input_seq_len: z.object({ value: numericField }).nullable().optional(),
-                output_seq_len: z.object({ value: numericField }).nullable().optional(),
+                input_seq_len: z.object({ value: numericField }).passthrough().nullable().optional(),
+                output_seq_len: z.object({ value: numericField }).passthrough().nullable().optional(),
                 rate_qps: numericField.optional(),
                 concurrency: numericField.optional(),
-            }).nullable().optional(),
+            }).passthrough().nullable().optional(),
             native: z.object({
                 config: z.object({
                     server: z.object({
                         model_name: z.string().nullable().optional(),
-                    }).nullable().optional(),
-                }).nullable().optional(),
-            }).nullable().optional(),
+                    }).passthrough().nullable().optional(),
+                }).passthrough().nullable().optional(),
+            }).passthrough().nullable().optional(),
             metadata: z.record(z.string(), z.unknown()).nullable().optional(),
-        }).nullable().optional(),
-    }).nullable().optional(),
+        }).passthrough().nullable().optional(),
+    }).passthrough().nullable().optional(),
     results: z.object({
         request_performance: z.object({
             aggregate: z.object({
                 throughput: z.object({
-                    output_token_rate: z.object({ mean: numericField }).nullable().optional(),
-                    input_token_rate: z.object({ mean: numericField }).nullable().optional(),
-                    total_token_rate: z.object({ mean: numericField }).nullable().optional(),
-                    request_rate: z.object({ mean: numericField }).nullable().optional(),
-                }).nullable().optional(),
+                    output_token_rate: ThroughputMetricSchema,
+                    input_token_rate: ThroughputMetricSchema,
+                    total_token_rate: ThroughputMetricSchema,
+                    request_rate: ThroughputMetricSchema,
+                }).passthrough().nullable().optional(),
                 latency: z.object({
                     time_to_first_token: LatencyValuesSchema,
                     time_per_output_token: LatencyValuesSchema,
+                    normalized_time_per_output_token: LatencyValuesSchema,
                     inter_token_latency: LatencyValuesSchema,
                     request_latency: LatencyValuesSchema,
-                }).nullable().optional(),
+                }).passthrough().nullable().optional(),
                 requests: z.object({
                     total: numericField.optional(),
                     failures: numericField.optional(),
-                }).nullable().optional(),
-            }).nullable().optional(),
-        }).nullable().optional(),
+                }).passthrough().nullable().optional(),
+            }).passthrough().nullable().optional(),
+            time_series: z.object({
+                latency: z.record(z.string(), z.unknown()).optional().nullable(),
+            }).passthrough().optional().nullable(),
+        }).passthrough().nullable().optional(),
+        session_performance: z.object({
+            aggregate: z.object({
+                latency: z.record(z.string(), z.unknown()).optional().nullable(),
+            }).passthrough().optional().nullable(),
+        }).passthrough().optional().nullable(),
         observability: ObservabilitySchema,
-    }).nullable().optional(),
+    }).passthrough().nullable().optional(),
 }).passthrough();
 
 // ---------------------------------------------------------------------------
@@ -266,6 +595,9 @@ export function parseReportV02(yamlText, filename) {
         tpotMean: lat.time_per_output_token?.mean ?? null,
         tpotP50: lat.time_per_output_token?.p50 ?? null,
         tpotP99: lat.time_per_output_token?.p99 ?? null,
+        ntpotMean: lat.normalized_time_per_output_token?.mean ?? null,
+        ntpotP50: lat.normalized_time_per_output_token?.p50 ?? null,
+        ntpotP99: lat.normalized_time_per_output_token?.p99 ?? null,
         itlMean: lat.inter_token_latency?.mean ?? null,
         itlP50: lat.inter_token_latency?.p50 ?? null,
         itlP99: lat.inter_token_latency?.p99 ?? null,
@@ -317,6 +649,8 @@ export function parseReportV02(yamlText, filename) {
         if (hasAny) observability = obsValues;
     }
 
+    const warnings = detectMissingUnitWarnings(rawDoc);
+
     return {
         runLabel: deriveRunLabel(doc, filename),
         filename,
@@ -331,7 +665,8 @@ export function parseReportV02(yamlText, filename) {
         performance,
         observability,
         components,
-        rawReport: doc,
+        warnings,
+        rawReport: rawDoc,
     };
 }
 
@@ -643,7 +978,7 @@ export function stageToEntry(stage) {
         // Hoist key metrics to root for Chart compatibility
         time_per_output_token: performance.tpotMean ?? null,
         tpot: performance.tpotMean ?? null,
-        ntpot: performance.tpotMean ?? null,
+        ntpot: performance.ntpotMean ?? performance.tpotMean ?? null,
         itl: performance.itlMean ?? null,
 
         prism_stage_index: stage.prism_stage_index !== undefined && stage.prism_stage_index !== null
@@ -707,8 +1042,10 @@ export function stageToEntry(stage) {
             tpot_ms: performance.tpotMean ?? null,
             tpot_p50: performance.tpotP50 ?? null,
             tpot_p99: performance.tpotP99 ?? null,
-            ntpot: performance.tpotMean ?? null,
-            ntpot_ms: performance.tpotMean ?? null,
+            ntpot: performance.ntpotMean ?? performance.tpotMean ?? null,
+            ntpot_ms: performance.ntpotMean ?? performance.tpotMean ?? null,
+            ntpot_p50: performance.ntpotP50 ?? performance.tpotP50 ?? null,
+            ntpot_p99: performance.ntpotP99 ?? performance.tpotP99 ?? null,
             itl: performance.itlMean ?? null,
             itl_ms: performance.itlMean ?? null,
             itl_p50: performance.itlP50 ?? null,
@@ -719,7 +1056,7 @@ export function stageToEntry(stage) {
         },
 
         rawReport: stage.rawReport || null,
-        _diagnostics: { msg: [], raw_snapshot: {} },
+        _diagnostics: { msg: [...(stage.warnings || [])], raw_snapshot: {} },
     });
 }
 
@@ -730,7 +1067,7 @@ export function stageToEntry(stage) {
 export function mutateRawReportMetadata(rawReport, { model_name, hardware_name, runLabel, inference_tool } = {}) {
     if (!rawReport || typeof rawReport !== 'object') return rawReport;
 
-    const newReport = JSON.parse(JSON.stringify(rawReport));
+    const newReport = normalizeReportUnits(rawReport);
 
     // 1. Update run description if provided
     if (runLabel) {

--- a/src/utils/benchmarkReportV02Parser.test.js
+++ b/src/utils/benchmarkReportV02Parser.test.js
@@ -11,7 +11,14 @@
 // limitations under the License.
 
 import { describe, it, expect } from 'vitest';
-import { parseReportV02, stageToEntry } from './benchmarkReportV02Parser.js';
+import {
+    parseReportV02,
+    stageToEntry,
+    unitToSecondsFactor,
+    normalizeReportUnits,
+    detectMissingUnitWarnings,
+} from './benchmarkReportV02Parser.js';
+import { validateBenchmark, validatePrismUploadStructure } from './benchmarkValidator.js';
 
 const createReport = (throughput) => ({
     version: '0.2',
@@ -93,5 +100,978 @@ describe('benchmarkReportV02Parser token rates', () => {
         expect(stage.performance.outputTokenRate).toBe(20.5);
         expect(entry.metrics.input_tput).toBe(0);
         expect(entry.metrics.total_tput).toBe(20.5);
+    });
+});
+
+describe('unitToSecondsFactor', () => {
+    it('handles seconds and variations', () => {
+        expect(unitToSecondsFactor('s')).toBe(1);
+        expect(unitToSecondsFactor('sec')).toBe(1);
+        expect(unitToSecondsFactor('seconds')).toBe(1);
+        expect(unitToSecondsFactor('s/token')).toBe(1);
+        expect(unitToSecondsFactor('s / token')).toBe(1);
+        expect(unitToSecondsFactor('SECONDS')).toBe(1);
+    });
+
+    it('handles milliseconds and variations', () => {
+        expect(unitToSecondsFactor('ms')).toBe(1e-3);
+        expect(unitToSecondsFactor('msec')).toBe(1e-3);
+        expect(unitToSecondsFactor('milliseconds')).toBe(1e-3);
+        expect(unitToSecondsFactor('ms/token')).toBe(1e-3);
+        expect(unitToSecondsFactor('ms / token')).toBe(1e-3);
+        expect(unitToSecondsFactor('MS')).toBe(1e-3);
+    });
+
+    it('handles microseconds and variations', () => {
+        expect(unitToSecondsFactor('us')).toBe(1e-6);
+        expect(unitToSecondsFactor('µs')).toBe(1e-6);
+        expect(unitToSecondsFactor('microseconds')).toBe(1e-6);
+        expect(unitToSecondsFactor('us/token')).toBe(1e-6);
+    });
+
+    it('handles nanoseconds and variations', () => {
+        expect(unitToSecondsFactor('ns')).toBe(1e-9);
+        expect(unitToSecondsFactor('nsec')).toBe(1e-9);
+        expect(unitToSecondsFactor('nanoseconds')).toBe(1e-9);
+        expect(unitToSecondsFactor('ns/token')).toBe(1e-9);
+    });
+
+    it('defaults to 1 for undefined, null, or unknown units', () => {
+        expect(unitToSecondsFactor(undefined)).toBe(1);
+        expect(unitToSecondsFactor(null)).toBe(1);
+        expect(unitToSecondsFactor('')).toBe(1);
+        expect(unitToSecondsFactor('unknown_unit')).toBe(1);
+    });
+});
+
+describe('normalizeReportUnits', () => {
+    it('normalizes milliseconds to seconds and sets units: s / s/token', () => {
+        const report = {
+            version: '0.2',
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            time_to_first_token: { mean: 300, p50: 250, p99: 500, units: 'ms' },
+                            time_per_output_token: { mean: 40, p50: 35, p99: 60, units: 'ms' },
+                            normalized_time_per_output_token: { mean: 30, p50: 28, p99: 50, units: 'ms/token' },
+                            request_latency: { mean: 3000, p50: 2800, p99: 3500, stddev: 200, units: 'ms' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const normalized = normalizeReportUnits(report);
+        const lat = normalized.results.request_performance.aggregate.latency;
+
+        expect(lat.time_to_first_token.mean).toBeCloseTo(0.3);
+        expect(lat.time_to_first_token.p50).toBeCloseTo(0.25);
+        expect(lat.time_to_first_token.p99).toBeCloseTo(0.5);
+        expect(lat.time_to_first_token.units).toBe('s');
+
+        expect(lat.time_per_output_token.mean).toBeCloseTo(0.04);
+        expect(lat.time_per_output_token.units).toBe('s/token');
+
+        expect(lat.normalized_time_per_output_token.mean).toBeCloseTo(0.03);
+        expect(lat.normalized_time_per_output_token.units).toBe('s/token');
+
+        expect(lat.request_latency.mean).toBeCloseTo(3.0);
+        expect(lat.request_latency.stddev).toBeCloseTo(0.2);
+        expect(lat.request_latency.units).toBe('s');
+    });
+
+    it('normalizes nanoseconds to seconds', () => {
+        const report = {
+            version: '0.2',
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            request_latency: { mean: 2500000000, units: 'nanoseconds' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const normalized = normalizeReportUnits(report);
+        const lat = normalized.results.request_performance.aggregate.latency;
+        expect(lat.request_latency.mean).toBeCloseTo(2.5);
+        expect(lat.request_latency.units).toBe('s');
+    });
+
+    it('ensures units: s / s/token are set when units were omitted', () => {
+        const report = {
+            version: '0.2',
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            time_to_first_token: { mean: 0.3 },
+                            normalized_time_per_output_token: { mean: 0.03 },
+                        },
+                    },
+                },
+            },
+        };
+
+        const normalized = normalizeReportUnits(report);
+        const lat = normalized.results.request_performance.aggregate.latency;
+        expect(lat.time_to_first_token.mean).toBe(0.3);
+        expect(lat.time_to_first_token.units).toBe('s');
+        expect(lat.normalized_time_per_output_token.mean).toBe(0.03);
+        expect(lat.normalized_time_per_output_token.units).toBe('s/token');
+    });
+
+    it('handles reports with unknown or custom units without modifying numbers and normalizes unit strings', () => {
+        const report = {
+            version: '0.2',
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            time_to_first_token: { mean: 1.25, p50: 1.0, units: 'custom_ticks' },
+                            time_per_output_token: { mean: 0.045, units: 'custom_tokens/token' },
+                            inter_token_latency: { mean: 0.04, units: 'arbitrary_unit/token' },
+                            request_latency: { mean: 15.5, units: 'unknown_timer' },
+                        },
+                    },
+                    time_series: {
+                        latency: {
+                            request_latency: {
+                                units: 'unknown_time_unit',
+                                series: [
+                                    { ts: '2026-08-31T07:44:02Z', mean: 12.5 },
+                                    { ts: '2026-08-31T07:44:03Z', mean: 14.0 },
+                                ],
+                            },
+                        },
+                    },
+                },
+                observability: {
+                    pod_startup_times: {
+                        aggregate: { mean: 42.0, units: 'clock_ticks' },
+                    },
+                },
+            },
+        };
+
+        const normalized = normalizeReportUnits(report);
+        const lat = normalized.results.request_performance.aggregate.latency;
+
+        // Numbers preserved as-is with factor 1
+        expect(lat.time_to_first_token.mean).toBe(1.25);
+        expect(lat.time_to_first_token.p50).toBe(1.0);
+        expect(lat.time_to_first_token.units).toBe('s');
+
+        expect(lat.time_per_output_token.mean).toBe(0.045);
+        expect(lat.time_per_output_token.units).toBe('s/token');
+
+        expect(lat.inter_token_latency.mean).toBe(0.04);
+        expect(lat.inter_token_latency.units).toBe('s/token');
+
+        expect(lat.request_latency.mean).toBe(15.5);
+        expect(lat.request_latency.units).toBe('s');
+
+        // Time series with unknown units preserved and canonicalized to 's'
+        const tsLat = normalized.results.request_performance.time_series.latency.request_latency;
+        expect(tsLat.units).toBe('s');
+        expect(tsLat.series[0].mean).toBe(12.5);
+        expect(tsLat.series[1].mean).toBe(14.0);
+
+        // Pod startup times
+        const podStartup = normalized.results.observability.pod_startup_times.aggregate;
+        expect(podStartup.mean).toBe(42.0);
+        expect(podStartup.units).toBe('s');
+    });
+
+    it('normalizes throughput metrics when units are missing or formatted as numbers', () => {
+        const report = {
+            version: '0.2',
+            results: {
+                request_performance: {
+                    aggregate: {
+                        throughput: {
+                            output_token_rate: { mean: 250 }, // object missing units
+                            request_rate: 10, // bare number
+                            total_token_rate: { mean: 500, units: 'tokens/s' }, // already has units
+                        },
+                    },
+                },
+            },
+        };
+
+        const normalized = normalizeReportUnits(report);
+        const tput = normalized.results.request_performance.aggregate.throughput;
+
+        expect(tput.output_token_rate.mean).toBe(250);
+        expect(tput.output_token_rate.units).toBe('tokens/s');
+
+        expect(tput.request_rate.mean).toBe(10);
+        expect(tput.request_rate.units).toBe('queries/s');
+
+        expect(tput.total_token_rate.mean).toBe(500);
+        expect(tput.total_token_rate.units).toBe('tokens/s');
+    });
+});
+
+describe('NTPOT extraction and issue #144 resolution', () => {
+    it('parses distinct TPOT and NTPOT metrics without overwriting NTPOT with TPOT', () => {
+        const report = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'test-model' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'vllm' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            time_per_output_token: { mean: 0.04, p50: 0.038, p99: 0.06, units: 's' },
+                            normalized_time_per_output_token: { mean: 0.025, p50: 0.022, p99: 0.04, units: 's/token' },
+                            request_latency: { mean: 2.0, units: 's' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const stage = parseReportV02(report, 'test.yaml');
+        expect(stage.performance.tpotMean).toBe(40);
+        expect(stage.performance.ntpotMean).toBe(25);
+
+        const entry = stageToEntry(stage);
+        expect(entry.tpot).toBe(40);
+        expect(entry.ntpot).toBe(25);
+        expect(entry.metrics.tpot).toBe(40);
+        expect(entry.metrics.ntpot).toBe(25);
+        expect(entry.metrics.ntpot_p50).toBe(22);
+    });
+
+    it('falls back to TPOT for NTPOT when normalized_time_per_output_token is absent', () => {
+        const report = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'test-model' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'vllm' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            time_per_output_token: { mean: 0.04, units: 's' },
+                            request_latency: { mean: 2.0, units: 's' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const stage = parseReportV02(report, 'test.yaml');
+        expect(stage.performance.ntpotMean).toBe(null);
+
+        const entry = stageToEntry(stage);
+        expect(entry.tpot).toBe(40);
+        expect(entry.ntpot).toBe(40);
+        expect(entry.metrics.ntpot).toBe(40);
+    });
+});
+
+describe('parseReportV02 latency unit parsing', () => {
+    it('correctly converts declared milliseconds to milliseconds internally', () => {
+        const report = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'test-model' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'vllm' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            time_to_first_token: { mean: 350, p50: 300, p99: 500, units: 'ms' },
+                            time_per_output_token: { mean: 25, units: 'ms/token' },
+                            request_latency: { mean: 2500, units: 'ms' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const stage = parseReportV02(report, 'test.yaml');
+        expect(stage.performance.ttftMean).toBeCloseTo(350);
+        expect(stage.performance.tpotMean).toBeCloseTo(25);
+        expect(stage.performance.e2eMean).toBeCloseTo(2500);
+
+        const entry = stageToEntry(stage);
+        expect(entry.ttft.mean).toBeCloseTo(350);
+        expect(entry.tpot).toBeCloseTo(25);
+        expect(entry.latency.mean).toBeCloseTo(2500);
+    });
+
+    it('correctly converts declared nanoseconds to milliseconds internally', () => {
+        const report = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'test-model' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'vllm' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            time_to_first_token: { mean: 200000000, units: 'nanoseconds' },
+                            request_latency: { mean: 5000000000, units: 'nanoseconds' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const stage = parseReportV02(report, 'test.yaml');
+        expect(stage.performance.ttftMean).toBeCloseTo(200); // 200,000,000 ns = 200 ms
+        expect(stage.performance.e2eMean).toBeCloseTo(5000);  // 5,000,000,000 ns = 5,000 ms
+    });
+
+    it('defaults unknown units to seconds and converts to milliseconds internally', () => {
+        const report = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'test-model' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'custom-harness' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            time_to_first_token: { mean: 1.5, p50: 1.2, p99: 2.0, units: 'unknown_unit' },
+                            time_per_output_token: { mean: 0.025, units: 'custom_unit/token' },
+                            request_latency: { mean: 12.0, units: 'unrecognized_metric' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const stage = parseReportV02(report, 'unknown_units.yaml');
+        expect(stage).toBeDefined();
+
+        // 1.5s -> 1500ms
+        expect(stage.performance.ttftMean).toBeCloseTo(1500);
+        expect(stage.performance.ttftP50).toBeCloseTo(1200);
+        expect(stage.performance.ttftP99).toBeCloseTo(2000);
+
+        // 0.025s/token -> 25ms
+        expect(stage.performance.tpotMean).toBeCloseTo(25);
+
+        // 12s -> 12000ms
+        expect(stage.performance.e2eMean).toBeCloseTo(12000);
+
+        const entry = stageToEntry(stage);
+        expect(entry.ttft.mean).toBeCloseTo(1500);
+        expect(entry.tpot).toBeCloseTo(25);
+        expect(entry.latency.mean).toBeCloseTo(12000);
+    });
+
+    it('triggers high latency validation warning when unknown unit value is large', () => {
+        // If an engine emitted raw milliseconds or nanoseconds under an unknown unit label
+        const rawReport = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'test-model' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'custom-harness' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        throughput: { output_token_rate: { mean: 50 } },
+                        latency: {
+                            request_latency: { mean: 5000, units: 'custom_timer' }, // 5000s > 1 hour (3600s)
+                        },
+                    },
+                },
+            },
+        };
+
+        const fileVal = validateBenchmark(JSON.stringify(rawReport), 'custom_timer.json');
+        expect(fileVal.warnings.some(w => w.includes('E2E latency is unusually high') && w.includes('> 1 hour'))).toBe(true);
+    });
+});
+
+describe('high latency warning hints during staging', () => {
+    it('flags warning hint when E2E latency > 1 hour (3600s)', () => {
+        const rawReport = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'meta-llama/Llama-3.1-8B-Instruct' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'vllm' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        throughput: { output_token_rate: { mean: 50 } },
+                        latency: {
+                            request_latency: { mean: 20867 }, // 20,867s without units
+                        },
+                    },
+                },
+            },
+        };
+
+        // File validation
+        const fileVal = validateBenchmark(JSON.stringify(rawReport), 'stage_0.json');
+        expect(fileVal.warnings.some(w => w.includes('E2E latency is unusually high') && w.includes('> 1 hour'))).toBe(true);
+
+        // Upload structure validation
+        const uploadData = {
+            runId: '11111111-1111-4111-8111-111111111111',
+            format: 'brv02',
+            runLabel: 'High Latency Test',
+            model_name: 'meta-llama/Llama-3.1-8B-Instruct',
+            hardware: { hardware_name: 'H100', accelerator_count: 8 },
+            entries: [{
+                run_id: '22222222-2222-4222-8222-222222222222',
+                run_description: 'High Latency Test',
+                filename: 'stage_0.json',
+                raw_report: rawReport,
+            }],
+        };
+
+        const structVal = validatePrismUploadStructure(uploadData, { isUpload: false });
+        expect(structVal.isValid).toBe(true); // Warnings do not invalidate the upload
+        expect(structVal.warnings.some(w => w.includes('E2E latency') && w.includes('> 1 hour'))).toBe(true);
+    });
+
+    it('does not flag warning hint when latency units are declared in ms even with large raw value', () => {
+        const rawReport = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'meta-llama/Llama-3.1-8B-Instruct' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'vllm' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        throughput: { output_token_rate: { mean: 50 } },
+                        latency: {
+                            request_latency: { mean: 20867, units: 'ms' }, // 20.867 seconds
+                            time_to_first_token: { mean: 1366, units: 'ms' }, // 1.366 seconds
+                        },
+                    },
+                },
+            },
+        };
+
+        const fileVal = validateBenchmark(JSON.stringify(rawReport), 'stage_0.json');
+        expect(fileVal.warnings.some(w => w.includes('unusually high'))).toBe(false);
+
+        const uploadData = {
+            runId: '11111111-1111-4111-8111-111111111111',
+            format: 'brv02',
+            runLabel: 'Normal Latency Test',
+            model_name: 'meta-llama/Llama-3.1-8B-Instruct',
+            hardware: { hardware_name: 'H100', accelerator_count: 8 },
+            entries: [{
+                run_id: '22222222-2222-4222-8222-222222222222',
+                run_description: 'Normal Latency Test',
+                filename: 'stage_0.json',
+                raw_report: rawReport,
+            }],
+        };
+
+        const structVal = validatePrismUploadStructure(uploadData, { isUpload: false });
+        expect(structVal.warnings.some(w => w.includes('unusually high'))).toBe(false);
+    });
+});
+
+describe('real-world TPU baseline report parsing and unit normalization', () => {
+    // Raw report numbers extracted from /tmp/run-20260831-tpu-optimized-baseline.zip
+    // (run-20260831-tpu-optimized-baseline/benchmark_report_v0.2,_stage_2_lifecycle_metrics.json.yaml)
+    const tpuBaselineStage2Raw = {
+        version: '0.2',
+        run: {
+            cid: 'bb4b7a47-0e6e-5c02-82b7-b7eb107c5bad',
+            eid: '1b4db7eb-4057-5ddf-91e0-36dec72071f5',
+            pid: 'fcf406c9-d3ff-4129-bbdc-ad2a98882311',
+            uid: 'b6717d51-83a4-48a4-a31d-b7db8ac3454b',
+            time: {
+                start: '2026-08-31T07:44:02Z',
+                end: '2026-08-31T08:58:01Z',
+                duration: 'PT4438.150105771S',
+            },
+        },
+        scenario: {
+            stack: [{
+                standardized: {
+                    role: 'decode',
+                    model: { name: 'google/gemma-4-31b-it' },
+                    accelerator: { count: 1, model: '' },
+                },
+            }],
+            load: {
+                standardized: {
+                    stage: 2,
+                    tool: 'inference-perf',
+                    tool_version: 'v0.6.0',
+                    concurrency: 20,
+                    rate_qps: 400.0,
+                    input_seq_len: { value: 14064.6, distribution: 'gaussian', min: 128, max: 32541 },
+                    output_seq_len: { value: 477.065, distribution: 'gaussian', min: 1, max: 4912 },
+                },
+            },
+        },
+        results: {
+            request_performance: {
+                aggregate: {
+                    latency: {
+                        request_latency: {
+                            mean: 21.558331447382503,
+                            p50: 8.664949262999926,
+                            p99: 137.07469749930002,
+                            units: 's',
+                        },
+                        time_to_first_token: {
+                            mean: 0.5040531363233116,
+                            p50: 0.17924734400003217,
+                            p99: 2.453011269560101,
+                            units: 's',
+                        },
+                        time_per_output_token: {
+                            mean: 0.012653682549065053,
+                            p50: 0.01175792287499943,
+                            p99: 0.026852995707660653,
+                            units: 's/token',
+                        },
+                        inter_token_latency: {
+                            mean: 0.012488129844540485,
+                            p50: 0.010950863500170271,
+                            p99: 0.05323104488002405,
+                            units: 's/token',
+                        },
+                        normalized_time_per_output_token: {
+                            mean: 0.14493545478724867,
+                            p50: 0.037196199899328986,
+                            p99: 1.6600611027258,
+                            units: 's/token',
+                        },
+                    },
+                    throughput: {
+                        output_token_rate: { mean: 222.21616933689222, units: 'tokens/s' },
+                        request_rate: { mean: 0.4657985166316796, units: 'queries/s' },
+                        total_token_rate: { mean: 6773.485986354813, units: 'tokens/s' },
+                    },
+                    requests: {
+                        total: 400,
+                        failures: 0,
+                    },
+                },
+            },
+        },
+    };
+
+    it('correctly parses raw TPU benchmark numbers and converts seconds to milliseconds', () => {
+        const stage = parseReportV02(tpuBaselineStage2Raw, 'benchmark_report_v0.2,_stage_2_lifecycle_metrics.json.yaml');
+        expect(stage).toBeDefined();
+
+        // Scenario & metadata
+        expect(stage.scenario.model).toBe('google/gemma-4-31b-it');
+        expect(stage.scenario.harness).toBe('inference-perf');
+        expect(stage.scenario.role).toBe('decode');
+        expect(stage.scenario.concurrency).toBe(20);
+        expect(stage.scenario.rateQps).toBe(400.0);
+        expect(stage.scenario.isl).toBe(14064.6);
+        expect(stage.scenario.osl).toBe(477.065);
+        expect(stage.stageIndex).toBe(2);
+        expect(stage.runUid).toBe('b6717d51-83a4-48a4-a31d-b7db8ac3454b');
+        expect(stage.timestamp).toBe('2026-08-31T07:44:02Z');
+
+        // Latencies converted from s (and s/token) to ms
+        expect(stage.performance.e2eMean).toBeCloseTo(21558.3314, 2);
+        expect(stage.performance.e2eP50).toBeCloseTo(8664.9493, 2);
+        expect(stage.performance.e2eP99).toBeCloseTo(137074.6975, 2);
+
+        expect(stage.performance.ttftMean).toBeCloseTo(504.0531, 2);
+        expect(stage.performance.ttftP50).toBeCloseTo(179.2473, 2);
+        expect(stage.performance.ttftP99).toBeCloseTo(2453.0113, 2);
+
+        expect(stage.performance.tpotMean).toBeCloseTo(12.6537, 3);
+        expect(stage.performance.tpotP50).toBeCloseTo(11.7579, 3);
+        expect(stage.performance.tpotP99).toBeCloseTo(26.8530, 3);
+
+        expect(stage.performance.itlMean).toBeCloseTo(12.4881, 3);
+        expect(stage.performance.itlP50).toBeCloseTo(10.9509, 3);
+        expect(stage.performance.itlP99).toBeCloseTo(53.2310, 3);
+
+        expect(stage.performance.ntpotMean).toBeCloseTo(144.9355, 3);
+        expect(stage.performance.ntpotP50).toBeCloseTo(37.1962, 3);
+        expect(stage.performance.ntpotP99).toBeCloseTo(1660.0611, 3);
+
+        // Throughput & requests
+        expect(stage.performance.outputTokenRate).toBe(222.21616933689222);
+        expect(stage.performance.requestRate).toBe(0.4657985166316796);
+        expect(stage.performance.totalTokenRate).toBe(6773.485986354813);
+        expect(stage.performance.totalRequests).toBe(400);
+        expect(stage.performance.failures).toBe(0);
+
+        // Confirm warnings are empty and rawReport preserves throughput units
+        expect(stage.warnings).toHaveLength(0);
+        expect(stage.rawReport.results.request_performance.aggregate.throughput.output_token_rate.units).toBe('tokens/s');
+        expect(stage.rawReport.results.request_performance.aggregate.throughput.request_rate.units).toBe('queries/s');
+    });
+
+    it('maps TPU stage record into a valid entry with expected derived metrics', () => {
+        const stage = parseReportV02(tpuBaselineStage2Raw, 'stage_2.yaml');
+        const entry = stageToEntry(stage);
+
+        expect(entry.model).toBe('gemma-4-31b-it');
+        expect(entry.model_name).toBe('gemma-4-31b-it');
+        expect(entry.backend).toBe('inference-perf');
+        expect(entry.metadata.architecture).toBe('decode');
+
+        // Workload
+        expect(entry.workload.input_tokens).toBe(14064.6);
+        expect(entry.workload.output_tokens).toBe(477.065);
+        expect(entry.workload.target_qps).toBe(400.0);
+        expect(entry.workload.concurrency).toBe(20);
+        expect(entry.workload.stage).toBe(2);
+
+        // Metrics
+        expect(entry.metrics.throughput).toBe(222.21616933689222);
+        expect(entry.metrics.output_tput).toBe(222.21616933689222);
+        expect(entry.metrics.total_tput).toBe(6773.485986354813);
+        // Derived input_tput: total - output
+        expect(entry.metrics.input_tput).toBeCloseTo(6551.2698, 2);
+        expect(entry.metrics.request_rate).toBe(0.4657985166316796);
+        expect(entry.metrics.error_count).toBe(0);
+
+        // Latencies in ms
+        expect(entry.metrics.latency.mean).toBeCloseTo(21558.3314, 2);
+        expect(entry.metrics.latency.p50).toBeCloseTo(8664.9493, 2);
+        expect(entry.metrics.latency.p99).toBeCloseTo(137074.6975, 2);
+        expect(entry.metrics.e2e_latency).toBeCloseTo(21558.3314, 2);
+
+        expect(entry.metrics.ttft.mean).toBeCloseTo(504.0531, 2);
+        expect(entry.metrics.ttft.p50).toBeCloseTo(179.2473, 2);
+        expect(entry.metrics.ttft.p99).toBeCloseTo(2453.0113, 2);
+
+        expect(entry.metrics.tpot).toBeCloseTo(12.6537, 3);
+        expect(entry.metrics.tpot_ms).toBeCloseTo(12.6537, 3);
+        expect(entry.metrics.tpot_p50).toBeCloseTo(11.7579, 3);
+        expect(entry.metrics.tpot_p99).toBeCloseTo(26.8530, 3);
+
+        expect(entry.metrics.ntpot).toBeCloseTo(144.9355, 3);
+        expect(entry.metrics.ntpot_ms).toBeCloseTo(144.9355, 3);
+        expect(entry.metrics.ntpot_p50).toBeCloseTo(37.1962, 3);
+        expect(entry.metrics.ntpot_p99).toBeCloseTo(1660.0611, 3);
+
+        expect(entry.metrics.itl).toBeCloseTo(12.4881, 3);
+        expect(entry.metrics.itl_ms).toBeCloseTo(12.4881, 3);
+        expect(entry.metrics.itl_p50).toBeCloseTo(10.9509, 3);
+        expect(entry.metrics.itl_p99).toBeCloseTo(53.2310, 3);
+    });
+
+    it('validates normalizeReportUnits properly attaches and preserves canonical units for TPU report', () => {
+        const normalized = normalizeReportUnits(tpuBaselineStage2Raw);
+        const lat = normalized.results.request_performance.aggregate.latency;
+
+        // Raw numbers already in seconds should remain exact
+        expect(lat.request_latency.mean).toBe(21.558331447382503);
+        expect(lat.request_latency.units).toBe('s');
+
+        expect(lat.time_to_first_token.mean).toBe(0.5040531363233116);
+        expect(lat.time_to_first_token.units).toBe('s');
+
+        expect(lat.time_per_output_token.mean).toBe(0.012653682549065053);
+        expect(lat.time_per_output_token.units).toBe('s/token');
+
+        expect(lat.inter_token_latency.mean).toBe(0.012488129844540485);
+        expect(lat.inter_token_latency.units).toBe('s/token');
+
+        expect(lat.normalized_time_per_output_token.mean).toBe(0.14493545478724867);
+        expect(lat.normalized_time_per_output_token.units).toBe('s/token');
+    });
+
+    it('correctly canonicalizes TPU metrics if reported in milliseconds into seconds and parses to matching ms', () => {
+        const rawLat = tpuBaselineStage2Raw.results.request_performance.aggregate.latency;
+        const msVariant = {
+            ...tpuBaselineStage2Raw,
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            request_latency: {
+                                mean: rawLat.request_latency.mean * 1000,
+                                p50: rawLat.request_latency.p50 * 1000,
+                                p99: rawLat.request_latency.p99 * 1000,
+                                units: 'ms',
+                            },
+                            time_to_first_token: {
+                                mean: rawLat.time_to_first_token.mean * 1000,
+                                p50: rawLat.time_to_first_token.p50 * 1000,
+                                p99: rawLat.time_to_first_token.p99 * 1000,
+                                units: 'ms',
+                            },
+                            time_per_output_token: {
+                                mean: rawLat.time_per_output_token.mean * 1000,
+                                p50: rawLat.time_per_output_token.p50 * 1000,
+                                p99: rawLat.time_per_output_token.p99 * 1000,
+                                units: 'ms/token',
+                            },
+                            inter_token_latency: {
+                                mean: rawLat.inter_token_latency.mean * 1000,
+                                p50: rawLat.inter_token_latency.p50 * 1000,
+                                p99: rawLat.inter_token_latency.p99 * 1000,
+                                units: 'ms/token',
+                            },
+                            normalized_time_per_output_token: {
+                                mean: rawLat.normalized_time_per_output_token.mean * 1000,
+                                p50: rawLat.normalized_time_per_output_token.p50 * 1000,
+                                p99: rawLat.normalized_time_per_output_token.p99 * 1000,
+                                units: 'ms/token',
+                            },
+                        },
+                        throughput: tpuBaselineStage2Raw.results.request_performance.aggregate.throughput,
+                        requests: tpuBaselineStage2Raw.results.request_performance.aggregate.requests,
+                    },
+                },
+            },
+        };
+
+        // 1. Check unit normalization to seconds
+        const normalized = normalizeReportUnits(msVariant);
+        const lat = normalized.results.request_performance.aggregate.latency;
+
+        expect(lat.request_latency.mean).toBeCloseTo(21.558331447382503, 6);
+        expect(lat.request_latency.units).toBe('s');
+
+        expect(lat.time_to_first_token.mean).toBeCloseTo(0.5040531363233116, 6);
+        expect(lat.time_to_first_token.units).toBe('s');
+
+        expect(lat.time_per_output_token.mean).toBeCloseTo(0.012653682549065053, 6);
+        expect(lat.time_per_output_token.units).toBe('s/token');
+
+        expect(lat.inter_token_latency.mean).toBeCloseTo(0.012488129844540485, 6);
+        expect(lat.inter_token_latency.units).toBe('s/token');
+
+        expect(lat.normalized_time_per_output_token.mean).toBeCloseTo(0.14493545478724867, 6);
+        expect(lat.normalized_time_per_output_token.units).toBe('s/token');
+
+        // 2. Check parseReportV02 directly on msVariant yields the exact expected milliseconds
+        const stage = parseReportV02(msVariant, 'ms_stage.yaml');
+        expect(stage.performance.e2eMean).toBeCloseTo(21558.3314, 2);
+        expect(stage.performance.ttftMean).toBeCloseTo(504.0531, 2);
+        expect(stage.performance.tpotMean).toBeCloseTo(12.6537, 3);
+        expect(stage.performance.itlMean).toBeCloseTo(12.4881, 3);
+        expect(stage.performance.ntpotMean).toBeCloseTo(144.9355, 3);
+    });
+});
+
+describe('missing units detection and warning generation', () => {
+    it('detects missing units across latency and throughput metrics with JSON paths and assumed defaults', () => {
+        const report = {
+            version: '0.2',
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            request_latency: { mean: 21.5 }, // missing units -> assumed 's'
+                            time_to_first_token: { mean: 0.5 }, // missing units -> assumed 's'
+                            time_per_output_token: { mean: 0.012 }, // missing units -> assumed 's/token'
+                            inter_token_latency: { mean: 0.011 }, // missing units -> assumed 's/token'
+                            normalized_time_per_output_token: { mean: 0.14 }, // missing units -> assumed 's/token'
+                        },
+                        throughput: {
+                            output_token_rate: { mean: 200 }, // missing units -> assumed 'tokens/s'
+                            request_rate: { mean: 5 }, // missing units -> assumed 'queries/s'
+                        },
+                    },
+                    time_series: {
+                        latency: {
+                            request_latency: {
+                                series: [{ ts: '2026-08-31T07:44:02Z', mean: 12.5 }],
+                            },
+                        },
+                    },
+                },
+                observability: {
+                    pod_startup_times: {
+                        aggregate: { mean: 42.0 },
+                        by_pod: {
+                            'vllm-0': { mean: 40.0 },
+                        },
+                    },
+                },
+                session_performance: {
+                    aggregate: {
+                        latency: {
+                            time_to_first_token: { mean: 1.0 },
+                        },
+                    },
+                },
+            },
+        };
+
+        const warnings = detectMissingUnitWarnings(report, 'stage_0.json');
+        expect(warnings).toHaveLength(11);
+
+        // Check each warning contains path, assumed unit, and filename prefix
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.request_performance.aggregate.latency.request_latency'; assumed 's' (seconds), but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.request_performance.aggregate.latency.time_to_first_token'; assumed 's' (seconds), but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.request_performance.aggregate.latency.time_per_output_token'; assumed 's/token' (seconds per token), but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.request_performance.aggregate.latency.inter_token_latency'; assumed 's/token' (seconds per token), but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.request_performance.aggregate.latency.normalized_time_per_output_token'; assumed 's/token' (seconds per token), but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.request_performance.aggregate.throughput.output_token_rate'; assumed 'tokens/s', but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.request_performance.aggregate.throughput.request_rate'; assumed 'queries/s', but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.request_performance.time_series.latency.request_latency'; assumed 's' (seconds), but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.observability.pod_startup_times.aggregate'; assumed 's' (seconds), but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.observability.pod_startup_times.by_pod.vllm-0'; assumed 's' (seconds), but validation is needed since units are missing from original report file."
+        );
+        expect(warnings).toContain(
+            "[stage_0.json] Missing units for '$.results.session_performance.aggregate.latency.time_to_first_token'; assumed 's' (seconds), but validation is needed since units are missing from original report file."
+        );
+    });
+
+    it('attaches missing unit warnings to stage and entry diagnostics on parseReportV02 and stageToEntry', () => {
+        const report = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'test-model' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'vllm' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            request_latency: { mean: 2.5 },
+                        },
+                    },
+                },
+            },
+        };
+
+        const stage = parseReportV02(report, 'stage_missing.yaml');
+        expect(stage.warnings).toHaveLength(1);
+        expect(stage.warnings[0]).toContain("Missing units for '$.results.request_performance.aggregate.latency.request_latency'; assumed 's' (seconds)");
+
+        const entry = stageToEntry(stage);
+        expect(entry._diagnostics.msg).toHaveLength(1);
+        expect(entry._diagnostics.msg[0]).toBe(stage.warnings[0]);
+    });
+
+    it('surfaces missing unit warnings in validateBenchmark and validatePrismUploadStructure', () => {
+        const rawReport = {
+            version: '0.2',
+            scenario: {
+                stack: [{ standardized: { role: 'aggregate', model: { name: 'test-model' }, accelerator: { model: 'H100' } } }],
+                load: { standardized: { tool: 'vllm' } },
+            },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        throughput: { output_token_rate: { mean: 50, units: 'tokens/s' } },
+                        latency: {
+                            request_latency: { mean: 2.5 }, // Missing units
+                            time_to_first_token: { mean: 0.5, units: 's' },
+                        },
+                    },
+                },
+            },
+        };
+
+        // File validation
+        const fileVal = validateBenchmark(JSON.stringify(rawReport), 'stage_0.json');
+        expect(fileVal.warnings.some(w => w.includes("Missing units for '$.results.request_performance.aggregate.latency.request_latency'"))).toBe(true);
+
+        // Upload structure validation
+        const uploadData = {
+            runId: '11111111-1111-4111-8111-111111111111',
+            format: 'brv02',
+            runLabel: 'Missing Units Test',
+            model_name: 'test-model',
+            hardware: { hardware_name: 'H100', accelerator_count: 1 },
+            entries: [{
+                run_id: '22222222-2222-4222-8222-222222222222',
+                run_description: 'Missing Units Test',
+                filename: 'stage_0.json',
+                raw_report: rawReport,
+            }],
+        };
+
+        const structVal = validatePrismUploadStructure(uploadData, { isUpload: false });
+        expect(structVal.isValid).toBe(true); // Warnings do not block upload
+        expect(structVal.warnings.some(w =>
+            w.includes('[stage_0.json]') &&
+            w.includes("Missing units for '$.results.request_performance.aggregate.latency.request_latency'") &&
+            w.includes("assumed 's' (seconds)")
+        )).toBe(true);
+    });
+
+    it('does not emit missing unit warnings when all units are explicitly declared', () => {
+        const report = {
+            version: '0.2',
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            request_latency: { mean: 21.5, units: 's' },
+                            time_to_first_token: { mean: 0.5, units: 's' },
+                            time_per_output_token: { mean: 0.012, units: 's/token' },
+                        },
+                        throughput: {
+                            output_token_rate: { mean: 200, units: 'tokens/s' },
+                            request_rate: { mean: 5, units: 'queries/s' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const warnings = detectMissingUnitWarnings(report);
+        expect(warnings).toHaveLength(0);
+    });
+
+    it('ensures parseReportV02 preserves units and does not emit warnings when throughput and latency declare units', () => {
+        const report = {
+            version: '0.2',
+            results: {
+                request_performance: {
+                    aggregate: {
+                        latency: {
+                            request_latency: { mean: 21.5, units: 's' },
+                            time_to_first_token: { mean: 0.5, units: 's' },
+                            time_per_output_token: { mean: 0.012, units: 's/token' },
+                        },
+                        throughput: {
+                            output_token_rate: { mean: 200, units: 'tokens/s' },
+                            request_rate: { mean: 5, units: 'queries/s' },
+                        },
+                    },
+                },
+            },
+        };
+
+        const stage = parseReportV02(report, 'stage_with_units.json');
+        expect(stage.warnings).toHaveLength(0);
+        expect(stage.rawReport.results.request_performance.aggregate.throughput.output_token_rate.units).toBe('tokens/s');
     });
 });

--- a/src/utils/benchmarkValidator.js
+++ b/src/utils/benchmarkValidator.js
@@ -1,5 +1,5 @@
 import yaml from 'js-yaml';
-import { parseReportV02, stageToEntry } from './benchmarkReportV02Parser.js';
+import { parseReportV02, stageToEntry, detectMissingUnitWarnings } from './benchmarkReportV02Parser.js';
 import { normalizeModelName, normalizeHardware } from './dataParser.js';
 import { PrismResultPayloadSchema } from '../../server/results/api.ts';
 
@@ -68,12 +68,27 @@ export function validateBenchmark(fileContent, filename) {
         try {
             const stage = parseReportV02(fileContent, filename);
             if (stage) {
+                if (Array.isArray(stage.warnings) && stage.warnings.length > 0) {
+                    result.warnings.push(...stage.warnings);
+                }
                 const entries = [];
                 
                 const entry = stageToEntry(stage);
                 const latencyVal = entry.latency && typeof entry.latency === 'object' ? entry.latency.mean : entry.latency;
                 if (entry.throughput === null || entry.throughput < 0 || latencyVal === null || latencyVal < 0) {
                     result.errors.push(`Stage ${stage.stageIndex} has negative metrics.`);
+                }
+                const e2eSec = latencyVal !== null ? latencyVal / 1000 : 0;
+                if (e2eSec > 3600) {
+                    result.warnings.push(`E2E latency is unusually high (${e2eSec.toFixed(1)}s > 1 hour). Verify that latency units were not emitted in milliseconds or nanoseconds without declaring units.`);
+                }
+                const ttftSec = (entry.ttft?.mean ?? 0) / 1000;
+                if (ttftSec > 600) {
+                    result.warnings.push(`TTFT is unusually high (${ttftSec.toFixed(1)}s > 10 minutes). Verify that latency units were not emitted in milliseconds or nanoseconds without declaring units.`);
+                }
+                const tpotSec = (entry.tpot ?? 0) / 1000;
+                if (tpotSec > 60) {
+                    result.warnings.push(`TPOT is unusually high (${tpotSec.toFixed(1)}s > 60 seconds per token). Verify that latency units were not emitted in milliseconds or nanoseconds without declaring units.`);
                 }
                 entries.push({
                     model_name: entry.model_name,
@@ -266,6 +281,13 @@ export function validatePrismUploadStructure(uploadData, options = {}) {
                 parsedStage.config = uploadData.config || null;
                 normalizedEntry = stageToEntry(parsedStage);
                 stageIndex = parsedStage.stageIndex ?? 0;
+
+                const rawReport = entry.raw_report || entry.rawReport || parsedStage.rawReport;
+                const missingUnitWarnings = detectMissingUnitWarnings(rawReport, entry.filename);
+                for (const w of missingUnitWarnings) {
+                    warnings.push(w);
+                    fieldErrors[`entries.${stageIndex}.missing_units`] = { message: w, severity: 'warning' };
+                }
             }
 
             // 1. Verify model name matches root $.model_name
@@ -321,6 +343,26 @@ export function validatePrismUploadStructure(uploadData, options = {}) {
             const latencyVal = normalizedEntry.latency && typeof normalizedEntry.latency === 'object' ? normalizedEntry.latency.mean : normalizedEntry.latency;
             if (normalizedEntry.throughput === null || normalizedEntry.throughput < 0 || latencyVal === null || latencyVal < 0) {
                 errors.push(`Stage ${stageIndex} (${entry.filename}) has negative metrics.`);
+            }
+
+            // 5. Verify latency values are not implausibly high (e.g. emitted in ms or ns without declaring units)
+            const e2eSec = latencyVal !== null ? latencyVal / 1000 : 0;
+            if (e2eSec > 3600) {
+                const msg = `Stage ${stageIndex} (${entry.filename || 'unknown'}) has an unusually high E2E latency (${e2eSec.toFixed(1)}s > 1 hour). This may indicate that metrics were emitted in milliseconds or nanoseconds without declaring units.`;
+                warnings.push(msg);
+                fieldErrors[`entries.${stageIndex}.latency`] = { message: msg, severity: 'warning' };
+            }
+            const ttftSec = (normalizedEntry.ttft?.mean ?? 0) / 1000;
+            if (ttftSec > 600) {
+                const msg = `Stage ${stageIndex} (${entry.filename || 'unknown'}) has an unusually high TTFT (${ttftSec.toFixed(1)}s > 10 minutes). This may indicate that metrics were emitted in milliseconds or nanoseconds without declaring units.`;
+                warnings.push(msg);
+                fieldErrors[`entries.${stageIndex}.ttft`] = { message: msg, severity: 'warning' };
+            }
+            const tpotSec = (normalizedEntry.tpot ?? 0) / 1000;
+            if (tpotSec > 60) {
+                const msg = `Stage ${stageIndex} (${entry.filename || 'unknown'}) has an unusually high TPOT (${tpotSec.toFixed(1)}s > 60 seconds per token). This may indicate that metrics were emitted in milliseconds or nanoseconds without declaring units.`;
+                warnings.push(msg);
+                fieldErrors[`entries.${stageIndex}.tpot`] = { message: msg, severity: 'warning' };
             }
 
         } catch (e) {


### PR DESCRIPTION
## What does this PR do?

- Fixes latency parsing and unit handling in BRv0.2 benchmark reports so latencies are correctly canonicalized and displayed in milliseconds.
- Prevents parser schemas from dropping declared unit metadata or extra properties from raw reports.
- Adds non-blocking warnings with exact JSON paths when report metrics omit units, assuming standard defaults (`s`, `s/token`, `tokens/s`, `queries/s`).
- Highlights suspicious latencies (> 1 hour) in the staging dialog to flag possible unit mismatches before upload.
- Improves staging table readability with horizontal scrolling, compact columns, and full timestamps.
- Documents unit handling specifications and defaulting rules in `specs/main/completed/results-api/unit_handling.md`.

## Why is this change needed?

Benchmark reports frequently emit latency metrics in different units (or omit unit fields entirely), leading to incorrect scaling (e.g. 1000x off) and false warnings about missing units during ingestion. This ensures Prism ingests and scales values accurately, surfaces clear diagnostic warnings when units are truly missing without blocking uploads, and makes staging validation easier to inspect.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

Verified with updated Vitest suites (127 tests passing) covering real-world TPU baseline report parsing, multi-unit conversions, unknown unit fallback handling, and missing-unit warning detection.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Linters pass (`npm run lint`)
- [x] Documentation updated (if applicable)

## Related Issues

Fixes https://github.com/llm-d/llm-d-prism/issues/144
