### PR TITLE
Clear Results Store URL params on navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -30,6 +30,7 @@ import SubmitValidationPage from './components/DataConnections/SubmitValidationP
 import LeftNavigation from './components/LeftNavigation';
 import { useDashboardState } from './hooks/useDashboardState';
 import { useDashboardData } from './hooks/useDashboardData';
+import { clearResultsStoreParams, clearSrcParams } from './utils/urlParams';
 
 function App() {
   const mainRef = useRef(null);
@@ -118,6 +119,23 @@ function App() {
     return () => window.removeEventListener('popstate', onPopState);
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const params = new URLSearchParams(window.location.search);
+    let changed = clearSrcParams(params);
+
+    if (currentView !== 'results-store') {
+      if (clearResultsStoreParams(params)) {
+        changed = true;
+      }
+    }
+
+    if (changed) {
+      const newSearch = params.toString();
+      const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}${window.location.hash || ''}`;
+      window.history.replaceState(null, '', newUrl);
+    }
+  }, [currentView]);
 
   const handleNavigate = (view, extraParams = {}) => {
     if (currentView !== 'submit-benchmarks') {
@@ -131,6 +149,15 @@ function App() {
     params.set('view', view);
     if (view !== 'workload-catalog') {
       params.delete('workload');
+    }
+
+    // ?src= should never be in the URLs
+    clearSrcParams(params);
+
+    // Only the Results Store page should ever show f_ and its own other params;
+    // when navving away, clear those params.
+    if (view !== 'results-store') {
+      clearResultsStoreParams(params);
     }
     
     const resolvedParams = {};
@@ -151,7 +178,9 @@ function App() {
     }
     setNavigationParams(resolvedParams);
 
-    window.history.pushState({}, '', `${window.location.pathname}?${params.toString()}${window.location.hash || ''}`);
+    const newSearch = params.toString();
+    const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}${window.location.hash || ''}`;
+    window.history.pushState({}, '', newUrl);
     
     // Reset scroll position on navigation
     window.scrollTo(0, 0);

--- a/src/components/ResultsStore.jsx
+++ b/src/components/ResultsStore.jsx
@@ -22,6 +22,7 @@ import { Button, Modal, Spinner, Checkbox, Input } from './ui';
 import { cn } from '../utils/cn';
 import { decodeShareLink } from '../utils/shareLinkEncoder';
 import { parseReportV02, stageToEntry } from '../utils/benchmarkReportV02Parser';
+import { clearResultsStoreParams, clearSrcParams, syncResultsStoreParams } from '../utils/urlParams';
 
 
 
@@ -251,48 +252,33 @@ export default function ResultsStore({ onNavigate, onNavigateBack, dashboardStat
 
     React.useEffect(() => {
         const params = new URLSearchParams(window.location.search);
-        if (kpiFilter) {
-            params.set('status', kpiFilter);
-            params.set('kpiFilter', kpiFilter);
-            if (['my-submissions', 'staged', 'unlisted', 'processing', 'in_review', 'approved', 'action'].includes(kpiFilter)) {
-                params.set('own', 'true');
-            } else {
-                params.delete('own');
-            }
-        } else {
-            params.delete('status');
-            params.delete('kpiFilter');
-            params.delete('own');
-        }
+        syncResultsStoreParams(params, {
+            kpiFilter,
+            includeUnlisted,
+            communityOnly,
+            searchTerm,
+            activeFilters
+        });
 
-        if (includeUnlisted) {
-            params.set('unlisted', '1');
-            params.set('includeUnlisted', '1');
-        } else {
-            params.delete('unlisted');
-            params.delete('includeUnlisted');
-        }
-
-        if (communityOnly) {
-            params.set('communityOnly', '1');
-        } else {
-            params.delete('communityOnly');
-            params.delete('community_only');
-            params.delete('community');
-        }
-
-        if (searchTerm) {
-            params.set('q', searchTerm);
-        } else {
-            params.delete('q');
-            params.delete('search');
-        }
-        
-        const newUrl = `${window.location.pathname}?${params.toString()}${window.location.hash || ''}`;
-        if (window.location.search !== `?${params.toString()}`) {
+        const newSearch = params.toString();
+        const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}${window.location.hash || ''}`;
+        if (window.location.search !== (newSearch ? `?${newSearch}` : '')) {
             window.history.replaceState(null, '', newUrl);
         }
-    }, [kpiFilter, includeUnlisted, communityOnly, searchTerm]);
+    }, [kpiFilter, includeUnlisted, communityOnly, searchTerm, activeFilters]);
+
+    React.useEffect(() => {
+        return () => {
+            const params = new URLSearchParams(window.location.search);
+            const rsChanged = clearResultsStoreParams(params);
+            const srcChanged = clearSrcParams(params);
+            if (rsChanged || srcChanged) {
+                const newSearch = params.toString();
+                const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}${window.location.hash || ''}`;
+                window.history.replaceState(null, '', newUrl);
+            }
+        };
+    }, []);
 
     React.useEffect(() => {
         const showSubmitFlow = sessionStorage.getItem('prism_show_submit_dialog_after_login');

--- a/src/hooks/useDashboardData.jsx
+++ b/src/hooks/useDashboardData.jsx
@@ -227,18 +227,17 @@ export const useDashboardData = (initialState, dashboardState) => {
 
             if (typeof window !== 'undefined') {
                 const params = new URLSearchParams(window.location.search);
-                params.delete('src');
-                if (selectedSources && selectedSources.size > 0) {
-                    Array.from(selectedSources).forEach(val => params.append('src', val));
-                }
-                const newSearch = params.toString();
-                const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}${window.location.hash || ''}`;
-                if (window.location.search !== (newSearch ? `?${newSearch}` : '')) {
-                    window.history.replaceState(null, '', newUrl);
+                if (params.has('src')) {
+                    params.delete('src');
+                    const newSearch = params.toString();
+                    const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}${window.location.hash || ''}`;
+                    if (window.location.search !== (newSearch ? `?${newSearch}` : '')) {
+                        window.history.replaceState(null, '', newUrl);
+                    }
                 }
             }
         } catch (e) {
-            console.warn("Failed to save selected sources to local storage or sync URL", e);
+            console.warn("Failed to save selected sources to local storage", e);
         }
     }, [selectedSources]);
     const [bucketConfigs, setBucketConfigs] = useState(() => {

--- a/src/hooks/useDashboardState.js
+++ b/src/hooks/useDashboardState.js
@@ -248,52 +248,14 @@ export const useDashboardState = () => {
                 filtersToSave[key] = Array.from(activeFilters[key]);
             }
             localStorage.setItem('prism_active_filters', JSON.stringify(filtersToSave));
-
-            if (typeof window !== 'undefined') {
-                const params = new URLSearchParams(window.location.search);
-                const filterKeysMap = {
-                    hardware: 'f_hw',
-                    machines: 'f_mach',
-                    tp: 'f_tp',
-                    precisions: 'f_prec',
-                    isl: 'f_isl',
-                    osl: 'f_osl',
-                    ratio: 'f_ratio',
-                    pdRatio: 'f_pd_ratio',
-                    modelServer: 'f_ms',
-                    servingStack: 'f_ss',
-                    origins: 'f_origin',
-                    acc_count: 'f_acc',
-                    useCase: 'f_uc',
-                    optimizations: 'f_opt',
-                    components: 'f_comp',
-                    models: 'f_models'
-                };
-
-                Object.values(filterKeysMap).forEach(paramKey => params.delete(paramKey));
-
-                Object.entries(filterKeysMap).forEach(([filterKey, paramKey]) => {
-                    const setVal = activeFilters[filterKey];
-                    if (setVal && setVal.size > 0) {
-                        Array.from(setVal).forEach(val => params.append(paramKey, val));
-                    }
-                });
-
-                const newSearch = params.toString();
-                const newUrl = `${window.location.pathname}${newSearch ? '?' + newSearch : ''}${window.location.hash || ''}`;
-                if (window.location.search !== (newSearch ? `?${newSearch}` : '')) {
-                    window.history.replaceState(null, '', newUrl);
-                }
-            }
         } catch (e) {
-            console.warn("Failed to save active filters to local storage or sync URL", e);
+            console.warn("Failed to save active filters to local storage", e);
         }
     }, [activeFilters]);
 
     const generateShareUrl = useCallback((
         bucketConfigs,
-        apiConfigs,
-        selectedSources
+        apiConfigs
     ) => {
         const params = new URLSearchParams();
         params.set('share', '1');
@@ -326,8 +288,6 @@ export const useDashboardState = () => {
         if (activeFilters.useCase.size > 0) [...activeFilters.useCase].forEach(v => params.append('f_uc', v));
         if (activeFilters.optimizations.size > 0) [...activeFilters.optimizations].forEach(v => params.append('f_opt', v));
         if (activeFilters.components.size > 0) [...activeFilters.components].forEach(v => params.append('f_comp', v));
-        
-        [...selectedSources].forEach(v => params.append('src', v));
         
         bucketConfigs.forEach(b => params.append('buckets', typeof b === 'string' ? b : b.bucket));
         apiConfigs.forEach(c => params.append('apis', typeof c === 'string' ? c : c.projectId));

--- a/src/utils/urlParams.js
+++ b/src/utils/urlParams.js
@@ -1,0 +1,141 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+export const FILTER_KEYS_MAP = {
+    hardware: 'f_hw',
+    machines: 'f_mach',
+    tp: 'f_tp',
+    precisions: 'f_prec',
+    isl: 'f_isl',
+    osl: 'f_osl',
+    ratio: 'f_ratio',
+    pdRatio: 'f_pd_ratio',
+    modelServer: 'f_ms',
+    servingStack: 'f_ss',
+    origins: 'f_origin',
+    acc_count: 'f_acc',
+    useCase: 'f_uc',
+    optimizations: 'f_opt',
+    components: 'f_comp',
+    models: 'f_models'
+};
+
+export const RESULTS_STORE_EXTRA_PARAM_KEYS = [
+    'status',
+    'kpiFilter',
+    'own',
+    'unlisted',
+    'includeUnlisted',
+    'communityOnly',
+    'community_only',
+    'community',
+    'q',
+    'search',
+    'benchmarks'
+];
+
+/**
+ * Removes all Results Store filter params (f_*) and extra params from a URLSearchParams object.
+ * @param {URLSearchParams} params
+ * @returns {boolean} Whether any params were removed
+ */
+export const clearResultsStoreParams = (params) => {
+    let changed = false;
+    const keys = Array.from(params.keys());
+    for (const key of keys) {
+        if (key.startsWith('f_')) {
+            params.delete(key);
+            changed = true;
+        }
+    }
+    for (const key of RESULTS_STORE_EXTRA_PARAM_KEYS) {
+        if (params.has(key)) {
+            params.delete(key);
+            changed = true;
+        }
+    }
+    return changed;
+};
+
+/**
+ * Removes the ?src= parameter from a URLSearchParams object.
+ * @param {URLSearchParams} params
+ * @returns {boolean} Whether ?src= was present and removed
+ */
+export const clearSrcParams = (params) => {
+    if (params.has('src')) {
+        params.delete('src');
+        return true;
+    }
+    return false;
+};
+
+/**
+ * Synchronizes Results Store state (kpiFilter, includeUnlisted, communityOnly, searchTerm, activeFilters)
+ * into a URLSearchParams object, ensuring ?src= is also stripped.
+ * @param {URLSearchParams} params
+ * @param {Object} state
+ */
+export const syncResultsStoreParams = (params, { kpiFilter, includeUnlisted, communityOnly, searchTerm, activeFilters }) => {
+    if (kpiFilter) {
+        params.set('status', kpiFilter);
+        params.set('kpiFilter', kpiFilter);
+        if (['my-submissions', 'staged', 'unlisted', 'processing', 'in_review', 'approved', 'action'].includes(kpiFilter)) {
+            params.set('own', 'true');
+        } else {
+            params.delete('own');
+        }
+    } else {
+        params.delete('status');
+        params.delete('kpiFilter');
+        params.delete('own');
+    }
+
+    if (includeUnlisted) {
+        params.set('unlisted', '1');
+        params.set('includeUnlisted', '1');
+    } else {
+        params.delete('unlisted');
+        params.delete('includeUnlisted');
+    }
+
+    if (communityOnly) {
+        params.set('communityOnly', '1');
+    } else {
+        params.delete('communityOnly');
+        params.delete('community_only');
+        params.delete('community');
+    }
+
+    if (searchTerm) {
+        params.set('q', searchTerm);
+    } else {
+        params.delete('q');
+        params.delete('search');
+    }
+
+    // Clear and sync activeFilters
+    Object.values(FILTER_KEYS_MAP).forEach(paramKey => params.delete(paramKey));
+    if (activeFilters) {
+        Object.entries(FILTER_KEYS_MAP).forEach(([filterKey, paramKey]) => {
+            const setVal = activeFilters[filterKey];
+            if (setVal && setVal.size > 0) {
+                Array.from(setVal).forEach(val => params.append(paramKey, val));
+            }
+        });
+    }
+
+    // Always ensure src is not in URL
+    params.delete('src');
+};

--- a/src/utils/urlParams.test.js
+++ b/src/utils/urlParams.test.js
@@ -1,0 +1,126 @@
+// Copyright 2026 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import { describe, it, expect } from 'vitest';
+import {
+    FILTER_KEYS_MAP,
+    RESULTS_STORE_EXTRA_PARAM_KEYS,
+    clearResultsStoreParams,
+    clearSrcParams,
+    syncResultsStoreParams
+} from './urlParams';
+
+describe('urlParams utils', () => {
+    describe('clearResultsStoreParams', () => {
+        it('clears all f_* filter parameters while preserving unrelated parameters', () => {
+            const params = new URLSearchParams('view=inference-scheduling&f_models=gemma-4-31b-it&f_hw=H100&other=val');
+            const changed = clearResultsStoreParams(params);
+
+            expect(changed).toBe(true);
+            expect(params.get('view')).toBe('inference-scheduling');
+            expect(params.get('other')).toBe('val');
+            expect(params.has('f_models')).toBe(false);
+            expect(params.has('f_hw')).toBe(false);
+        });
+
+        it('clears all Results Store extra params (status, own, q, unlisted, communityOnly)', () => {
+            const params = new URLSearchParams('view=home&status=approved&own=true&q=llama&unlisted=1&communityOnly=1&benchmarks=abc');
+            const changed = clearResultsStoreParams(params);
+
+            expect(changed).toBe(true);
+            expect(params.get('view')).toBe('home');
+            expect(params.has('status')).toBe(false);
+            expect(params.has('own')).toBe(false);
+            expect(params.has('q')).toBe(false);
+            expect(params.has('unlisted')).toBe(false);
+            expect(params.has('communityOnly')).toBe(false);
+            expect(params.has('benchmarks')).toBe(false);
+        });
+
+        it('returns false if no Results Store params exist', () => {
+            const params = new URLSearchParams('view=inference-scheduling&intent=test');
+            const changed = clearResultsStoreParams(params);
+
+            expect(changed).toBe(false);
+            expect(params.toString()).toBe('view=inference-scheduling&intent=test');
+        });
+    });
+
+    describe('clearSrcParams', () => {
+        it('removes ?src= when present', () => {
+            const params = new URLSearchParams('view=home&src=local&src=llmd_drive');
+            const changed = clearSrcParams(params);
+
+            expect(changed).toBe(true);
+            expect(params.has('src')).toBe(false);
+            expect(params.get('view')).toBe('home');
+        });
+
+        it('returns false when ?src= is not present', () => {
+            const params = new URLSearchParams('view=home');
+            const changed = clearSrcParams(params);
+
+            expect(changed).toBe(false);
+            expect(params.toString()).toBe('view=home');
+        });
+    });
+
+    describe('syncResultsStoreParams', () => {
+        it('synchronizes filters, status, search, and flags into URL params', () => {
+            const params = new URLSearchParams('view=results-store&src=local');
+            const activeFilters = {
+                models: new Set(['gemma-4-31b-it']),
+                hardware: new Set(['H100', 'B200']),
+                tp: new Set(['8'])
+            };
+
+            syncResultsStoreParams(params, {
+                kpiFilter: 'approved',
+                includeUnlisted: true,
+                communityOnly: false,
+                searchTerm: 'llama',
+                activeFilters
+            });
+
+            expect(params.get('view')).toBe('results-store');
+            expect(params.has('src')).toBe(false);
+            expect(params.get('status')).toBe('approved');
+            expect(params.get('own')).toBe('true');
+            expect(params.get('unlisted')).toBe('1');
+            expect(params.has('communityOnly')).toBe(false);
+            expect(params.get('q')).toBe('llama');
+            expect(params.getAll('f_models')).toEqual(['gemma-4-31b-it']);
+            expect(params.getAll('f_hw')).toEqual(['H100', 'B200']);
+            expect(params.getAll('f_tp')).toEqual(['8']);
+        });
+
+        it('removes parameters when values are cleared', () => {
+            const params = new URLSearchParams('view=results-store&status=approved&own=true&unlisted=1&q=test&f_models=gemma');
+            syncResultsStoreParams(params, {
+                kpiFilter: null,
+                includeUnlisted: false,
+                communityOnly: false,
+                searchTerm: '',
+                activeFilters: { models: new Set() }
+            });
+
+            expect(params.has('status')).toBe(false);
+            expect(params.has('own')).toBe(false);
+            expect(params.has('unlisted')).toBe(false);
+            expect(params.has('q')).toBe(false);
+            expect(params.has('f_models')).toBe(false);
+            expect(params.has('src')).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
### Before
Navigating away from the Results Store carried its filter parameters (`f_*`, search, status) over into guides and other views. Every page load also appended a long list of `?src=` parameters to the URL bar.

### After
Navigating away from the Results Store clears its filter parameters from the URL (while preserving filter selections in local storage), and `?src=` parameters are no longer added to the URL.

Fixes https://github.com/llm-d/llm-d-prism/issues/137