### PR TITLE
Default sort Results Store by run label and add Community Only filter

### DIFF
--- a/specs/main/completed/results-api/parser_and_data_model.md
+++ b/specs/main/completed/results-api/parser_and_data_model.md
@@ -267,3 +267,14 @@ localeCompare(otherString, undefined, {
 
 This guarantees that sequence lengths (e.g., "128", "256", "1024") are ordered
 numerically rather than lexicographically.
+
+### 7.2 Results Store Default Sorting & Grouping
+
+The Results Store table sorts by **Run Label** (`runLabel`) ascending (`asc`) by
+default, ordering benchmarks naturally by benchmark name / run label (using the
+same locale-sensitive natural numeric sort) and falling back to model name /
+benchmark key when unspecified.
+
+When grouping by any dimension (such as Model, Hardware, or Origin), the group
+headers are also consistently sorted using natural numeric-aware locale
+comparison, placing "Other" and "Unknown" fallback categories at the end.

--- a/src/components/Dashboard.jsx
+++ b/src/components/Dashboard.jsx
@@ -1376,7 +1376,7 @@ const Dashboard = ({ mode = 'browser', onNavigateBack, onNavigate, dashboardStat
 
             stats.push({
                 benchmarkKey,
-                runLabel: payload?.runLabel || '',
+                runLabel: payload?.runLabel || groupingData.find(d => d.runLabel)?.runLabel || groupingData[0]?.runLabel || '',
                 model,
                 configuration, // Explicitly pass configuration
                 maxTput,

--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -18,7 +18,7 @@ import { Filter, ChevronDown, ChevronUp, Check, ArrowDown01, ArrowDown10, Loader
 import { MultiSelectDropdown } from '../common';
 import { Button, Input, Select, Label } from '../ui';
 import { cn } from '../../utils/cn';
-import { USE_CASE_META, formatOriginLabel } from '../../utils/dashboardHelpers';
+import { USE_CASE_META, formatOriginLabel, getSourceType } from '../../utils/dashboardHelpers';
 import { useGitHubAuth } from '../../hooks/useGitHubAuth';
 
 const SPEC_LABELS = {
@@ -101,6 +101,7 @@ export const FilterPanel = ({
     loadSubmissions,
     searchTerm, setSearchTerm, kpiFilter, setKpiFilter,
     includeUnlisted = false, setIncludeUnlisted,
+    communityOnly = false, setCommunityOnly,
     updateSubmissionStatus,
     bulkUpdateSubmissionStatus,
     deleteSubmission,
@@ -216,13 +217,14 @@ export const FilterPanel = ({
 
     const hasAnyActiveFilters = React.useMemo(() => {
         const hasActiveFacet = Object.values(activeFilters).some(valSet => valSet instanceof Set && valSet.size > 0);
-        return hasActiveFacet || !!searchTerm || !!kpiFilter || !!includeUnlisted;
-    }, [activeFilters, searchTerm, kpiFilter, includeUnlisted]);
+        return hasActiveFacet || !!searchTerm || !!kpiFilter || !!includeUnlisted || !!communityOnly;
+    }, [activeFilters, searchTerm, kpiFilter, includeUnlisted, communityOnly]);
 
     const handleClearAllFilters = () => {
         setSearchTerm('');
         setKpiFilter(null);
         if (setIncludeUnlisted) setIncludeUnlisted(false);
+        if (setCommunityOnly) setCommunityOnly(false);
         const newFilters = {};
         Object.keys(activeFilters).forEach(key => {
             newFilters[key] = new Set();
@@ -460,6 +462,17 @@ export const FilterPanel = ({
 
     const legacyCount = totalCount - verifiedCount;
 
+    const hiddenBuiltinCount = React.useMemo(() => {
+        return modelStats.filter(s => {
+            const firstEntry = s.data?.[0];
+            if (!firstEntry) return true;
+            const src = firstEntry.source || '';
+            const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
+            const isBuiltin = getSourceType(firstEntry) === 'Built-in' || !isBrv02;
+            return isBuiltin;
+        }).length;
+    }, [modelStats]);
+
     const allRuns = React.useMemo(() => {
         const runs = [];
         modelStats.forEach(s => {
@@ -588,6 +601,7 @@ export const FilterPanel = ({
                 kpiFilter={kpiFilter}
                 setKpiFilter={setKpiFilter}
                 includeUnlisted={includeUnlisted}
+                communityOnly={communityOnly}
                 paretoKeys={paretoKeys}
                 submissionsMap={submissionsMap}
                 isLoadingSubmissions={isLoadingSubmissions}
@@ -609,7 +623,7 @@ export const FilterPanel = ({
         setActiveFilters, expandedModels, toggleBenchmark, toggleModelExpansion, baselineBenchmarkKey,
         setBaselineBenchmarkKey, hideShowSelectedOnly, renameClearToUnselectAll, brv02Runs, brv02CustomLabels,
         setBrv02CustomLabels, removeBrv02Run, scannedFilenames, setShowDataPanel, searchTerm, setSearchTerm, kpiFilter,
-        setKpiFilter, includeUnlisted, paretoKeys, submissionsMap, isLoadingSubmissions, updateSubmissionStatus,
+        setKpiFilter, includeUnlisted, communityOnly, paretoKeys, submissionsMap, isLoadingSubmissions, updateSubmissionStatus,
         bulkUpdateSubmissionStatus, deleteSubmission, onOpenSubmitDialog, hasFiltersToSave, loadAllData, loadingConnections,
         dashboardState, defaultSources, addToast, dashboardData
     ]);
@@ -867,6 +881,52 @@ export const FilterPanel = ({
                                                         </div>
                                                     </div>
                                                 </div>
+
+                                                {/* Pane: Community Benchmarks Only Pane */}
+                                                <button
+                                                    onClick={() => setCommunityOnly ? setCommunityOnly(prev => !prev) : null}
+                                                    className={cn(
+                                                        "flex flex-col justify-between px-4 py-3 rounded-xl border text-left transition-all duration-300 cursor-pointer select-none min-w-[210px] max-w-[240px]",
+                                                        communityOnly
+                                                        ? "bg-slate-900 border-blue-500/50 shadow-[0_0_12px_rgba(59,130,246,0.15)]"
+                                                        : "bg-slate-900/40 border-slate-900/80 hover:border-slate-800/80 hover:bg-slate-800/40"
+                                                    )}
+                                                    title="Toggle community benchmarks only"
+                                                >
+                                                    <div className="flex flex-col justify-center">
+                                                        <span className="text-[10px] font-bold uppercase tracking-wider text-slate-400/95 leading-none">
+                                                            Community Only
+                                                        </span>
+                                                        <span className="text-[10px] text-slate-500 mt-1.5 leading-tight">
+                                                            Hides built-in benchmarks and only show community-submitted benchmarks
+                                                        </span>
+                                                    </div>
+                                                    
+                                                    <div className="pt-2 flex items-center justify-between border-t border-slate-800/60 mt-2.5">
+                                                        <span className={cn("text-[9px] font-bold uppercase tracking-wider whitespace-nowrap", communityOnly ? "text-blue-400" : "text-slate-500")}>
+                                                            {communityOnly ? (
+                                                                <>
+                                                                    Active{" "}
+                                                                    <span className="normal-case tracking-normal font-semibold text-blue-300/85">
+                                                                        ({hiddenBuiltinCount} hidden)
+                                                                    </span>
+                                                                </>
+                                                            ) : (
+                                                                "Off"
+                                                            )}
+                                                        </span>
+                                                        
+                                                        <div className={cn(
+                                                            "w-7 h-4 rounded-full p-0.5 transition-colors duration-200 ease-in-out flex items-center",
+                                                            communityOnly ? "bg-blue-500 shadow-[0_0_8px_rgba(59,130,246,0.4)]" : "bg-slate-800 border border-slate-700/60"
+                                                        )}>
+                                                            <div className={cn(
+                                                                "w-3 h-3 rounded-full shadow-md transform transition-transform duration-200 ease-in-out",
+                                                                communityOnly ? "translate-x-3 bg-slate-950" : "translate-x-0 bg-slate-400"
+                                                            )} />
+                                                        </div>
+                                                    </div>
+                                                </button>
 
                                                 {/* Pane 2: Standalone Unlisted Pane */}
                                                 <button

--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -312,16 +312,26 @@ export const FilterPanel = ({
     
     const [sortByField, setSortByField] = useState(() => {
         try {
+            const migrated = localStorage.getItem('prism_manage_sort_default_v2');
+            if (!migrated) {
+                localStorage.setItem('prism_manage_sort_default_v2', 'true');
+                const saved = localStorage.getItem('prism_manage_sort_by');
+                if (!saved || saved === 'timestamp') {
+                    localStorage.setItem('prism_manage_sort_by', 'runLabel');
+                    localStorage.setItem('prism_manage_sort_dir', 'asc');
+                    return 'runLabel';
+                }
+            }
             const saved = localStorage.getItem('prism_manage_sort_by');
-            return saved || 'timestamp';
-        } catch { return 'timestamp'; }
+            return saved || 'runLabel';
+        } catch { return 'runLabel'; }
     });
 
     const [sortDirection, setSortDirection] = useState(() => {
         try {
             const saved = localStorage.getItem('prism_manage_sort_dir');
-            return saved || 'desc';
-        } catch { return 'desc'; }
+            return saved || 'asc';
+        } catch { return 'asc'; }
     });
 
     const [isFiltersExpanded, setIsFiltersExpanded] = useState(() => {
@@ -990,7 +1000,7 @@ export const FilterPanel = ({
                                 }}
                                 className={cn(
                                     'px-3 py-2 text-xs font-semibold rounded-xl border transition-colors cursor-pointer flex items-center gap-1.5',
-                                    showViewSettings || groupBy !== 'None' || sortByField !== 'timestamp'
+                                    showViewSettings || groupBy !== 'None' || sortByField !== 'runLabel'
                                     ? 'bg-cyan-500/10 text-cyan-400 border-cyan-500/30 font-bold'
                                     : 'bg-[#070b13] border-slate-800 hover:border-slate-700 text-slate-400 hover:text-slate-205'
                                 )}
@@ -1029,6 +1039,7 @@ export const FilterPanel = ({
                                                     value={sortByField}
                                                     onChange={(e) => setSortByField(e.target.value)}
                                                 >
+                                                    <option value="runLabel">Run Label</option>
                                                     <option value="timestamp">Timestamp</option>
                                                     <option value="maxTput">Max Throughput</option>
                                                     <option value="minLat">Min Latency</option>

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -19,8 +19,8 @@ import { RunComparisonChart } from '../Dashboard/RunComparisonChart';
 import { ThroughputCostChart } from '../Dashboard/ThroughputCostChart';
 import { Button, Badge, StatusChip, Modal, Textarea } from '../ui';
 import { cn } from '../../utils/cn';
-import { getSourceTag, getSourceType, getSourceTypeStyle, formatOriginLabel, getSubmissionStatusDetails, getBenchmarkKey } from '../../utils/dashboardHelpers';
-import { buildRunLabel } from '../../utils/runLabel';
+import { getSourceTag, getSourceType, getSourceTypeStyle, formatOriginLabel, getSubmissionStatusDetails, getBenchmarkKey, sortGroupKeys } from '../../utils/dashboardHelpers';
+import { buildRunLabel, getBenchmarkSortLabel } from '../../utils/runLabel';
 import yaml from 'js-yaml';
 import { useGitHubAuth } from '../../hooks/useGitHubAuth';
 import { validateBenchmark } from '../../utils/benchmarkValidator';
@@ -323,8 +323,8 @@ export const UnifiedDataTable = (props) => {
         onOpenSubmitDialog,
         isFiltered = false,
         groupBy = 'Model',
-        sortByField = 'timestamp',
-        sortDirection = 'desc',
+        sortByField = 'runLabel',
+        sortDirection = 'asc',
         visibleSpecs = {
             hardware: true,
             timestamp: true,
@@ -1292,7 +1292,10 @@ export const UnifiedDataTable = (props) => {
         return [...filteredStats].sort((a, b) => {
             let valA, valB;
             
-            if (sortByField === 'timestamp') {
+            if (sortByField === 'runLabel') {
+                valA = getBenchmarkSortLabel(a, brv02CustomLabels);
+                valB = getBenchmarkSortLabel(b, brv02CustomLabels);
+            } else if (sortByField === 'timestamp') {
                 valA = a.timestamp || 0;
                 valB = b.timestamp || 0;
             } else if (sortByField === 'maxTput') {
@@ -1337,6 +1340,17 @@ export const UnifiedDataTable = (props) => {
                 return primaryResult;
             }
 
+            if (sortByField === 'runLabel') {
+                const modelA = a.model_name || a.model || '';
+                const modelB = b.model_name || b.model || '';
+                const modelCmp = modelA.localeCompare(modelB, undefined, { numeric: true, sensitivity: 'base' });
+                if (modelCmp !== 0) return modelCmp;
+
+                const timeA = a.timestamp || 0;
+                const timeB = b.timestamp || 0;
+                if (timeA !== timeB) return timeB - timeA;
+            }
+
             // Fallback tie-breaker: Origin/Folder first, then Filename
             const firstA = a.data?.[0];
             const firstB = b.data?.[0];
@@ -1359,7 +1373,7 @@ export const UnifiedDataTable = (props) => {
 
             return (a.benchmarkKey || '').localeCompare(b.benchmarkKey || '', undefined, { numeric: true, sensitivity: 'base' });
         });
-    }, [filteredStats, sortByField, sortDirection]);
+    }, [filteredStats, sortByField, sortDirection, brv02CustomLabels]);
 
     const needsExpansion = sortedStats.length > 4;
 
@@ -1398,11 +1412,20 @@ export const UnifiedDataTable = (props) => {
                 if (!grouped[key]) grouped[key] = [];
                 grouped[key].push(stat);
             });
+
+            const isGroupSortDesc = (groupBy === 'Model' && sortByField === 'model') ? sortDirection === 'desc' : false;
+            const sortedKeys = sortGroupKeys(Object.keys(grouped), { isDesc: isGroupSortDesc });
+
+            const sortedGrouped = {};
+            for (const key of sortedKeys) {
+                sortedGrouped[key] = grouped[key];
+            }
+            return sortedGrouped;
         } else {
             grouped['All'] = sortedStats;
+            return grouped;
         }
-        return grouped;
-    }, [sortedStats, groupBy]);
+    }, [sortedStats, groupBy, sortByField, sortDirection]);
 
     const visibleStatsList = React.useMemo(() => {
         return Object.values(groupedStats).flat();

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -138,7 +138,7 @@ const getKpiFilterLabel = (filter, isPlaygroundMode = false) => {
 };
 
 export const UnifiedDataTable = (props) => {
-    const { dashboardState, includeUnlisted = false, addToast, dashboardData } = props;
+    const { dashboardState, includeUnlisted = false, communityOnly = false, addToast, dashboardData } = props;
     const { user, isPlaygroundMode } = useGitHubAuth();
     const isAdmin = user?.permission === 'admin';
         const [rawYamlContent, setRawYamlContent] = useState(null);
@@ -1151,6 +1151,16 @@ export const UnifiedDataTable = (props) => {
                     return status !== 'unlisted';
                 });
             }
+            if (communityOnly) {
+                stats = stats.filter(stat => {
+                    const firstEntry = stat.data?.[0];
+                    if (!firstEntry) return false;
+                    const src = firstEntry.source || '';
+                    const isBrv02 = src.startsWith('brv02:') || firstEntry.source_info?.type === 'benchmark_report_v02';
+                    const isBuiltin = getSourceType(firstEntry) === 'Built-in' || !isBrv02;
+                    return !isBuiltin;
+                });
+            }
         }
 
         // Apply KPI Filter
@@ -1286,7 +1296,7 @@ export const UnifiedDataTable = (props) => {
         }
 
         return stats;
-    }, [modelStats, showSelectedOnly, selectedBenchmarks, kpiFilter, includeUnlisted, searchTerm, paretoKeys, baselineBenchmarkKey, submissionsMap, user, isPlaygroundMode]);
+    }, [modelStats, showSelectedOnly, selectedBenchmarks, kpiFilter, includeUnlisted, communityOnly, searchTerm, paretoKeys, baselineBenchmarkKey, submissionsMap, user, isPlaygroundMode]);
 
     const sortedStats = React.useMemo(() => {
         return [...filteredStats].sort((a, b) => {

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -652,7 +652,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
 
             stats.push({
                 benchmarkKey,
-                runLabel: payload?.runLabel || '',
+                runLabel: payload?.runLabel || groupingData.find(d => d.runLabel)?.runLabel || groupingData[0]?.runLabel || '',
                 model,
                 configuration,
                 maxTput,

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -175,6 +175,26 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
         }
     });
 
+    const [communityOnly, setCommunityOnly] = React.useState(() => {
+        try {
+            const params = new URLSearchParams(window.location.search);
+            if (params.has('communityOnly')) {
+                return params.get('communityOnly') === 'true' || params.get('communityOnly') === '1';
+            }
+            if (params.has('community_only')) {
+                return params.get('community_only') === 'true' || params.get('community_only') === '1';
+            }
+            if (params.has('community')) {
+                return params.get('community') === 'true' || params.get('community') === '1';
+            }
+
+            const saved = localStorage.getItem('prism_community_only');
+            if (saved !== null) return saved === 'true';
+        } catch {
+            return false;
+        }
+    });
+
     const [kpiFilter, setKpiFilter] = React.useState(() => {
         try {
             const params = new URLSearchParams(window.location.search);
@@ -215,6 +235,12 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
 
     React.useEffect(() => {
         try {
+            localStorage.setItem('prism_community_only', communityOnly.toString());
+        } catch (e) { console.warn(e); }
+    }, [communityOnly]);
+
+    React.useEffect(() => {
+        try {
             if (kpiFilter) {
                 localStorage.setItem('prism_status_filter', kpiFilter);
             } else {
@@ -247,6 +273,14 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
             params.delete('includeUnlisted');
         }
 
+        if (communityOnly) {
+            params.set('communityOnly', '1');
+        } else {
+            params.delete('communityOnly');
+            params.delete('community_only');
+            params.delete('community');
+        }
+
         if (searchTerm) {
             params.set('q', searchTerm);
         } else {
@@ -258,7 +292,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
         if (window.location.search !== `?${params.toString()}`) {
             window.history.replaceState(null, '', newUrl);
         }
-    }, [kpiFilter, includeUnlisted, searchTerm]);
+    }, [kpiFilter, includeUnlisted, communityOnly, searchTerm]);
 
     React.useEffect(() => {
         const showSubmitFlow = sessionStorage.getItem('prism_show_submit_dialog_after_login');
@@ -1043,6 +1077,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
                         brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run, scannedFilenames,
                         searchTerm, setSearchTerm, kpiFilter, setKpiFilter,
                         includeUnlisted, setIncludeUnlisted,
+                        communityOnly, setCommunityOnly,
                         submissionsMap,
                         isLoadingSubmissions,
                         updateSubmissionStatus,
@@ -1071,6 +1106,7 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
         brv02Runs, brv02CustomLabels, setBrv02CustomLabels, removeBrv02Run, scannedFilenames,
         searchTerm, setSearchTerm, kpiFilter, setKpiFilter,
         includeUnlisted,
+        communityOnly,
         submissionsMap,
         isLoadingSubmissions,
         updateSubmissionStatus,

--- a/src/hooks/useDashboardState.js
+++ b/src/hooks/useDashboardState.js
@@ -30,6 +30,7 @@ export const getSharedState = () => {
             own: params.has('own') ? params.get('own') === 'true' : null,
             q: params.get('q') || params.get('search') || null,
             unlisted: params.has('unlisted') ? params.get('unlisted') === 'true' || params.get('unlisted') === '1' : (params.has('includeUnlisted') ? params.get('includeUnlisted') === 'true' || params.get('includeUnlisted') === '1' : null),
+            communityOnly: params.has('communityOnly') ? params.get('communityOnly') === 'true' || params.get('communityOnly') === '1' : (params.has('community_only') ? params.get('community_only') === 'true' || params.get('community_only') === '1' : null),
             chartMode: params.get('c_mode') || 'tpot',
             tputType: params.get('t_type') || 'output',
             costMode: params.get('cost_mode') || 'spot',

--- a/src/utils/dashboardHelpers.jsx
+++ b/src/utils/dashboardHelpers.jsx
@@ -192,6 +192,20 @@ export const sortBuckets = (buckets) => {
     });
 };
 
+export const sortGroupKeys = (keys, { isDesc = false } = {}) => {
+    return [...keys].sort((a, b) => {
+        const strA = String(a ?? '');
+        const strB = String(b ?? '');
+        const isSpecialA = strA === 'Other' || strA.startsWith('Unknown');
+        const isSpecialB = strB === 'Other' || strB.startsWith('Unknown');
+        if (isSpecialA && !isSpecialB) return 1;
+        if (!isSpecialA && isSpecialB) return -1;
+
+        const cmp = strA.localeCompare(strB, undefined, { numeric: true, sensitivity: 'base' });
+        return isDesc ? -cmp : cmp;
+    });
+};
+
 export const findParetoPoint = (dataset, xKey, yKey, minimizeX, maximizeY) => {
     if (!dataset || dataset.length === 0) return null;
 

--- a/src/utils/dashboardHelpers.test.js
+++ b/src/utils/dashboardHelpers.test.js
@@ -51,3 +51,23 @@ describe('dashboardHelpers sortBuckets', () => {
         expect(sortBuckets(buckets)).toEqual(['128', '512', '1024', '2048']);
     });
 });
+
+describe('dashboardHelpers getSourceType', () => {
+    it('identifies built-in sources correctly', async () => {
+        const { getSourceType } = await import('./dashboardHelpers.jsx');
+        expect(getSourceType({ source: 'local' })).toBe('Built-in');
+        expect(getSourceType({ source: 'llm-d-results:google_drive' })).toBe('Built-in');
+        expect(getSourceType({ source: 'llmd_drive' })).toBe('Built-in');
+        expect(getSourceType({ source: 'quality_scores' })).toBe('Built-in');
+        expect(getSourceType(null)).toBe('Built-in');
+    });
+
+    it('identifies cloud and local brv02 sources correctly', async () => {
+        const { getSourceType } = await import('./dashboardHelpers.jsx');
+        expect(getSourceType({ source: 'gcs:llm-d-benchmarks' })).toBe('Cloud');
+        expect(getSourceType({ source: 'gcs:llm-d-benchmarks-staging' })).toBe('Cloud');
+        expect(getSourceType({ source: 'aws:my-bucket' })).toBe('Cloud');
+        expect(getSourceType({ source: 'brv02:run-123' })).toBe('Local');
+    });
+});
+

--- a/src/utils/dashboardHelpers.test.js
+++ b/src/utils/dashboardHelpers.test.js
@@ -1,0 +1,53 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import { sortGroupKeys, sortBuckets } from './dashboardHelpers.jsx';
+
+describe('dashboardHelpers sortGroupKeys', () => {
+    it('sorts group keys alphabetically using natural numeric sorting', () => {
+        const keys = ['Qwen3-32B', 'Llama-3.1-8B', 'Llama-3.1-70B', 'Gemma-2-9B'];
+        const sorted = sortGroupKeys(keys);
+        expect(sorted).toEqual(['Gemma-2-9B', 'Llama-3.1-8B', 'Llama-3.1-70B', 'Qwen3-32B']);
+    });
+
+    it('sorts hardware chip numbers naturally', () => {
+        const keys = ['8x H100', '1x H100', '16x H100', '2x H100'];
+        const sorted = sortGroupKeys(keys);
+        expect(sorted).toEqual(['1x H100', '2x H100', '8x H100', '16x H100']);
+    });
+
+    it('places Other and Unknown groups at the end', () => {
+        const keys = ['Unknown Hardware', '8x H100', 'Other', '1x H100', 'Unknown Model'];
+        const sorted = sortGroupKeys(keys);
+        expect(sorted.slice(0, 2)).toEqual(['1x H100', '8x H100']);
+        // The remaining 3 should be Other and Unknowns
+        expect(sorted.slice(2)).toContain('Other');
+        expect(sorted.slice(2)).toContain('Unknown Hardware');
+        expect(sorted.slice(2)).toContain('Unknown Model');
+    });
+
+    it('supports descending order while keeping special keys at the end', () => {
+        const keys = ['Qwen3-32B', 'Other', 'Gemma-2-9B', 'Llama-3.1-70B'];
+        const sorted = sortGroupKeys(keys, { isDesc: true });
+        expect(sorted).toEqual(['Qwen3-32B', 'Llama-3.1-70B', 'Gemma-2-9B', 'Other']);
+    });
+});
+
+describe('dashboardHelpers sortBuckets', () => {
+    it('sorts sequence length buckets numerically', () => {
+        const buckets = ['1024', '128', '2048', '512'];
+        expect(sortBuckets(buckets)).toEqual(['128', '512', '1024', '2048']);
+    });
+});

--- a/src/utils/runLabel.js
+++ b/src/utils/runLabel.js
@@ -82,3 +82,43 @@ export const getEntryLabel = (entry) => {
         description: entry.runLabel || entry.metadata?.variant || entry.metadata?.configuration,
     });
 };
+
+/**
+ * Resolves the benchmark name / run label for table sorting in Results Store.
+ * Prefers active custom label overrides, then the benchmark runLabel,
+ * and falls back to model or benchmarkKey when unspecified.
+ */
+export const getBenchmarkSortLabel = (stat, customLabels = {}) => {
+    if (!stat) return '';
+    const benchmarkData = Array.isArray(stat.data) ? stat.data : [];
+    const sourceStr = benchmarkData[0]?.source || stat.source || '';
+    const isBrv02 = sourceStr.startsWith('brv02:') ||
+        benchmarkData[0]?.source_info?.type === 'benchmark_report_v02' ||
+        stat.source_info?.type === 'benchmark_report_v02';
+    const runId = isBrv02
+        ? (sourceStr.startsWith('brv02:')
+            ? sourceStr.replace('brv02:', '')
+            : (benchmarkData[0]?.run_id || stat.run_id))
+        : null;
+
+    if (runId && customLabels?.[runId]) {
+        return customLabels[runId];
+    }
+    const customKeyId = getCustomLabelRunId(stat.benchmarkKey || stat);
+    if (customKeyId && customLabels?.[customKeyId]) {
+        return customLabels[customKeyId];
+    }
+
+    const rawLabel = stat.runLabel ||
+        stat.payload?.runLabel ||
+        benchmarkData[0]?.runLabel ||
+        benchmarkData[0]?.payload?.runLabel ||
+        benchmarkData.find?.(d => d.runLabel)?.runLabel;
+
+    if (rawLabel && typeof rawLabel === 'string' && rawLabel.trim()) {
+        return rawLabel.trim();
+    }
+
+    return stat.model_name || stat.model || benchmarkData[0]?.metadata?.model_name || stat.benchmarkKey || '';
+};
+

--- a/src/utils/runLabel.test.js
+++ b/src/utils/runLabel.test.js
@@ -14,7 +14,7 @@
 
 import { describe, it } from 'vitest';
 import assert from 'node:assert/strict';
-import { buildRunLabel, getEntryLabel, stripModelPrefix, stripExperimentIdSuffix, getCustomLabelRunId } from './runLabel.js';
+import { buildRunLabel, getEntryLabel, stripModelPrefix, stripExperimentIdSuffix, getCustomLabelRunId, getBenchmarkSortLabel } from './runLabel.js';
 
 const MODEL = 'qwen3-32b';
 
@@ -102,4 +102,53 @@ describe('run label', () => {
         assert.equal(
             getCustomLabelRunId({ source_info: { type: 'benchmark_report_v02' }, run_id: 'r9' }), 'r9');
     });
+
+    it('resolves benchmark sort label prioritizing custom label, runLabel, then model fallback', () => {
+        // Direct runLabel
+        assert.equal(getBenchmarkSortLabel({ runLabel: 'Baseline Test' }), 'Baseline Test');
+
+        // From data array or payload
+        assert.equal(getBenchmarkSortLabel({ data: [{ runLabel: 'Nested Stage Label' }] }), 'Nested Stage Label');
+        assert.equal(getBenchmarkSortLabel({ payload: { runLabel: 'Payload Run Name' } }), 'Payload Run Name');
+
+        // Custom label overrides
+        assert.equal(
+            getBenchmarkSortLabel(
+                { benchmarkKey: 'results-store:run-abc', runLabel: 'Original Label' },
+                { 'run-abc': 'Renamed Benchmark' }
+            ),
+            'Renamed Benchmark'
+        );
+
+        // Fallback to model name when no label is present
+        assert.equal(getBenchmarkSortLabel({ model: 'llama-3.1-70b' }), 'llama-3.1-70b');
+        assert.equal(getBenchmarkSortLabel({ benchmarkKey: 'custom-key' }), 'custom-key');
+        assert.equal(getBenchmarkSortLabel(null), '');
+    });
+
+    it('sorts benchmarks by benchmark name using natural numeric comparison', () => {
+        const stats = [
+            { benchmarkKey: '3', runLabel: 'Run 10' },
+            { benchmarkKey: '1', runLabel: 'Run 2' },
+            { benchmarkKey: '2', runLabel: 'Alpha Baseline' },
+            { benchmarkKey: '4', model: 'Zero-Label Model' },
+        ];
+
+        const sortedAsc = [...stats].sort((a, b) => {
+            const labelA = getBenchmarkSortLabel(a);
+            const labelB = getBenchmarkSortLabel(b);
+            return labelA.localeCompare(labelB, undefined, { numeric: true, sensitivity: 'base' });
+        });
+
+        assert.deepEqual(sortedAsc.map(s => s.benchmarkKey), ['2', '1', '3', '4']);
+
+        const sortedDesc = [...stats].sort((a, b) => {
+            const labelA = getBenchmarkSortLabel(a);
+            const labelB = getBenchmarkSortLabel(b);
+            return labelB.localeCompare(labelA, undefined, { numeric: true, sensitivity: 'base' });
+        });
+
+        assert.deepEqual(sortedDesc.map(s => s.benchmarkKey), ['4', '3', '1', '2']);
+    });
 });
+


### PR DESCRIPTION
## What does this PR do?

- Sets the default table sorting in Results Store to Run Label (A-Z) using natural numeric sorting, with fallback to model name or benchmark key.
- Sorts group category headers alphabetically while positioning "Other" and "Unknown" fallback categories at the end.
- Adds a "Community Only" filter toggle to the Results Store to hide built-in benchmarks, persisting state in localStorage and URL query params (`communityOnly=1`).

<div align="center">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/fb58a562-c404-42c7-8a42-07168fc3e5c5" />
</div>

## Why is this change needed?

Improves benchmark discoverability in the Results Store by ordering runs naturally by their descriptive run labels instead of ingestion order, and gives users a dedicated toggle to focus solely on community-submitted runs.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

Unit tests added in `src/utils/runLabel.test.js` and `src/utils/dashboardHelpers.test.js` (136 tests passing). Verified toggle filtering and sorting behaviors in Results Store.

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Linters pass (`npm run lint`)
- [x] Documentation updated (if applicable)

## Related Issues
