### PR TITLE
Fix staged run reordering and detail Zod errors

### DIFF
--- a/server/results/api.ts
+++ b/server/results/api.ts
@@ -21,7 +21,7 @@ export const PrismStageEntrySchema = z.object({
     /** Unique identifier for the stage. Generated as a unique UUIDv4 by Prism. */
     run_id: z.string().uuid(),
     /** Human-friendly run description/label matching the parent run. Example: "gemma-4-9b-it" */
-    run_description: z.string(),
+    run_description: z.string().optional(),
     /** Original filename of the evaluated benchmark stage report. Example: "benchmark_report_v0.2_stage_1.yaml" */
     filename: z.string(),
     /** Sequential normalized stage index stored in Prism payload structure. Example: 0 */

--- a/src/components/DataConnections/SubmitValidationPage.jsx
+++ b/src/components/DataConnections/SubmitValidationPage.jsx
@@ -6,6 +6,7 @@ import { validateBenchmark, validatePrismUploadStructure } from '../../utils/ben
 import { parseReportV02, stageToEntry, canonicalStringify, mutateRawReportMetadata, compareOriginalStageOrder, normalizeReportUnits } from '../../utils/benchmarkReportV02Parser';
 import { toOptimalDataUri, parseDataUri } from '../../utils/dataParser';
 import yaml from 'js-yaml';
+import { isValidUuid } from '../../utils/shareLinkEncoder';
 
 import IntelligentRoutingChart from '../IntelligentRoutingChart';
 import { useGitHubAuth } from '../../hooks/useGitHubAuth';
@@ -627,10 +628,21 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             const [moved] = entries.splice(fromIndex, 1);
             entries.splice(toIndex, 0, moved);
 
+            const fallbackRunDesc = bundle.name || bundle.payload?.runLabel || 'Unnamed Run';
             const reindexedEntries = entries.map((entry, idx) => ({
                 ...entry,
+                run_id: (entry.run_id && isValidUuid(entry.run_id)) ? entry.run_id : uuidv4(),
+                run_description: entry.run_description || fallbackRunDesc,
                 prism_stage_index: idx
             }));
+
+            let updatedStageFiles = bundle.stageFiles;
+            if (Array.isArray(bundle.stageFiles) && bundle.stageFiles.length === entries.length) {
+                const sfCopy = [...bundle.stageFiles];
+                const [movedSf] = sfCopy.splice(fromIndex, 1);
+                sfCopy.splice(toIndex, 0, movedSf);
+                updatedStageFiles = sfCopy;
+            }
 
             const updatedPayload = {
                 ...bundle.payload,
@@ -640,6 +652,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             const uploadValidation = validatePrismUploadStructure(updatedPayload, { isUpload: false });
             return {
                 ...bundle,
+                stageFiles: updatedStageFiles,
                 payload: updatedPayload,
                 validation: {
                     ...bundle.validation,
@@ -711,10 +724,24 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                 return newDirection === 'asc' ? diff : -diff;
             });
 
+            const fallbackRunDesc = bundle.name || bundle.payload?.runLabel || 'Unnamed Run';
             const sortedEntries = entriesWithMetrics.map(({ entry }, idx) => ({
                 ...entry,
+                run_id: (entry.run_id && isValidUuid(entry.run_id)) ? entry.run_id : uuidv4(),
+                run_description: entry.run_description || fallbackRunDesc,
                 prism_stage_index: idx
             }));
+
+            let updatedStageFiles = bundle.stageFiles;
+            if (Array.isArray(bundle.stageFiles) && bundle.stageFiles.length === sortedEntries.length) {
+                const matchedFiles = sortedEntries.map(entry => {
+                    return bundle.stageFiles.find(sf => (sf.filename || sf.name || sf.file?.name) === entry.filename)
+                        || bundle.stageFiles[entry.prism_stage_index];
+                }).filter(Boolean);
+                if (matchedFiles.length === bundle.stageFiles.length) {
+                    updatedStageFiles = matchedFiles;
+                }
+            }
 
             const updatedPayload = {
                 ...bundle.payload,
@@ -724,6 +751,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             const uploadValidation = validatePrismUploadStructure(updatedPayload, { isUpload: false });
             return {
                 ...bundle,
+                stageFiles: updatedStageFiles,
                 payload: updatedPayload,
                 validation: {
                     ...bundle.validation,
@@ -747,11 +775,25 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                 return bundle;
             }
 
+            const fallbackRunDesc = bundle.name || bundle.payload?.runLabel || 'Unnamed Run';
             const sortedEntries = [...bundle.payload.entries].sort(compareOriginalStageOrder);
             const reindexedEntries = sortedEntries.map((entry, idx) => ({
                 ...entry,
+                run_id: (entry.run_id && isValidUuid(entry.run_id)) ? entry.run_id : uuidv4(),
+                run_description: entry.run_description || fallbackRunDesc,
                 prism_stage_index: idx
             }));
+
+            let updatedStageFiles = bundle.stageFiles;
+            if (Array.isArray(bundle.stageFiles) && bundle.stageFiles.length === reindexedEntries.length) {
+                const matchedFiles = reindexedEntries.map(entry => {
+                    return bundle.stageFiles.find(sf => (sf.filename || sf.name || sf.file?.name) === entry.filename)
+                        || bundle.stageFiles[entry.prism_stage_index];
+                }).filter(Boolean);
+                if (matchedFiles.length === bundle.stageFiles.length) {
+                    updatedStageFiles = matchedFiles;
+                }
+            }
 
             const updatedPayload = {
                 ...bundle.payload,
@@ -767,6 +809,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             const uploadValidation = validatePrismUploadStructure(updatedPayload, { isUpload: false });
             return {
                 ...bundle,
+                stageFiles: updatedStageFiles,
                 payload: updatedPayload,
                 validation: {
                     ...bundle.validation,
@@ -788,8 +831,11 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
                 return prev.filter(b => b.id !== bundleId);
             }
 
+            const fallbackRunDesc = bundle.name || bundle.payload?.runLabel || 'Unnamed Run';
             const reindexedEntries = remainingEntries.map((entry, idx) => ({
                 ...entry,
+                run_id: (entry.run_id && isValidUuid(entry.run_id)) ? entry.run_id : uuidv4(),
+                run_description: entry.run_description || fallbackRunDesc,
                 prism_stage_index: idx
             }));
 
@@ -1931,6 +1977,36 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
         }
     };
 
+    const sanitizeStagedBundles = (bundles) => {
+        if (!Array.isArray(bundles)) return [];
+        return bundles.map(bundle => {
+            if (!bundle || !bundle.payload) return bundle;
+            const fallbackDesc = bundle.name || bundle.payload.runLabel || 'Unnamed Run';
+            const rawEntries = Array.isArray(bundle.payload.entries) ? bundle.payload.entries : [];
+            const entries = rawEntries.map((entry, idx) => ({
+                ...entry,
+                run_id: (entry.run_id && isValidUuid(entry.run_id)) ? entry.run_id : uuidv4(),
+                run_description: entry.run_description || fallbackDesc,
+                prism_stage_index: entry.prism_stage_index !== undefined ? entry.prism_stage_index : idx
+            }));
+            const updatedPayload = {
+                ...bundle.payload,
+                entries
+            };
+            const uploadValidation = validatePrismUploadStructure(updatedPayload, { isUpload: false });
+            return {
+                ...bundle,
+                payload: updatedPayload,
+                validation: {
+                    ...bundle.validation,
+                    errors: uploadValidation.errors || [],
+                    warnings: uploadValidation.warnings || [],
+                    fieldErrors: uploadValidation.fieldErrors || {}
+                }
+            };
+        });
+    };
+
     React.useEffect(() => {
         if (hasInitialized.current) return;
         hasInitialized.current = true;
@@ -1943,7 +2019,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
         if (cached) {
             try {
                 const parsed = JSON.parse(cached);
-                setStagedFiles(parsed);
+                setStagedFiles(sanitizeStagedBundles(parsed));
                 setWizardStep(3);
                 setUploadIntent('submit-review');
             } catch (e) {
@@ -1959,7 +2035,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             try {
                 const savedBundles = localStorage.getItem('prism_active_staged_bundles');
                 if (savedBundles) {
-                    setStagedFiles(JSON.parse(savedBundles));
+                    setStagedFiles(sanitizeStagedBundles(JSON.parse(savedBundles)));
                 }
             } catch { /* ignore */ }
         } else if (wizardStepSaved) {
@@ -1976,7 +2052,7 @@ export default function UploadValidationPage({ onNavigateBack, onNavigate, dashb
             try {
                 const savedBundles = localStorage.getItem('prism_active_staged_bundles');
                 if (savedBundles) {
-                    setStagedFiles(JSON.parse(savedBundles));
+                    setStagedFiles(sanitizeStagedBundles(JSON.parse(savedBundles)));
                 }
             } catch (err) {
                 console.error("Failed to parse saved staged bundles:", err);

--- a/src/components/ManageBenchmarks/UnifiedDataTable.jsx
+++ b/src/components/ManageBenchmarks/UnifiedDataTable.jsx
@@ -23,7 +23,7 @@ import { getSourceTag, getSourceType, getSourceTypeStyle, formatOriginLabel, get
 import { buildRunLabel, getBenchmarkSortLabel } from '../../utils/runLabel';
 import yaml from 'js-yaml';
 import { useGitHubAuth } from '../../hooks/useGitHubAuth';
-import { validateBenchmark } from '../../utils/benchmarkValidator';
+import { validateBenchmark, validatePrismUploadStructure } from '../../utils/benchmarkValidator';
 import { encodeShareLink, isValidUuid } from '../../utils/shareLinkEncoder';
 import { isFileBackedRun } from '../../utils/benchmarkReportV02Parser';
 import { v4 as uuidv4 } from 'uuid';
@@ -545,12 +545,10 @@ export const UnifiedDataTable = (props) => {
             } : null
         };
 
-        const bundleValidation = {
-            format: 'brv02',
-            errors: [],
-            warnings: [],
-            dcoChecked: true
-        };
+        const validRunId = (run.runId && isValidUuid(run.runId))
+            ? run.runId
+            : ((run.payload?.runId && isValidUuid(run.payload.runId)) ? run.payload.runId : uuidv4());
+        const runLabel = run.runLabel || run.payload?.runLabel || 'Unnamed Run';
 
         const forkedFromVal = run.forked_from 
             || run.payload?.forked_from 
@@ -586,38 +584,69 @@ export const UnifiedDataTable = (props) => {
             || run.bundle?.payload?.evidence 
             || null;
 
+        const payload = {
+            ...(run.payload || {}),
+            runId: validRunId,
+            runLabel: runLabel,
+            format: 'brv02',
+            model_name: run.model_name || run.stages?.[0]?.scenario?.model || 'Unknown Model',
+            hardware: { 
+                hardware_name: run.hardware?.hardware_name || run.stages?.[0]?.scenario?.hardware || 'Unknown Hardware',
+                accelerator_count: run.hardware?.accelerator_count ?? null
+            },
+            run_metadata: run.run_metadata || null,
+            entries: (run.stages || []).map((stage, idx) => {
+                let rawObj = stage.rawReport || stage.raw_report;
+                if (typeof rawObj === 'string') {
+                    try {
+                        rawObj = JSON.parse(rawObj);
+                    } catch {
+                        try {
+                            rawObj = yaml.load(rawObj);
+                        } catch {
+                            rawObj = {};
+                        }
+                    }
+                }
+                if (!rawObj || typeof rawObj !== 'object') {
+                    rawObj = {};
+                }
+
+                return {
+                    run_id: (stage.run_id && isValidUuid(stage.run_id)) ? stage.run_id : uuidv4(),
+                    run_description: stage.run_description || runLabel,
+                    filename: stage.filename || `stage_${idx + 1}.yaml`,
+                    raw_report: rawObj,
+                    stage: stage.stageIndex ?? idx,
+                    prism_stage_index: stage.prism_stage_index !== undefined ? stage.prism_stage_index : (stage.stageIndex ?? idx),
+                    runUid: stage.runUid
+                };
+            }),
+            well_lit_path: run.wellLitPath || run.well_lit_path || null,
+            ...(forkedFromVal ? { forked_from: forkedFromVal } : {}),
+            ...(githubAuthorVal ? { github_author: githubAuthorVal } : {}),
+            ...(inferenceToolVal ? { inference_tool: inferenceToolVal } : {}),
+            ...(inferenceToolVersionVal ? { inference_tool_version: inferenceToolVersionVal } : {}),
+            ...(manifestsVal ? { manifests: manifestsVal } : {}),
+            ...(evidenceVal ? { evidence: evidenceVal } : {})
+        };
+
+        const uploadValidation = validatePrismUploadStructure(payload, { isUpload: false });
+        const bundleValidation = {
+            format: 'brv02',
+            errors: uploadValidation.errors || [],
+            warnings: uploadValidation.warnings || [],
+            fieldErrors: uploadValidation.fieldErrors || {},
+            dcoChecked: true
+        };
+
         return {
             id: Math.random().toString(36).substring(7),
-            dirKey: run.runId,
-            name: run.runLabel,
+            dirKey: validRunId,
+            name: runLabel,
             stageFiles,
             metadataFiles,
-            payload: {
-                ...(run.payload || {}),
-                runId: run.runId,
-                runLabel: run.runLabel,
-                format: 'brv02',
-                model_name: run.model_name || run.stages[0]?.scenario?.model || 'Unknown Model',
-                hardware: { 
-                    hardware_name: run.hardware?.hardware_name || run.stages[0]?.scenario?.hardware || 'Unknown Hardware',
-                    accelerator_count: run.hardware?.accelerator_count ?? null
-                },
-                run_metadata: run.run_metadata || null,
-                entries: run.stages.map(stage => ({
-                    run_id: stage.run_id || uuidv4(),
-                    filename: stage.filename,
-                    raw_report: stage.rawReport,
-                    stage: stage.stageIndex,
-                    runUid: stage.runUid
-                })),
-                well_lit_path: run.wellLitPath || run.well_lit_path || null,
-                ...(forkedFromVal ? { forked_from: forkedFromVal } : {}),
-                ...(githubAuthorVal ? { github_author: githubAuthorVal } : {}),
-                ...(inferenceToolVal ? { inference_tool: inferenceToolVal } : {}),
-                ...(inferenceToolVersionVal ? { inference_tool_version: inferenceToolVersionVal } : {}),
-                ...(manifestsVal ? { manifests: manifestsVal } : {}),
-                ...(evidenceVal ? { evidence: evidenceVal } : {})
-            },
+            payload,
             validation: bundleValidation,
             isExpanded: true,
             isSkipped: false,

--- a/src/utils/benchmarkReportV02Parser.test.js
+++ b/src/utils/benchmarkReportV02Parser.test.js
@@ -18,7 +18,7 @@ import {
     normalizeReportUnits,
     detectMissingUnitWarnings,
 } from './benchmarkReportV02Parser.js';
-import { validateBenchmark, validatePrismUploadStructure } from './benchmarkValidator.js';
+import { validateBenchmark, validatePrismUploadStructure, formatZodIssuePath } from './benchmarkValidator.js';
 
 const createReport = (throughput) => ({
     version: '0.2',
@@ -1074,4 +1074,119 @@ describe('missing units detection and warning generation', () => {
         expect(stage.warnings).toHaveLength(0);
         expect(stage.rawReport.results.request_performance.aggregate.throughput.output_token_rate.units).toBe('tokens/s');
     });
+
+    it('validates upload payload when entries omit run_description without throwing undefined string errors', () => {
+        const validDoc = {
+            version: '0.2',
+            run: { id: 'test-run-1', description: 'Test' },
+            scenario: { model: 'meta-llama/Llama-3-8B-Instruct', hardware: 'H100' },
+            results: {
+                request_performance: {
+                    aggregate: {
+                        throughput: { output_token_rate: { mean: 100, units: 'tokens/s' } },
+                        latency: { request_latency: { mean: 1.5, units: 's' } }
+                    }
+                }
+            }
+        };
+
+        const uploadData = {
+            runId: '11111111-1111-4111-8111-111111111111',
+            runLabel: 'Staged Benchmark Run',
+            model_name: 'meta-llama/Llama-3-8B-Instruct',
+            hardware: { hardware_name: 'H100', accelerator_count: 8 },
+            format: 'brv02',
+            entries: [
+                {
+                    run_id: '22222222-2222-4222-8222-222222222222',
+                    filename: 'stage_1.yaml',
+                    raw_report: validDoc,
+                    prism_stage_index: 0
+                    // run_description intentionally omitted
+                },
+                {
+                    run_id: '33333333-3333-4333-8333-333333333333',
+                    filename: 'stage_2.yaml',
+                    raw_report: validDoc,
+                    prism_stage_index: 1
+                    // run_description intentionally omitted
+                }
+            ]
+        };
+
+        const validation = validatePrismUploadStructure(uploadData, { isUpload: false });
+        expect(validation.isValid).toBe(true);
+        expect(validation.errors).toHaveLength(0);
+        expect(validation.errors.some(e => e.includes('expected string, received undefined'))).toBe(false);
+
+        // Simulate moving sub-runs around: swapping entries and re-indexing prism_stage_index
+        const [moved] = uploadData.entries.splice(0, 1);
+        uploadData.entries.splice(1, 0, moved);
+        uploadData.entries.forEach((e, idx) => {
+            e.prism_stage_index = idx;
+        });
+
+        const movedValidation = validatePrismUploadStructure(uploadData, { isUpload: false });
+        expect(movedValidation.isValid).toBe(true);
+        expect(movedValidation.errors).toHaveLength(0);
+    });
+
+    describe('formatZodIssuePath and detailed Zod error reporting', () => {
+        it('formats simple and nested object paths correctly', () => {
+            expect(formatZodIssuePath([])).toBe('');
+            expect(formatZodIssuePath(null)).toBe('');
+            expect(formatZodIssuePath(undefined)).toBe('');
+            expect(formatZodIssuePath(['model_name'])).toBe('model_name');
+            expect(formatZodIssuePath(['hardware', 'hardware_name'])).toBe('hardware.hardware_name');
+            expect(formatZodIssuePath(['entries', 0, 'run_id'])).toBe('entries[0].run_id');
+            expect(formatZodIssuePath(['entries', 1, 'raw_report', 'scenario', 'load', 'tool'])).toBe('entries[1].raw_report.scenario.load.tool');
+            expect(formatZodIssuePath(['manifests', 'deployment.yaml'])).toBe('manifests["deployment.yaml"]');
+            expect(formatZodIssuePath([0, 'nested', 2])).toBe('[0].nested[2]');
+        });
+
+        it('includes the object path in errors and fieldErrors when Zod schema validation fails', () => {
+            const invalidPayload = {
+                runId: 'not-a-valid-uuid',
+                format: 'brv02',
+                runLabel: 'Invalid Payload Test',
+                model_name: '',
+                hardware: {
+                    hardware_name: 'H100',
+                    accelerator_count: 0 // invalid count
+                },
+                entries: [
+                    {
+                        run_id: 'invalid-stage-uuid',
+                        filename: 'stage_0.json',
+                        // missing raw_report
+                    }
+                ]
+            };
+
+            const result = validatePrismUploadStructure(invalidPayload, { isUpload: false });
+            expect(result.isValid).toBe(false);
+
+            // Verify runId error includes path
+            expect(result.errors.some(e => e.startsWith('runId:'))).toBe(true);
+            expect(result.fieldErrors['runId']).toBeDefined();
+
+            // Verify model_name error includes path
+            expect(result.errors.some(e => e.startsWith('model_name:'))).toBe(true);
+            expect(result.fieldErrors['model_name']).toBeDefined();
+
+            // Verify hardware.accelerator_count error includes path
+            expect(result.errors.some(e => e.startsWith('hardware.accelerator_count:'))).toBe(true);
+            expect(result.fieldErrors['hardware.accelerator_count']).toBeDefined();
+
+            // Verify nested entry errors include array index and field path
+            expect(result.errors.some(e => e.startsWith('entries[0].run_id:'))).toBe(true);
+            expect(result.fieldErrors['entries.0.run_id']).toBeDefined();
+            expect(result.fieldErrors['entries[0].run_id']).toBeDefined();
+
+            expect(result.errors.some(e => e.startsWith('entries[0].raw_report:'))).toBe(true);
+            expect(result.fieldErrors['entries.0.raw_report']).toBeDefined();
+            expect(result.fieldErrors['entries[0].raw_report']).toBeDefined();
+        });
+    });
 });
+

--- a/src/utils/benchmarkValidator.js
+++ b/src/utils/benchmarkValidator.js
@@ -154,6 +154,32 @@ export function validateBenchmark(fileContent, filename) {
 }
 
 /**
+ * Formats a Zod issue path array into a readable object path string.
+ * Examples:
+ * - ['entries', 0, 'run_id'] -> 'entries[0].run_id'
+ * - ['hardware', 'hardware_name'] -> 'hardware.hardware_name'
+ * - ['manifests', 'deployment.yaml'] -> 'manifests["deployment.yaml"]'
+ *
+ * @param {Array<string|number>} path
+ * @returns {string}
+ */
+export function formatZodIssuePath(path) {
+    if (!path || !Array.isArray(path) || path.length === 0) {
+        return '';
+    }
+    return path.reduce((acc, seg) => {
+        if (typeof seg === 'number' || /^\d+$/.test(String(seg))) {
+            return `${acc}[${seg}]`;
+        }
+        const segStr = String(seg);
+        if (/^[a-zA-Z_$][a-zA-Z0-9_$]*$/.test(segStr)) {
+            return acc ? `${acc}.${segStr}` : segStr;
+        }
+        return acc ? `${acc}["${segStr}"]` : `["${segStr}"]`;
+    }, '');
+}
+
+/**
  * Validate the complete Prism Run Upload Structure.
  * Rejects runs if any of its stages contain mismatching info (model, hardware).
  * Isomorphic/shared function called by both frontend and backend.
@@ -175,11 +201,22 @@ export function validatePrismUploadStructure(uploadData, options = {}) {
         const parsedResult = PrismResultPayloadSchema.safeParse(uploadData);
         if (!parsedResult.success) {
             for (const issue of parsedResult.error.issues) {
-                const fieldPath = issue.path.join('.');
-                const message = issue.message;
+                const dotPath = issue.path.join('.');
+                const formattedPath = formatZodIssuePath(issue.path);
+                const prefix = formattedPath ? `${formattedPath}: ` : '';
+                const detailedMessage = (formattedPath && !issue.message.startsWith(prefix) && !issue.message.startsWith(`${formattedPath} `))
+                    ? `${formattedPath}: ${issue.message}`
+                    : issue.message;
 
-                errors.push(message);
-                fieldErrors[fieldPath] = { message, severity: 'error' };
+                errors.push(detailedMessage);
+
+                const errorEntry = { message: detailedMessage, severity: 'error' };
+                if (dotPath) {
+                    fieldErrors[dotPath] = errorEntry;
+                }
+                if (formattedPath && formattedPath !== dotPath) {
+                    fieldErrors[formattedPath] = errorEntry;
+                }
             }
         }
     } else {


### PR DESCRIPTION
## What does this PR do?

Editing a staged benchmark and reordering sub-runs previously blocked saving with `"Invalid input: expected string, received undefined"` due to missing `run_description` fields and desynchronized stage entries.

This PR fixes this by:
- Making `run_description` optional in `PrismStageEntrySchema` and preserving stage metadata (`run_description`, `run_id`, `prism_stage_index`, and `stageFiles`) across stage moves, sorts, and deletions.
- Sanitizing cached staged bundles restored from localStorage.
- Prepending object paths to Zod schema validation errors (e.g., `entries[0].run_description: ...`) so failing fields are clearly identified.

## How was this tested?

- Unit tests: `npm test` (all 141 tests passing).
- Manual testing: verified stage moving, restoring order, and error path formatting.