### PR TITLE
Support multi-item grouping in Results Store

### DIFF
--- a/src/components/ManageBenchmarks/FilterPanel.jsx
+++ b/src/components/ManageBenchmarks/FilterPanel.jsx
@@ -59,6 +59,15 @@ const FILTER_FIELD_LABELS = {
     acc_count: 'Accelerator Count'
 };
 
+const GROUP_BY_OPTIONS = ['Model', 'Hardware', 'Origin', 'OriginFolder'];
+
+const GROUP_BY_LABELS = {
+    Model: 'Model',
+    Hardware: 'Hardware',
+    Origin: 'Source Connections',
+    OriginFolder: 'Origin/Folder',
+};
+
 const getKpiFilterLabel = (filter, isPlaygroundMode = false) => {
     switch (filter) {
         case 'my-submissions': return isPlaygroundMode ? 'Pending Benchmarks' : 'My Benchmarks';
@@ -308,9 +317,31 @@ export const FilterPanel = ({
     const [groupBy, setGroupBy] = useState(() => {
         try {
             const saved = localStorage.getItem('prism_manage_group_by');
-            return saved || 'Model';
-        } catch { return 'Model'; }
+            if (!saved) return ['Model'];
+            if (saved.startsWith('[') && saved.endsWith(']')) {
+                const parsed = JSON.parse(saved);
+                if (Array.isArray(parsed)) return parsed.filter(Boolean);
+            }
+            if (saved === 'None') return [];
+            const items = saved.split(',').map(s => s.trim()).filter(s => s && s !== 'None');
+            return items.length > 0 ? items : ['Model'];
+        } catch { return ['Model']; }
     });
+
+    const handleToggleGroupBy = (val) => {
+        if (!val) {
+            setGroupBy([]);
+            return;
+        }
+        setGroupBy(prev => {
+            const current = Array.isArray(prev) ? prev : (prev && prev !== 'None' ? [prev] : []);
+            if (current.includes(val)) {
+                return current.filter(item => item !== val);
+            } else {
+                return [...current, val];
+            }
+        });
+    };
     
     const [sortByField, setSortByField] = useState(() => {
         try {
@@ -380,7 +411,7 @@ export const FilterPanel = ({
 
     useEffect(() => {
         try {
-            localStorage.setItem('prism_manage_group_by', groupBy);
+            localStorage.setItem('prism_manage_group_by', JSON.stringify(groupBy));
         } catch (e) { console.warn(e); }
     }, [groupBy]);
 
@@ -1060,7 +1091,7 @@ export const FilterPanel = ({
                                 }}
                                 className={cn(
                                     'px-3 py-2 text-xs font-semibold rounded-xl border transition-colors cursor-pointer flex items-center gap-1.5',
-                                    showViewSettings || groupBy !== 'None' || sortByField !== 'runLabel'
+                                    showViewSettings || (groupBy && groupBy.length > 0) || sortByField !== 'runLabel'
                                     ? 'bg-cyan-500/10 text-cyan-400 border-cyan-500/30 font-bold'
                                     : 'bg-[#070b13] border-slate-800 hover:border-slate-700 text-slate-400 hover:text-slate-205'
                                 )}
@@ -1077,17 +1108,16 @@ export const FilterPanel = ({
                                         {/* Grouping */}
                                         <div className="flex flex-col gap-1.5">
                                             <Label className="mb-0 text-[9px] uppercase font-bold text-slate-400 tracking-wider">Group By</Label>
-                                            <Select
-                                                className="text-xs rounded-lg px-2.5 py-1.5 cursor-pointer"
-                                                value={groupBy}
-                                                onChange={(e) => setGroupBy(e.target.value)}
-                                            >
-                                                <option value="None">None</option>
-                                                <option value="Model">Model</option>
-                                                <option value="Hardware">Hardware</option>
-                                                <option value="Origin">Source Connections</option>
-                                                <option value="OriginFolder">Origin/Folder</option>
-                                            </Select>
+                                            <MultiSelectDropdown
+                                                options={GROUP_BY_OPTIONS}
+                                                selected={new Set(groupBy)}
+                                                onChange={handleToggleGroupBy}
+                                                emptyLabel="None"
+                                                clearLabel="None"
+                                                showSelectedNames={true}
+                                                formatLabel={(opt) => GROUP_BY_LABELS[opt] || opt}
+                                                menuClassName="w-full z-[120]"
+                                            />
                                         </div>
 
                                         {/* Sorting */}

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -32,6 +32,13 @@ import { parseDataUri } from '../../utils/dataParser';
 import { forkBenchmark } from '../../utils/benchmarkForker';
 import { createGlobMatcher, matchesBenchmarkStat } from '../../utils/globUtils';
 
+const GROUP_BY_TAGS = {
+    Model: 'MODEL',
+    Hardware: 'HARDWARE',
+    Origin: 'SOURCE',
+    OriginFolder: 'ORIGIN',
+};
+
 const getStatusTooltipText = (status, sub) => {
     switch (status) {
         case 'staged':
@@ -322,7 +329,7 @@ export const UnifiedDataTable = (props) => {
         qualityMetrics,
         onOpenSubmitDialog,
         isFiltered = false,
-        groupBy = 'Model',
+        groupBy = ['Model'],
         sortByField = 'runLabel',
         sortDirection = 'asc',
         visibleSpecs = {
@@ -1387,43 +1394,66 @@ export const UnifiedDataTable = (props) => {
 
     const needsExpansion = sortedStats.length > 4;
 
+    const activeGroupBy = React.useMemo(() => {
+        if (!groupBy) return [];
+        if (Array.isArray(groupBy)) return groupBy.filter(g => g && g !== 'None');
+        if (groupBy instanceof Set) return Array.from(groupBy).filter(g => g && g !== 'None');
+        if (typeof groupBy === 'string') return groupBy === 'None' ? [] : [groupBy];
+        return [];
+    }, [groupBy]);
+
     const groupedStats = React.useMemo(() => {
         const grouped = {};
-        if (groupBy !== 'None') {
+        if (activeGroupBy.length > 0) {
             // Build a mapping of lowercase clean model names to their first seen nicely-cased clean name
             const canonicalCasing = {};
-            sortedStats.forEach(stat => {
-                if (groupBy === 'Model') {
+            if (activeGroupBy.includes('Model')) {
+                sortedStats.forEach(stat => {
                     const rawName = stat.model_name || stat.model || 'Unknown Model';
                     const clean = getCleanModelName(rawName);
                     const cleanLower = clean.toLowerCase();
                     if (!canonicalCasing[cleanLower]) {
                         canonicalCasing[cleanLower] = clean;
                     }
-                }
-            });
+                });
+            }
 
-            sortedStats.forEach(stat => {
-                let key = 'Other';
-                if (groupBy === 'Model') {
+            const getDimValue = (stat, dim) => {
+                if (dim === 'Model') {
                     const rawName = stat.model_name || stat.model || 'Unknown Model';
                     const clean = getCleanModelName(rawName);
-                    key = canonicalCasing[clean.toLowerCase()] || clean;
+                    return canonicalCasing[clean.toLowerCase()] || clean;
                 }
-                if (groupBy === 'Hardware') key = stat.hardware || 'Unknown Hardware';
-                if (groupBy === 'Origin') {
+                if (dim === 'Hardware') {
+                    return stat.hardware || 'Unknown Hardware';
+                }
+                if (dim === 'Origin') {
                     const origin = stat.data?.[0]?.source_info?.origin || stat.data?.[0]?.source;
-                    key = origin ? getSourceTag(stat.data[0]) : 'Unknown Origin';
+                    return origin ? getSourceTag(stat.data[0]) : 'Unknown Origin';
                 }
-                if (groupBy === 'OriginFolder') {
+                if (dim === 'OriginFolder') {
                     const origin = stat.data?.[0]?.source_info?.origin || stat.data?.[0]?.source;
-                    key = origin ? formatOriginLabel(origin) : 'Unknown Origin/Folder';
+                    return origin ? formatOriginLabel(origin) : 'Unknown Origin/Folder';
                 }
+                return 'Other';
+            };
+
+            sortedStats.forEach(stat => {
+                const parts = activeGroupBy.map(dim => {
+                    const tag = GROUP_BY_TAGS[dim] || dim.toUpperCase();
+                    const val = getDimValue(stat, dim);
+                    return `${tag}: ${val}`;
+                });
+                const key = parts.join(' + ');
                 if (!grouped[key]) grouped[key] = [];
                 grouped[key].push(stat);
             });
 
-            const isGroupSortDesc = (groupBy === 'Model' && sortByField === 'model') ? sortDirection === 'desc' : false;
+            const firstDim = activeGroupBy[0];
+            const isGroupSortDesc = (
+                (firstDim === 'Model' && sortByField === 'model') ||
+                (firstDim === 'Hardware' && sortByField === 'hardware')
+            ) ? sortDirection === 'desc' : false;
             const sortedKeys = sortGroupKeys(Object.keys(grouped), { isDesc: isGroupSortDesc });
 
             const sortedGrouped = {};
@@ -1435,7 +1465,7 @@ export const UnifiedDataTable = (props) => {
             grouped['All'] = sortedStats;
             return grouped;
         }
-    }, [sortedStats, groupBy, sortByField, sortDirection]);
+    }, [sortedStats, activeGroupBy, sortByField, sortDirection]);
 
     const visibleStatsList = React.useMemo(() => {
         return Object.values(groupedStats).flat();
@@ -2039,8 +2069,8 @@ export const UnifiedDataTable = (props) => {
                         const isAllSelected = stats.every(s => selectedBenchmarks.has(s.benchmarkKey));
                         return (
                         <div key={groupKey} className="flex flex-col gap-2">
-                            {groupBy !== 'None' && (
-                                <div className="sticky top-0 z-10 bg-slate-150 dark:bg-slate-900 py-1.5 px-3 rounded text-xs font-bold text-slate-550 dark:text-slate-400 uppercase tracking-wider border-y border-slate-200 dark:border-slate-800/60 flex items-center gap-3">
+                            {activeGroupBy.length > 0 && (
+                                <div className="sticky top-0 z-10 bg-slate-150 dark:bg-slate-900 py-1.5 px-3 rounded text-xs font-bold text-slate-550 dark:text-slate-400 border-y border-slate-200 dark:border-slate-800/60 flex items-center gap-3">
                                     <div 
                                         onClick={(e) => {
                                             e.stopPropagation();
@@ -2055,7 +2085,29 @@ export const UnifiedDataTable = (props) => {
                                             {isAllSelected && <Check size={10} strokeWidth={3} />}
                                         </div>
                                     </div>
-                                    {groupKey}
+                                    <span className="font-mono text-xs inline-flex items-center flex-wrap gap-x-2 gap-y-1">
+                                        {groupKey.split(' + ').map((part, idx) => {
+                                            const colonIdx = part.indexOf(':');
+                                            if (colonIdx === -1) {
+                                                return <span key={idx} className="text-slate-800 dark:text-slate-200 font-semibold">{part}</span>;
+                                            }
+                                            const tag = part.slice(0, colonIdx).trim();
+                                            const val = part.slice(colonIdx + 1).trim();
+                                            return (
+                                                <React.Fragment key={idx}>
+                                                    {idx > 0 && <span className="text-slate-400 dark:text-slate-600 font-normal select-none">+</span>}
+                                                    <span className="inline-flex items-center gap-1.5">
+                                                        <span className="text-[10px] uppercase font-bold text-slate-400 dark:text-slate-500 tracking-wider select-none">
+                                                            {tag}:
+                                                        </span>
+                                                        <span className="text-slate-800 dark:text-slate-200 font-semibold">
+                                                            {val}
+                                                        </span>
+                                                    </span>
+                                                </React.Fragment>
+                                            );
+                                        })}
+                                    </span>
                                 </div>
                             )}
                             

--- a/src/components/common/MultiSelectDropdown.jsx
+++ b/src/components/common/MultiSelectDropdown.jsx
@@ -14,8 +14,22 @@
 
 import React, { useState, useRef, useEffect } from 'react';
 import { ChevronDown, Check } from 'lucide-react';
+import { cn } from '../../utils/cn';
 
-export const MultiSelectDropdown = ({ label, options, selected = new Set(), onChange, counts, formatLabel, labelSuffix }) => {
+export const MultiSelectDropdown = ({ 
+    label, 
+    options, 
+    selected = new Set(), 
+    onChange, 
+    counts, 
+    formatLabel, 
+    labelSuffix,
+    emptyLabel = 'All',
+    clearLabel,
+    buttonClassName,
+    menuClassName,
+    showSelectedNames = false
+}) => {
     const [isOpen, setIsOpen] = useState(false);
     const containerRef = useRef(null);
 
@@ -29,28 +43,44 @@ export const MultiSelectDropdown = ({ label, options, selected = new Set(), onCh
         return () => document.removeEventListener('mousedown', handleClickOutside);
     }, []);
 
-    const safeSelected = selected || new Set();
+    const safeSelected = selected instanceof Set ? selected : new Set(selected || []);
     const selectedCount = safeSelected.size;
+
+    let displaySelectedText = emptyLabel;
+    if (selectedCount > 0) {
+        if (showSelectedNames) {
+            displaySelectedText = [...safeSelected].map(opt => (formatLabel ? formatLabel(opt) : opt)).join(', ');
+        } else {
+            displaySelectedText = `${selectedCount} selected`;
+        }
+    }
     
     return (
         <div className="relative" ref={containerRef}>
             <button 
+                type="button"
                 onClick={() => setIsOpen(!isOpen)}
-                className="w-full bg-[#0b0f17] border border-slate-800/40 text-slate-300 text-xs rounded-xl px-3 py-2 flex items-center justify-between hover:border-slate-700/45 hover:bg-[#101622] transition-all duration-200"
-                title={`${label}: ${selectedCount > 0 ? [...safeSelected].join(', ') : 'All'}`}
+                className={cn(
+                    "w-full bg-[#0b0f17] border border-slate-800/40 text-slate-300 text-xs rounded-xl px-3 py-2 flex items-center justify-between hover:border-slate-700/45 hover:bg-[#101622] transition-all duration-200",
+                    buttonClassName
+                )}
+                title={`${label ? `${label}: ` : ''}${selectedCount > 0 ? [...safeSelected].map(x => (formatLabel ? formatLabel(x) : x)).join(', ') : emptyLabel}`}
             >
                 <div className="flex items-center gap-2 truncate pr-2">
-                    <span className="font-semibold text-slate-500">{label}</span>
+                    {label && <span className="font-semibold text-slate-500">{label}</span>}
                     {labelSuffix}
                     <span className="truncate text-slate-200">
-                        {selectedCount === 0 ? 'All' : `${selectedCount} selected`}
+                        {displaySelectedText}
                     </span>
                 </div>
                 <ChevronDown size={12} className={`text-slate-500 transition-transform duration-350 ${isOpen ? 'rotate-180 text-cyan-400' : ''}`} />
             </button>
 
             {isOpen && (
-                <div className="absolute top-full left-0 mt-2 w-64 max-h-80 overflow-y-auto bg-[#0b0f17]/95 border border-slate-800/40 rounded-xl shadow-2xl z-[100] p-2.5 space-y-1.5 backdrop-blur-md">
+                <div className={cn(
+                    "absolute top-full left-0 mt-2 w-64 max-h-80 overflow-y-auto bg-[#0b0f17]/95 border border-slate-800/40 rounded-xl shadow-2xl z-[100] p-2.5 space-y-1.5 backdrop-blur-md",
+                    menuClassName
+                )}>
                     <div 
                         className={`flex items-center gap-2 px-2.5 py-2 rounded-lg cursor-pointer hover:bg-slate-800/80 transition-all ${selectedCount === 0 ? 'bg-cyan-500/10 text-cyan-400 font-semibold' : 'text-slate-300 hover:text-slate-200'}`}
                         onClick={() => { onChange(''); setIsOpen(false); }}
@@ -58,8 +88,8 @@ export const MultiSelectDropdown = ({ label, options, selected = new Set(), onCh
                          <div className={`w-3.5 h-3.5 rounded border flex items-center justify-center transition-colors ${selectedCount === 0 ? 'bg-cyan-500 border-cyan-500 text-white' : 'border-slate-800/40 bg-slate-950'}`}>
                             {selectedCount === 0 && <Check size={10} className="text-white" strokeWidth={3} />}
                          </div>
-                         <span className="text-xs">All {label}</span>
-                         <span className="text-[10px] text-slate-500 ml-auto font-mono">{options.length}</span>
+                         <span className="text-xs">{clearLabel || (label ? `All ${label}` : 'All')}</span>
+                         {counts && <span className="text-[10px] text-slate-500 ml-auto font-mono">{options.length}</span>}
                     </div>
                     
                     <div className="h-px bg-slate-800/30 my-1.5 mx-1" />
@@ -70,7 +100,7 @@ export const MultiSelectDropdown = ({ label, options, selected = new Set(), onCh
                         return (
                             <div 
                                 key={opt} 
-                                className={`flex items-center gap-2 px-2.5 py-2 rounded-lg cursor-pointer transition-all ${count === 0 ? 'opacity-45 hover:bg-slate-800/30' : 'hover:bg-slate-800/80'} ${isSelected ? 'bg-cyan-500/10 text-cyan-400 font-semibold' : 'text-slate-300 hover:text-slate-200'}`}
+                                className={`flex items-center gap-2 px-2.5 py-2 rounded-lg cursor-pointer transition-all ${counts && count === 0 ? 'opacity-45 hover:bg-slate-800/30' : 'hover:bg-slate-800/80'} ${isSelected ? 'bg-cyan-500/10 text-cyan-400 font-semibold' : 'text-slate-300 hover:text-slate-200'}`}
                                 onClick={() => onChange(opt)}
                                 title={formatLabel ? formatLabel(opt) : opt}
                             >
@@ -80,7 +110,7 @@ export const MultiSelectDropdown = ({ label, options, selected = new Set(), onCh
                                  <span className={`text-xs truncate flex-1 ${isSelected ? 'text-cyan-400 font-semibold' : 'text-slate-300'}`}>
                                      {formatLabel ? formatLabel(opt) : opt}
                                  </span>
-                                 <span className="text-[10px] text-slate-500 dark:text-slate-400 font-mono ml-auto">{count}</span>
+                                 {counts && <span className="text-[10px] text-slate-500 dark:text-slate-400 font-mono ml-auto">{count}</span>}
                             </div>
                         );
                     })}

--- a/src/utils/dashboardHelpers.jsx
+++ b/src/utils/dashboardHelpers.jsx
@@ -196,8 +196,8 @@ export const sortGroupKeys = (keys, { isDesc = false } = {}) => {
     return [...keys].sort((a, b) => {
         const strA = String(a ?? '');
         const strB = String(b ?? '');
-        const isSpecialA = strA === 'Other' || strA.startsWith('Unknown');
-        const isSpecialB = strB === 'Other' || strB.startsWith('Unknown');
+        const isSpecialA = strA === 'Other' || strA.startsWith('Unknown') || strA.includes(': Unknown') || strA.includes(': Other');
+        const isSpecialB = strB === 'Other' || strB.startsWith('Unknown') || strB.includes(': Unknown') || strB.includes(': Other');
         if (isSpecialA && !isSpecialB) return 1;
         if (!isSpecialA && isSpecialB) return -1;
 

--- a/src/utils/dashboardHelpers.test.js
+++ b/src/utils/dashboardHelpers.test.js
@@ -43,6 +43,34 @@ describe('dashboardHelpers sortGroupKeys', () => {
         const sorted = sortGroupKeys(keys, { isDesc: true });
         expect(sorted).toEqual(['Qwen3-32B', 'Llama-3.1-70B', 'Gemma-2-9B', 'Other']);
     });
+
+    it('sorts multi-item group keys alphabetically and naturally', () => {
+        const keys = [
+            'MODEL: qwen + HARDWARE: h200',
+            'MODEL: gemini + HARDWARE: h100',
+            'MODEL: qwen + HARDWARE: h100',
+        ];
+        const sorted = sortGroupKeys(keys);
+        expect(sorted).toEqual([
+            'MODEL: gemini + HARDWARE: h100',
+            'MODEL: qwen + HARDWARE: h100',
+            'MODEL: qwen + HARDWARE: h200',
+        ]);
+    });
+
+    it('places multi-item group keys with Unknown at the end', () => {
+        const keys = [
+            'MODEL: Unknown Model + HARDWARE: h100',
+            'MODEL: qwen + HARDWARE: h100',
+            'MODEL: gemini + HARDWARE: h100',
+        ];
+        const sorted = sortGroupKeys(keys);
+        expect(sorted).toEqual([
+            'MODEL: gemini + HARDWARE: h100',
+            'MODEL: qwen + HARDWARE: h100',
+            'MODEL: Unknown Model + HARDWARE: h100',
+        ]);
+    });
 });
 
 describe('dashboardHelpers sortBuckets', () => {


### PR DESCRIPTION
## What does this PR do?

Switches the "Group by" control under View Options in the Results Store from a single-select dropdown to a multiselect dropdown matching the advanced filter style:

- Supports multi-dimensional grouping by combinations of Model, Hardware, Source Connections, and Origin/Folder.
- Formats group permutation headers as `TAG: value` (for a single dimension) and `TAG: value + TAG: value` (for multiple dimensions, e.g. `MODEL: gemma-3 + HARDWARE: H100`).
- Greys out uppercase dimension tags and separators for visual contrast against high-contrast values.

<div align="center">
<img width="567" height="412" alt="image" src="https://github.com/user-attachments/assets/92b6290b-ee7b-4c50-a675-f5292207750d" />
</div>

## Why is this change needed?

Previously, the Results Store only supported grouping benchmarks by a single dimension at a time (e.g. only Model or only Hardware). Supporting multi-item grouping allows users to analyze permutations of models across hardware and sources together in structured groups.

## How was this tested?

- [x] Unit tests added/updated
- [ ] Integration/e2e tests added/updated
- [x] Manual testing performed

## Checklist

- [x] Commits are signed off (`git commit -s`) per [DCO](PR_SIGNOFF.md)
- [x] Code follows project [contributing guidelines](CONTRIBUTING.md)
- [x] Tests pass locally (`npm test`)
- [x] Linters pass (`npm run lint`)
- [x] Documentation updated (if applicable)

## Related Issues
